### PR TITLE
Make URL scheme for CC-Menu more explicit

### DIFF
--- a/user/cc-menu.md
+++ b/user/cc-menu.md
@@ -34,9 +34,10 @@ Private repositories require an authenticated URL with a token in it. You can fi
 
 ### Using the CC feed with accounts
 
-The above technique only allows you to add one repository at a time, which can be unwieldy for team members of organizations with several repositories they're working on.
+The above technique only allows you to add one repository at a time, which can be unwieldy for team members of organizations with several repositories they're working on. Rather than specify the owner and the repository, you can simply specify the owner and select a subset of projects. 
 
-Rather than specify the owner and the repository, you can also specify just the owner, for instance `https://api.travis-ci.org/repos/travis-ci.xml`.
+* For open source projects use `https://api.travis-ci.org/repos/<owner>.xml`
+* For closed source projects use `https://api.travis-ci.com/repos/<owner>.xml?token=<token>`.
 
 CCMenu will show you a list of all the available repositories you can then add in single, swift action.
 


### PR DESCRIPTION
Had some issues setting up a closed source project w/ CC-Menu and think that this is clearer
