### PR TITLE
Fixed copy&paste mistake for webhook notification

### DIFF
--- a/user/notifications.md
+++ b/user/notifications.md
@@ -382,7 +382,7 @@ You can define webhooks to be notified about build results the same way:
     notifications:
       webhooks: http://your-domain.com/notifications
 
-Or multiple channels:
+Or multiple URLs:
 
     notifications:
       webhooks:


### PR DESCRIPTION
As stated in the commit message. Looks like a simple copy&paste mistake to me.

Cheers,

Christian
