### PR TITLE
To change timezone, we have to append to travis.ini

### DIFF
--- a/user/languages/php.md
+++ b/user/languages/php.md
@@ -144,7 +144,7 @@ And myconfig.ini:
 
 You can also use this one line command:
 
-    echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/travis.ini
+    echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 ## PHP extensions
 


### PR DESCRIPTION
To change timzone setting, we have to append to travis.ini.
Because it might have timezone setting and it will override timezone setting in php.ini.
https://travis-ci.org/yandod/travis-ci-php-ini-change/builds/22245431
