### PR TITLE
Remove git.io from setup instructions

### DIFF
--- a/user/languages/javascript-with-nodejs.md
+++ b/user/languages/javascript-with-nodejs.md
@@ -83,7 +83,7 @@ like this:
     node_js:
       - "0.10"
     before_install:
-      - "curl -L http://git.io/3l-rRA | /bin/sh"
+      - "curl -L https://raw.githubusercontent.com/arunoda/travis-ci-laika/master/configure.sh | /bin/sh"
     services:
       - mongodb
     env:
@@ -101,7 +101,7 @@ For example, you can use the following `.travis.yml` file .
     node_js:
       - "0.10"
     before_install:
-      - "curl -L http://git.io/ejPSng | /bin/sh"
+      - "curl -L https://raw.githubusercontent.com/arunoda/travis-ci-meteor-packages/master/configure.sh | /bin/sh"
 
 The `before_install` script will make sure the required dependencies are installed.
 


### PR DESCRIPTION
git.io has no TLS support and is generally recommended against except
for casual short-linking. git.io is officially unfit for linking to https-URLs,
relevant email discussion with github support attached.

![screen shot 2014-11-07 at 12 36 19](https://cloud.githubusercontent.com/assets/47542/4952301/5bde706e-6672-11e4-83d1-d18100c9fa1a.png)

As a quick fix, I included the full URLs.

Also, on the same note: wouldn't it make sense to use specific revisions if the install scripts for automated building?
