### PR TITLE
Drop the suggestion for pip --use-mirrors

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -105,8 +105,6 @@ The exact default command is
 
 which is very similar to what [Heroku build pack for Python](https://github.com/heroku/heroku-buildpack-python/) uses.
 
-We highly recommend using `--use-mirrors` if you override dependency installation command to reduce the load on PyPI and possibility of installation failures.
-
 ### Pre-installed packages
 
 Travis pre-installs a few packages in each virtualenv by default to


### PR DESCRIPTION
PyPI is using a CDN now and the PyPI mirror infrastructure is being officially deprecated.  Current versions of `pip` complain if you try to use `--use-mirrors`:

```
--use-mirrors has been deprecated and will be removed in the future.
```
