### PR TITLE
Added region field to S3 deploy documentation

### DIFF
--- a/user/deployment/s3.md
+++ b/user/deployment/s3.md
@@ -36,6 +36,23 @@ You can also have the `travis` tool set up everything for you:
 
 Keep in mind that the above command has to run in your project directory, so it can modify the `.travis.yml` for you.
 
+### S3 bucket regions
+
+By default the region `us-east-1` is used when deploying to S3. If your bucket is hosted in a different region, deploying using the default region results in the following error.
+
+    The bucket you are attempting to access must be addressed using the specified endpoint.
+    Please send all future requests to this endpoint. (AWS::S3::Errors::PermanentRedirect)
+
+This can be resolved by specifying your bucket's region using the `region` configuration. For example, this example uses the `eu-west-1` region.
+
+    deploy:
+      provider: s3
+      access_key_id: "YOUR AWS ACCESS KEY"
+      secret_access_key: "YOUR AWS SECRET KEY"
+      bucket: "S3 Bucket"
+      skip_cleanup: true
+      region: eu-west-1
+
 ### Deploy On Tags
 
 Often, you want to deploy only when you release a new version of your code.


### PR DESCRIPTION
After running in to deploy issues with S3, the (undocumented) `region` configuration field was described to me by @fritzek. This resolved my issue, so I decided to patch the docs accordingly.
