### PR TITLE
give more attention to Oracle JDK 8 being available

### DIFF
--- a/user/build-configuration.md
+++ b/user/build-configuration.md
@@ -180,7 +180,7 @@ One of the key features of Travis CI is the ease of running your test suite agai
 
 ### Clojure
 
-Currently Clojure projects can be tested against Oracle JDK 7, OpenJDK 7 and OpenJDK 6. Clojure flagship build tool, Leiningen, supports testing against multiple Clojure versions:
+Currently Clojure projects can be tested against Oracle JDK 8, Oracle JDK 7, OpenJDK 7 and OpenJDK 6. Clojure flagship build tool, Leiningen, supports testing against multiple Clojure versions:
 
 * In Leiningen 1.x, via [lein-multi plugin](https://github.com/maravillas/lein-multi)
 * In upcoming Leiningen 2.0, via Leiningen Profiles
@@ -202,13 +202,13 @@ Learn more about [.travis.yml options for Erlang projects](/user/languages/erlan
 
 ### Groovy
 
-Groovy projects can be currently tested against Oracle JDK 7, OpenJDK 7 and OpenJDK 6. Support for multiple JDKs will be added eventually.
+Groovy projects can be currently tested against Oracle JDK 8, Oracle JDK 7, OpenJDK 7 and OpenJDK 6.
 
 Learn more in our [Groovy guide](/user/languages/groovy/).
 
 ### Java
 
-Java projects can be currently tested against Oracle JDK 7, OpenJDK 7 and OpenJDK 6. Support for multiple JDKs will be added eventually.
+Java projects can be currently tested against Oracle JDK 8, Oracle JDK 7, OpenJDK 7 and OpenJDK 6.
 
 Learn more in our [Java guide](/user/languages/java/).
 

--- a/user/ci-environment.md
+++ b/user/ci-environment.md
@@ -194,10 +194,10 @@ and belonging to secondary groups given above in `usermod`.
 
 ### JDK
 
-* Oracle JDK 7u6 (oraclejdk7)
+* Oracle JDK 7 (oraclejdk7)
 * OpenJDK 7 (openjdk7)
 * OpenJDK 6 (openjdk6)
-* Oracle JDK 8 EA (oraclejdk8)
+* Oracle JDK 8 (oraclejdk8)
 
 OracleJDK 7 is the default because we have a much more recent patch level compared to OpenJDK 7 from the Ubuntu repositories. Sun/Oracle JDK 6 is not provided because
 it reached End of Life in fall 2012.

--- a/user/getting-started.md
+++ b/user/getting-started.md
@@ -172,6 +172,7 @@ Learn more about [.travis.yml options for Groovy projects](/user/languages/groov
 
     language: java
     jdk:
+      - oraclejdk8
       - oraclejdk7
       - openjdk7
       - openjdk6

--- a/user/languages/groovy.md
+++ b/user/languages/groovy.md
@@ -10,14 +10,12 @@ This guide covers build environment and configuration topics specific to Groovy 
 
 ## Overview
 
-Travis CI environment provides OpenJDK 7, OpenJDK 6, Oracle JDK 7u4, Gradle 1.4, Maven 3 and Ant. Groovy project builder has reasonably good defaults for
+Travis CI environment provides OpenJDK 7, OpenJDK 6, Oracle JDK 8, Oracle JDK 7, Gradle 1.4, Maven 3 and Ant. Groovy project builder has reasonably good defaults for
 projects that use Gradle, Maven or Ant, so quite often you won't have to configure anything beyond
 
     language: groovy
 
 in your `.travis.yml` file.
-
-Support for multiple JDKs will be available in the future.
 
 ## Projects Using Gradle
 
@@ -88,7 +86,7 @@ To test against OpenJDK 7 and Oracle JDK 7:
       - openjdk7
       - oraclejdk7
 
-Travis CI provides OpenJDK 6, OpenJDK 7 and Oracle JDK 7. Sun JDK 6 is not provided and because it is EOL in November 2012,
+Travis CI provides OpenJDK 6, OpenJDK 7, Oracle JDK 7 and Oracle JDK 8. Sun JDK 6 is not provided and because it is EOL in November 2012,
 will not be provided.
 
 JDK 7 is backwards compatible, we think it's time for all projects to start testing against JDK 7 first and JDK 6 if resources permit.

--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -10,7 +10,7 @@ This guide covers build environment and configuration topics specific to Java pr
 
 ## Overview
 
-Travis CI environment provides Oracle JDK 7 (default), Oracle JDK 8 ("Early Access" release), OpenJDK 6, OpenJDK 7, Gradle 1.11, Maven 3.2 and Ant 1.8. Java project builder has reasonably good defaults for projects that use Gradle, Maven or Ant, so quite often you won't have to configure anything beyond
+Travis CI environment provides Oracle JDK 7 (default), Oracle JDK 8, OpenJDK 6, OpenJDK 7, Gradle 1.11, Maven 3.2 and Ant 1.8. Java project builder has reasonably good defaults for projects that use Gradle, Maven or Ant, so quite often you won't have to configure anything beyond
 
     language: java
 
@@ -83,6 +83,7 @@ Because there is no single standard way of installing project dependencies with 
 To test against multiple JDKs, use the `jdk:` key in `.travis.yml`. For example, to test against Oracle JDK 7 (which is newer than OpenJDK 7 on Travis CI) and OpenJDK 6:
 
     jdk:
+      - oraclejdk8
       - oraclejdk7
       - openjdk6
 
@@ -92,7 +93,7 @@ To test against OpenJDK 7 and Oracle JDK 7:
       - openjdk7
       - oraclejdk7
 
-Travis CI provides OpenJDK 6, OpenJDK 7 and Oracle JDK 7. Sun JDK 6 is not provided, because it is EOL as of November 2012.
+Travis CI provides OpenJDK 6, OpenJDK 7, Oracle JDK 7 and Oracle JDK 8. Sun JDK 6 is not provided, because it is EOL as of November 2012.
 
 JDK 7 is backwards compatible, we think it's time for all projects to start testing against JDK 7 first and JDK 6 if resources permit.
 

--- a/user/languages/ruby.md
+++ b/user/languages/ruby.md
@@ -271,7 +271,7 @@ It is possible to test projects against multiple JDKs, namely
 
  * OpenJDK 7
  * Oracle JDK 7
- * Oracle JDK 8 EA
+ * Oracle JDK 8
  * OpenJDK 6
 
 To do so, use the `jdk` key in your `.travis.yml`, for example:
@@ -280,11 +280,12 @@ To do so, use the `jdk` key in your `.travis.yml`, for example:
       - oraclejdk7
       - openjdk7
 
-or all 3:
+or all 4:
 
     jdk:
       - openjdk7
       - oraclejdk7
+      - oraclejdk8
       - openjdk6
 
 Each JDK you test against will create permutations with all other


### PR DESCRIPTION
Oracle JDK 8 is a production release and this PR gives more attention to this being a mainstream release. I also changed/dropped the minor versions as these will probably always be out-of-date.

Also I think it's safe to say "Support for multiple JDKs will be available in the future." is an outdated statement.
