### PR TITLE
Updates docs with default cpanm install args.

### DIFF
--- a/pt-BR/user/languages/perl.md
+++ b/pt-BR/user/languages/perl.md
@@ -66,7 +66,7 @@ Por padrão o Travis CI usa o `cpanm` para gerenciar as dependências do seu pro
 
 O comando padrão executado é
 
-    cpanm --installdeps --notest .
+    cpanm --quiet --installdeps --notest .
 
 ### Ao Sobrescrever Comandos de Build, Não Utilize o sudo
 

--- a/user/languages/perl.md
+++ b/user/languages/perl.md
@@ -65,7 +65,7 @@ By default Travis CI use `cpanm` to manage your project's dependencies. It is po
 
 The exact default command is
 
-    cpanm --installdeps --notest .
+    cpanm --quiet --installdeps --notest .
 
 ### When Overriding Build Commands, Do Not Use sudo
 


### PR DESCRIPTION
Based on this https://travis-ci.org/maxmind/mod_maxminddb/jobs/18610995 it looks like the defaults for cpanm are now:

"cpanm --quiet --installdeps --notest ."
