### PR TITLE
Remove a superfluous "and"

### DIFF
--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -92,7 +92,7 @@ To test against OpenJDK 7 and Oracle JDK 7:
       - openjdk7
       - oraclejdk7
 
-Travis CI provides OpenJDK 6, OpenJDK 7 and Oracle JDK 7. Sun JDK 6 is not provided and because it is EOL as of November 2012.
+Travis CI provides OpenJDK 6, OpenJDK 7 and Oracle JDK 7. Sun JDK 6 is not provided, because it is EOL as of November 2012.
 
 JDK 7 is backwards compatible, we think it's time for all projects to start testing against JDK 7 first and JDK 6 if resources permit.
 


### PR DESCRIPTION
The "and" is there because the sentence used to end with "will not be provided" (see 0097347). If you'd like, I can restore that version instead.
