### PR TITLE
Note ambiguous message multiple branch deploy

### DIFF
--- a/user/deployment.md
+++ b/user/deployment.md
@@ -74,6 +74,12 @@ Common options are:
 1. **`tags`**: When set to `true`, the application is deployed when a tag is applied to the commit.
   (Due to a [known issue](https://github.com/travis-ci/travis-ci/issues/1675), you should also set `all_branches: true`.)
 
+Note: Deploying from multiple branches, say `master` and `developement`, will cause the following message to appear:
+
+`Skipping deployment with the s3 provider because this branch is not permitted to deploy`
+
+This is not an error. In the case that you have just pushed to `development`, the master branch will not be deployed which is the desired result.
+
 #### Examples of Conditional Releases using `on:`
 
 This example deploys to Nodejistu only from the `staging` branch when the test has run on Node.js version 0.11.


### PR DESCRIPTION
travis-ci/travis-ci#2824

The message that appeears indicating the complementary branch(es) are not to be released is ambiguous enough to cause the user to think the deploy did not happen on the intended branch.  Made a note of this behavior.