### PR TITLE
emphasize that the private ssh key needs to be used in .travis.yml

### DIFF
--- a/user/travis-pro.md
+++ b/user/travis-pro.md
@@ -23,32 +23,31 @@ be reused throughout all of GitHub.
 If you need to pull in Git submodules or dependent repositories, that's still
 easy to achieve, though. You can either specify the dependencies using GitHub's
 https URL scheme, which can include username and password, e.g.
-`https://user:password@github.com/organization/repo.git`. Ideally the user is a
-separate user in your organization that only has read access to the required
-repository.
+`https://user:password@github.com/organization/repo.git`.
+Ideally the user is a separate user in your organization that only has read
+access to the required repository.
 
-
-As this doesn't work in all cases, e.g. with Composer, there's an alternative.
+As this doesn't work in all cases, e.g. with Composer, there's another way.
 It still requires setting up a separate user with pull access to the relevant
-repositories. But instead of specifying the username and passwords in for
+repositories, but instead of specifying the username and passwords in for
 instance your Gemfile, you use an SSH key: you add the public key for this user
-on GitHub and store the the private key into your .travis.yml.
+on GitHub and store the the private key into your `.travis.yml`.
 
-Here are the steps to take:
+In order to do this, follow these steps:
 
-* Create a new user on GitHub, add it to your organization, and give it pull
+1. Create a new user on GitHub, add it to your organization, and give it pull
   permission to the relevant repositories.
-* Create an SSH key for the user: `ssh-keygen -f id_username_travisci`.
+1. Create an SSH key for the user: `ssh-keygen -f id_username_travisci`.
   Note: this must be a password-less key for Travis CI to be able to use it.
-* Add the public SSH key (`id_username_travisci.pub`) to the user on GitHub.
-* Add a Base64-encoded version of the private key (`id_username_travisci`) to
+1. Add the public SSH key (`id_username_travisci.pub`) to the user on GitHub.
+1. Add a Base64-encoded version of the private key (`id_username_travisci`) to
   your .travis.yml. On a Mac, you can run `base64 id_username_travisci |
   pbcopy` to copy the encoded version of the key to the clipboard.
-* Add a the encoded private key to your main repositories' .travis.yml file:
+1. Add a the encoded private key to your main repositories' `.travis.yml` file:
   `source_key: `. (This value should be the encoded version of the private SSH
   key in double quotes and on a single line.)
 
-Travis CI will automatically prefer the key specified in your .travis.yml over the
+Travis CI will automatically prefer the key specified in your `.travis.yml` to the
 deploy key for a repository, so all repositories you're pulling in for the build
 to succeed automatically use this key.
 


### PR DESCRIPTION
Feedback from a customer:

> I'm so used to providing GitHub with public keys (and I'd just added a new one to our newly-created travis-only user account) that I'd set up my source_key with that user's public key. Turns out if you do that you get prompted for a passphrase. ... Maybe emphasizing "private key" a bit more in the setup document would have helped me avoid scanning over it the first time.

I have also renamed the key from `id_mustache_power` to `id_username_travisci`

Feel free to amend!
