### PR TITLE
Android Updates in new build environment (August 2014)

### DIFF
--- a/user/languages/android.md
+++ b/user/languages/android.md
@@ -91,6 +91,7 @@ For more flexibility, the licenses can also be referenced with regular expressio
 While the following components are preinstalled, the exact list may change without prior notice. To ensure the stability of your build environment, we recommend that you explicitly specify the required components for your project.
 
 - platform-tools
+- build-tools-20.0.0
 - android-19
 - sys-img-armeabi-v7a-android-19
 - android-18


### PR DESCRIPTION
Summary:
- build-tools-20.0.0 is now preinstalled
- thanks to great help of https://github.com/travis-ci/travis-build/pull/285, I don't think it is necessary adapt the documentation.

@BanzaiMan this is an "overkill" example, to illustrate the usage of this "upcoming updates" branch (201408-vm-update).
