### PR TITLE
Remove “words to avoid in technical writing”

### DIFF
--- a/user/build-configuration.md
+++ b/user/build-configuration.md
@@ -115,7 +115,7 @@ If your project uses non-standard dependency management tools, you can override 
 
 As with other scripts, `install` command can be anything but has to exit with the 0 status in order to be considered successful.
 
-If you'd like to skip the `install` stage entirely, just set it to `true` and nothing will be run.
+If you'd like to skip the `install` stage entirely, set it to `true` and nothing will be run.
 
     install: true
 
@@ -174,7 +174,7 @@ Currently Clojure projects can be tested against Oracle JDK 7, OpenJDK 7 and Ope
 * In Leiningen 1.x, via [lein-multi plugin](https://github.com/maravillas/lein-multi)
 * In upcoming Leiningen 2.0, via Leiningen Profiles
 
-If you are interested in testing against multiple Clojure releases, just use these Leiningen features and it will work without special support on the Travis side.
+If you are interested in testing against multiple Clojure releases, you can use these Leiningen features and it will work without special support on the Travis side.
 
 Learn more in our [Clojure guide](/user/languages/clojure/).
 
@@ -445,7 +445,7 @@ Such configuration will generate matrix with 2 following env rows:
 
 ### Secure environment variables
 
-In the last example I used a token as one of the environment variables. However, it's not very wise to put your private tokens in the publicly available file. Travis supports environment variables encryption to handle this case and allows you to keep configuration public, while keeping parts of it private. Example configuration with secure environment variables looks something like:
+In the previous example, one of the environment variables had a token in it. Since putting private tokens in a file in cleartext isn't always the best idea, Travis supports encryption of environment variables. This allows you to keep parts of the configuration private. A configuration with secure environment variables might look something like this:
 
     env:
       global:

--- a/user/caching.md
+++ b/user/caching.md
@@ -101,21 +101,21 @@ Currently Pull Requests will use the cache of the branch they are supposed to be
 
 ### Clearing Caches
 
-Sometimes you ruin your cache by storing bad data in one of the cached directories. Currently it is not possible to clear the cache via the web interface. However, you can use our [command line client](https://github.com/travis-ci/travis#readme) to [clear the cache](https://github.com/travis-ci/travis#cache):
+Sometimes you ruin your cache by storing bad data in one of the cached directories. Currently it is not possible to clear the cache via the web interface, but you can use our [command line client](https://github.com/travis-ci/travis#readme) to [clear the cache](https://github.com/travis-ci/travis#cache):
 
 <figure>
   [ ![travis cache --delete](/images/cli-cache.png) ](/images/cli-cache.png)
   <figcaption>Running <tt>travis cache --delete</tt> inside the project directory.</figcaption>
 </figure>
 
-Of course there is a [corresponding API](https://api.travis-ci.com/#/repos/:owner_name/:name/caches).
+There is also a [corresponding API](https://api.travis-ci.com/#/repos/:owner_name/:name/caches) for clearing the cache.
 
 ## Caching Ubuntu packages
 
 A network-local APT cache is available, allowing for more reliable download
 speeds compared to the Ubuntu mirrors.
 
-Simply enable APT caching in your .travis.yml:
+To enable APT caching, add the following to your .travis.yml:
 
     cache: apt
 

--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -26,7 +26,10 @@ This guide covers data stores and other services (e.g. RabbitMQ) offered in the 
 * Kestrel
 * SQLite3
 
-All the aforementioned services use mostly stock default settings. However, when it makes sense, new users are added and security settings are relaxed (because for continuous integration ease of use is more important): one example of such adaptation is PostgreSQL that has strict default access settings.
+All of these data stores use the default settings, with one exception: When it
+makes sense, new users are added and the security settings are relaxed for ease
+of use. One example of this is PostgreSQL which normally has very strict
+default access settings.
 
 ## Configure Your Projects to Use Services in Tests
 
@@ -118,7 +121,7 @@ For Ruby projects, ensure that you have the sqlite3 ruby bindings in your bundle
       database: ":memory:"
       timeout: 500
 
-However, if your project is a general library or plugin, you need to handle connecting to the database yourself in tests. For example, connecting with ActiveRecord:
+If you're not using a `config/database.yml` file to configure ActiveRecord, you need to connect to the database manually in the tests. For example, connecting with ActiveRecord could be done like this:
 
     ActiveRecord::Base.establish_connection :adapter => 'sqlite3',
                                             :database => ':memory:'
@@ -132,9 +135,7 @@ MongoDB is **not started on boot**. To make Travis CI start the service for you,
 
 to your `.travis.yml`.
 
-MongoDB binds to 127.0.0.1 and requires no authentication or database creation up front.
-
-However, authentication will be enabled upon adding an admin user as mongod is started with the `--auth` parameter.
+MongoDB binds to 127.0.0.1 and requires no authentication or database creation up front. If you add an admin user, authentication will be enabled, since mongod is started with the `--auth` argument.
 
 Note: Admin users are users created on the admin database.
 

--- a/user/deployment.md
+++ b/user/deployment.md
@@ -23,12 +23,11 @@ Continuous Deployment to the following providers are currently supported out of 
 * [Engine Yard](/user/deployment/engineyard)
 * [Custom deployment via after_success hook](/user/deployment/custom)
 
-### Deploying to multiple Providers
+### Deploying to Multiple Providers
 
-If you would like to deploy to multiple providers, you will need to set up your `.travis.yml` a little differently.
-Add the information for the providers you want to deploy to to the `deploy` section of your `.travis.yml`, just like you would add them individually.
-Now, in front of each provider declaration (e.g. `provider: heroku`), place a dash (-).
-If you want to deploy to, say, cloudControl and Heroku, your `deploy` section would look like this:
+Deploying to multiple providers is possible by adding the different providers
+to the `deploy` section as a list. For example, if you want to deploy to both
+cloudControl and Heroku, your `deploy` section would look something like this:
 
     deploy:
       - provider: cloudcontrol

--- a/user/deployment/cloudfiles.md
+++ b/user/deployment/cloudfiles.md
@@ -15,10 +15,9 @@ For a minimal configuration, all you need to do is add the following to your `.t
       region: "CLOUDFILE REGION"
       container: "CLOUDFILES CONTAINER NAME"
 
+This example is almost certainly not ideal, as you probably want to upload your built binaries and documentation. Set skip_cleanup to true to prevent Travis CI from deleting your build artifacts.
 
-However, this example is almost certainly not ideal, as you probably want to upload your built binaries and documentation. Set skip_cleanup to true to prevent Travis CI from deleting your build artifacts.
-
-	 deploy:
+    deploy:
       provider: cloudfiles
       username: "RACKSPACE USERNAME"
       api-key: "RACKSPACE API KEY"

--- a/user/deployment/npm.md
+++ b/user/deployment/npm.md
@@ -13,9 +13,9 @@ For a minimal configuration, all you need to do is add the following to your `.t
       email: "YOUR EMAIL ADDRESS"
       api_key: "YOUR API KEY"
 
-However, this is almost certainly not ideal.
-Instead, you will most likely want to only release to NPM when you release a new version of your package.
-To do this, add `tags: true` to the `on` section of your `.travis.yml` like so:
+Most likely, you would only want to deploy to NPM when a new version of your
+package is cut. To do this, you can tell Travis CI to only deploy on tagged
+commits, like so:
 
     deploy:
       provider: npm

--- a/user/deployment/pypi.md
+++ b/user/deployment/pypi.md
@@ -13,10 +13,9 @@ For a minimal configuration, all you need to do is add the following to your `.t
       user: "Your username"
       password: "Your password"
 
-
-However, this is almost certainly not ideal.
-Instead, you will most likely want to only release to PyPI when you release a new version of your package.
-To do this, add `tags: true` to the `on` section of your `.travis.yml` like so:
+Most likely, you would only want to deploy to PyPI when a new version of your
+package is cut. To do this, you can tell Travis CI to only deploy on tagged
+commits, like so:
 
     deploy:
       provider: pypi

--- a/user/deployment/rubygems.md
+++ b/user/deployment/rubygems.md
@@ -12,9 +12,9 @@ For a minimal configuration, all you need to do is add the following to your `.t
       provider: rubygems
       api_key: "YOUR API KEY"
 
-However, this is almost certainly not ideal.
-Instead, you will most likely want to only release to RubyGems when you release a new version of your gem.
-To do this, add `tags: tags` to the `on` section of your `.travis.yml` like so:
+Most likely you would only want to deploy to RubyGems when a new version of
+your package is cut. To do this, you can tell Travis CI to only deploy on
+tagged commits, like so:
 
     deploy:
       provider: rubygems

--- a/user/deployment/s3.md
+++ b/user/deployment/s3.md
@@ -14,8 +14,7 @@ For a minimal configuration, all you need to do is add the following to your `.t
       secret_access_key: "YOUR AWS SECRET KEY"
       bucket: "S3 Bucket"
 
-
-However, this example is almost certainly not ideal, as you probably want to upload your built binaries and documentation. Set skip_cleanup to true to prevent Travis CI from deleting your build artifacts.
+This example is almost certainly not ideal, as you probably want to upload your built binaries and documentation. Set skip_cleanup to true to prevent Travis CI from deleting your build artifacts.
 
 	 deploy:
       provider: s3

--- a/user/how-to-skip-a-build.md
+++ b/user/how-to-skip-a-build.md
@@ -13,13 +13,10 @@ Configuration](/user/build-configuration/) guides before reading this one.
 
 ## Not All Commits Need CI Builds
 
-Sometimes you just change a README, some docs or just stuff which has no effect
-on the app itself. So you would like to know how to prevent your push from
-being built.
-
-It's easy - just add the following to the commit message:
-
-    [ci skip]
+Sometimes all you are changing is the README, some documentation or other
+things which have no effect on the tests. In this case, you may not want a
+build to be created for that commit. To do this, all you need to do is to add
+`[ci skip]` somewhere in the commit message.
 
 Commits that have `[ci skip]` anywhere in the commit messages will be ignored.
 `[ci skip]` does not have to appear on the first line, so it is possible to use

--- a/user/languages/clojure.md
+++ b/user/languages/clojure.md
@@ -21,8 +21,8 @@ Clojure projects on travis-ci.org assume you use [Leiningen](https://github.com/
 
 ## Dependency Management
 
-With Leiningen, explicit dependencies installation step (`lein deps`) typically is not necessary. Simply make sure all dependencies are listed in
-`project.clj` and `lein test` and other tasks will automatically install them if necessary before doing other things.
+If you use Leiningen, it will automatically install any dependencies you need
+as long as they are listed in the `project.clj` file.
 
 ### Alternate Install Step
 

--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -1,4 +1,3 @@
----
 title: Building a Java project
 layout: en
 permalink: java/

--- a/user/languages/javascript-with-nodejs.md
+++ b/user/languages/javascript-with-nodejs.md
@@ -76,8 +76,9 @@ to install your dependencies. Note that dependency installation in Travis CI env
 
 ## Meteor Apps
 
-You can build your **Meteor Apps** on Travis and test against [`laika`](http://arunoda.github.io/laika/). 
-Simply add following `.travis.yml` file to your project root.
+You can build your **Meteor Apps** on Travis and test against
+[`laika`](http://arunoda.github.io/laika/). To do this, use a .travis.yml file
+like this:
 
     language: node_js
     node_js:

--- a/user/languages/php.md
+++ b/user/languages/php.md
@@ -98,17 +98,17 @@ After install you should refresh your path
 
     phpenv rehash
 
-So, for example when you want to use phpcs, you should execute:
+For example, if you want to use phpcs, you should execute:
 
     pyrus install pear/PHP_CodeSniffer
     phpenv rehash
 
-Then you can use phpcs as simply as phpunit command
+Then you can use phpcs like the phpunit command
 
 ### Installing Composer packages
 
 You can also install [Composer](http://packagist.org/) packages into the Travis PHP environment. The composer
-command comes pre-installed, so just use the following:
+command comes pre-installed, use the following:
 
     composer install
 
@@ -118,10 +118,10 @@ To ensure that everything works, use http(s) URLs on [Packagist](http://packagis
 
 You'll find the default configure options used to build the different PHP versions used on Travis [here](https://github.com/travis-ci/travis-cookbooks/blob/master/ci_environment/phpbuild/templates/default/default_configure_options.erb), it will give you an overview of Travis' PHP installation.
 
-However please note the following differences between the different PHP versions available on Travis:
+Please note the following differences between the different PHP versions available on Travis:
 
 * For unmaintained PHP versions we provide (5.2.x, 5.3.3), OpenSSL extension is disabled because of [compilation problems with OpenSSL 1.0](http://blog.travis-ci.com/upcoming_ubuntu_11_10_migration/). Recent PHP 5.3.x and 5.4.x releases we provision do have OpenSSL extension support.
-* Pyrus is obviously not available for PHP 5.2.x.
+* Pyrus is not available for PHP 5.2.x.
 * Different SAPIs:
 
   * 5.2.x and 5.3.3 come with php-cgi only.
@@ -203,7 +203,7 @@ If you want to learn all the details of how we build and provision multiple PHP 
 
 ### Apache + PHP
 
-Currently Travis does not support mod_php for apache, however you can configure php-fpm for your integration tests.
+Currently Travis does not support mod_php for apache, but you can configure php-fpm for your integration tests.
 
 In your .travis.yml:
 

--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -52,7 +52,7 @@ If you decide to use apt anyway, note that Python system packages only include P
 ### PyPy Support
 
 We provide the most recent stable release of PyPy via [PyPy Team's Releases PPA](https://launchpad.net/~pypy/+archive/ppa). For pure Python projects,
-it works well. However, due to known issues with the development (header) packages, native libraries won't install on PyPy. We have notified
+it works well. Native libraries won't install on PyPy due to known issues with the development (header) packages. We have notified
 PyPy package maintainers as well as PyPy core team members about the issue and waiting for it to be resolved.
 
 To test your project against PyPy, add "pypy" to the list of Pythons in your `.travis.yml`:

--- a/user/languages/ruby.md
+++ b/user/languages/ruby.md
@@ -141,7 +141,7 @@ alternatives (like JDBC-based drivers for MySQL, PostgreSQL and so on).
 ## Default Test Script
 
 Travis CI runs `rake` by default to execute your tests. Please note that **you
-need to add rake to your Gemfile** (adding it to just the `:test` group should
+need to add rake to your Gemfile** (adding it to the `:test` group should
 be sufficient).
 
 ## Dependency Management
@@ -337,8 +337,8 @@ installed by the newest Bundler/RubyGems combination.
 
 We try to keep it as up-to-date as possible.
 
-However, should you require the latest version of RubyGems, you can add the
-following to your .travis.yml:
+Should you require the latest version of RubyGems, you can add the following to
+your .travis.yml:
 
     before_install:
       - gem update --system

--- a/user/notifications.md
+++ b/user/notifications.md
@@ -22,7 +22,7 @@ And it will by default send emails when, on the given branch:
 
 You can change this behaviour using the following options:
 
-> Note: Items in brackets are just placeholders. Brackets should be omitted.
+> Note: Items in brackets are placeholders. Brackets should be omitted.
 
 ## Email notifications
 
@@ -48,7 +48,7 @@ Also, you can specify when you want to get notified:
         on_success: [always|never|change] # default: change
         on_failure: [always|never|change] # default: always
 
-`always` and `never` obviously mean that you want email notifications to be sent always or never. `change` means that you will get them when the build status changes on the given branch.
+`always` and `never` mean that you want email notifications to be sent always or never. `change` means that you will get them when the build status changes on the given branch.
 
 ## IRC notification
 
@@ -64,7 +64,7 @@ Or multiple channels:
         - "chat.freenode.net#travis"
         - "chat.freenode.net#some-other-channel"
 
-Just as with other notification types you can specify when IRC notifications will be sent:
+As with other notification types you can specify when IRC notifications will be sent:
 
     notifications:
       irc:
@@ -229,7 +229,7 @@ Or multiple channels:
         - http://your-domain.com/notifications
         - http://another-domain.com/notifications
 
-Just as with other notification types you can specify when webhook payloads will be sent:
+As with other notification types you can specify when webhook payloads will be sent:
 
     notifications:
       webhooks:

--- a/user/travis-pro.md
+++ b/user/travis-pro.md
@@ -15,10 +15,10 @@ continuous integration solution for private repositories.
 
 By default Travis focuses its build efforts around a single repository. We set
 up a private deploy key for every repository that's enabled to build on Travis
-Pro and assign that to the repository. That means we can't simply pull in
-dependent repositories, e.g. from your Gemfile or for your Composer setup. The
-key can only be assigned to the single repository and not be reused throughout
-all of GitHub.
+Pro and assign that to the repository. That means we can't pull in dependent
+repositories, e.g. from your Gemfile or for your Composer setup, without some
+additional setup. The key can only be assigned to the single repository and not
+be reused throughout all of GitHub.
 
 If you need to pull in Git submodules or dependent repositories, that's still
 easy to achieve, though. You can either specify the dependencies using GitHub's


### PR DESCRIPTION
Words were taken from this blog post: http://css-tricks.com/words-avoid-educational-writing/. It recommends to avoid using the phrases “obviously”, “basically”, “simply”, “of course”, “clearly”, “just”, “everyone knows”, “however”, “so” and “easy”. I did a project-wide search for these phrases and rewrote things where I thought it improved the sentence.

For future reference, this is the command I ran to find these:

```
ag -i '(obviously|basically|simply|of\scourse|clearly|just|everyone\sknows|however|so,|easy)' user
```

Not 100% sure about all of these changes, please do look over them and add some comments if you think there shouldn't be a change or the sentence could be rewritten in a better way.
