### PR TITLE
Fix invalid command `jitsu tokens create travis`

### DIFF
--- a/user/deployment/nodejitsu.md
+++ b/user/deployment/nodejitsu.md
@@ -16,7 +16,7 @@ For a minimal configuration, all you need to do is add the following to your `.t
 You can create an API key by running `jitsu tokens create travis` or retrieve an existing one by running `jitsu tokens list`.
 It is recommended to encrypt that key. Assuming you have the Nodejitsu and Travis CI command line clients installed, you can do it like this:
 
-    $ jitsu token create travis
+    $ jitsu tokens create travis
     ...
     data:    travis : THE-API-TOKEN
     ...


### PR DESCRIPTION
No `token` sub-command on `jitsu v0.13.18, node v0.10.29`
