### PR TITLE
Document xcode_workspace option for Objective-C

### DIFF
--- a/user/languages/objective-c.md
+++ b/user/languages/objective-c.md
@@ -24,7 +24,7 @@ See [general build configuration guide](/user/build-configuration/) to learn mor
 
 ## Default Test Script
 
-Travis CI uses [xctool](https://github.com/facebook/xctool) by default to run the tests. In order for xctool to work, you need to tell it the name of your scheme and either project or workspace. For example:
+Travis CI uses [xctool](https://github.com/facebook/xctool) by default to run the tests. In order for xctool to work, you need to tell it the name of your scheme and either project using `xcode_project` or workspace using `xcode_workspace`. For example:
 
     language: objective-c
     xcode_project: MyNewProject.xcodeproj


### PR DESCRIPTION
Just a small doc edit that might save others a few minutes. The Objective-C documentation indicates that you need to provide, "the name of your scheme and either project or workspace," with the example showing the use of `xcode_project` option. We weren't sure whether we should pass an Xcode workspace to the `xcode_project` option, if there was an `xcode_workspace` option to use, or if we needed to override the `script` to specify the `-workspace` flag to xctool.
