### PR TITLE
Remove node.js mention about discouraging specific versions

### DIFF
--- a/user/languages/javascript-with-nodejs.md
+++ b/user/languages/javascript-with-nodejs.md
@@ -21,7 +21,7 @@ Historically Node.js projects were built on Ruby workers but in November 2011 No
 
 This will make Travis CI run your tests against the latest (as provided by Travis CI maintainers, not necessary the absolutely the latest) 0.6.x, 0.8.x, 0.10.x and 0.11.x branch releases.
 
-0.10 is an alias for "the most recent 0.10.x release" and so on.
+0.10 is an alias for "the most recent 0.10.x release" and so on. If you don't need to test specific version, we encourage to specify it this way as it will run the newest stable release.
 
 For example, see [hook.io-amqp-listener .travis.yml](https://github.com/scottyapp/hook.io-amqp-listener/blob/master/.travis.yml).
 


### PR DESCRIPTION
One of the customers asked about this sentence, ie. if older versions get removed. I think this is misleading, because even if we remove one of the older versions, it will still be compiled, so while it may increase the build time, it should work correctly, at least to some degree (really old versions may have problems with compiling).

I've changed this part to encourage specifying major and minor version only, but without "highly discouraging" doing otherwise.
