### PR TITLE
Clarification on using encryption for pull requests from forks

### DIFF
--- a/user/encryption-keys.md
+++ b/user/encryption-keys.md
@@ -7,7 +7,7 @@ permalink: encryption-keys/
 Travis CI generates a pair of private and public RSA keys which can be used
 to encrypt information which you will want to put into the `.travis.yml` file and
 still keep it private. Currently we allow encryption of
-[environment variables](/user/build-configuration/#Secure-environment-variables), notification settings, and deploy api keys.
+[environment variables](/user/build-configuration/#Secure-environment-variables), notification settings, and deploy api keys. Please note that encrypted environment variables are not available for pull requests from forks.
 
 ## Usage
 


### PR DESCRIPTION
This additional line might save someone a few hours of debugging time. The only mention that "secure environment variable are not available on pull requests from forks" is currently buried far down on the [Build Configuration](http://docs.travis-ci.com/user/build-configuration/#Secure-environment-variables) page. I added a reference to this restriction on the [Encryption Keys](http://docs.travis-ci.com/user/encryption-keys/)  page where it is featured more prominently and less likely to be missed.
