### PR TITLE
Update tested Rubies

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -268,12 +268,12 @@ When you combine the three main configuration options of *Runtime*, *Environment
 Below is an example configuration for a build matrix that expands to *56 individual (7 * 4 * 2)* builds.
 
     rvm:
-      - 1.8.7
-      - 1.9.2
       - 1.9.3
-      - rbx-2
-      - jruby
+      - 2.0.0
+      - 2.2
       - ruby-head
+      - jruby
+      - rbx-2
       - ree
     gemfile:
       - gemfiles/Gemfile.rails-2.3.x
@@ -288,7 +288,7 @@ You can also define exclusions to the build matrix:
 
     matrix:
       exclude:
-        - rvm: 1.8.7
+        - rvm: 1.9.3
           gemfile: gemfiles/Gemfile.rails-2.3.x
           env: ISOLATED=true
         - rvm: jruby

--- a/user/getting-started.md
+++ b/user/getting-started.md
@@ -27,9 +27,8 @@ Or if you want a more complete guide to a particular language, pick one of these
    ```yaml
    language: ruby
    rvm:
-    - "1.8.7"
-    - "1.9.2"
-    - "1.9.3"
+    - 2.2
+    - jruby
     - rbx
    # uncomment this line if your project needs to run something other than `rake`:
    # script: bundle exec rspec spec
@@ -240,12 +239,9 @@ Learn more about [.travis.yml options for R projects](/user/languages/r/)
 
     language: ruby
     rvm:
-      - "1.8.7"
-      - "1.9.2"
-      - "1.9.3"
-      - jruby-18mode # JRuby in 1.8 mode
-      - jruby-19mode # JRuby in 1.9 mode
-      - rbx
+      - 2.2
+      - jruby
+      - rbx-2
     # uncomment this line if your project needs to run something other than `rake`:
     # script: bundle exec rspec spec
 

--- a/user/languages/ruby.md
+++ b/user/languages/ruby.md
@@ -39,19 +39,16 @@ To specify them, use `rvm:` key in your `.travis.yml` file, for example:
 
     language: ruby
     rvm:
-      - 1.9.3
-      - jruby-18mode # JRuby in 1.8 mode
-      - jruby-19mode # JRuby in 1.9 mode
-      - rbx-2.1.1
-      - 1.8.7
-      - ree
+      - 2.2
+      - jruby
+      - rbx-2
 
 > Note that the `rvm:` key is only available in Ruby Build Environments, not in other
 images containing a ruby implementation.
 
-As we upgrade both RVM and Rubies, aliases like `1.9.3` or `jruby` point to different exact versions, patch levels and so on.
+As we upgrade both RVM and Rubies, aliases like `2.2` or `jruby` point to different exact versions, patch levels and so on.
 
-For full up-to-date list of provided Rubies, see our [CI
+For a full up-to-date list of provided Rubies, see our [CI
 environment guide](/user/ci-environment/).
 
 If you don't specify a version, Travis CI will use MRI 1.9.3 as the default.


### PR DESCRIPTION
Changes include:

* Removing 1.8.7 and 1.9.2 from the default config since they were end-of-life'd.

* Prioritizing 2.2 over 1.9.3.

* Changing jruby-head to jruby, as per travis-ci/travis-ci/issues/3067.

* Specifying Ruby 2.x instead of 2.x.x.

  Since Ruby 2.1.0, [the MRI versioning policy changed to follow Semantic Versioning][1].

  Thus, it is better to leave the patch version unspecified as this way the latest patch release will be selected automatically.

  This probably deserves to be mentioned in the Ruby documentation but for now I think these changes will do.

[1]:
https://www.ruby-lang.org/en/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/