### PR TITLE
Fix link to PostgreSQL addon documentation

### DIFF
--- a/user/addons.md
+++ b/user/addons.md
@@ -9,5 +9,5 @@ moved:
 
 * [Sauce Connect](/user/sauce-connect)
 * [Custom Host Names](/user/hosts/)
-* [PostgreSQL](/user/postgresql/)
+* [PostgreSQL](/user/using-postgresql/)
 * [Firefox](/user/firefox/)


### PR DESCRIPTION
The permalink for postgresql is /using-postgresql/ but the filename is `postgresql.md`.
