### PR TITLE
Correct default Ruby script

### DIFF
--- a/user/getting-started.md
+++ b/user/getting-started.md
@@ -241,7 +241,7 @@ Learn more about [.travis.yml options for Python projects](/user/languages/pytho
       - jruby-19mode # JRuby in 1.9 mode
       - rbx
     # uncomment this line if your project needs to run something other than `rake`:
-    # script: bundle exec rspec spec
+    # script: bundle exec rake
 
 Learn more about [.travis.yml options for Ruby projects](/user/languages/ruby/)
 


### PR DESCRIPTION
Just created a new project that works with `bundle exec rspec spec`, and discovered that Travis actually runs `bundle exec rake` instead. Which doesn't work. :sob:
