### PR TITLE
Fixed typo in travis-pro.md

### DIFF
--- a/user/travis-pro.md
+++ b/user/travis-pro.md
@@ -163,7 +163,7 @@ step:
 
     before_install:
       - secret=`openssl rsautl -decrypt -inkey ~/.ssh/id_rsa -in secret`
-      - openssl aes-256-cbc -k $secret -in id_private.enc -d -a -out id_private
+      - openssl aes-256-cbc -k "$secret" -in id_private.enc -d -a -out id_private
       - ssh-add -D
       - chmod 600 id_private
       - ssh-add ./id_private


### PR DESCRIPTION
The $secret-variable must be wrapped in quotes, or it will be interpreted as an option and the build will fail with the message "unknown option '{contents of $secret}'".
