### PR TITLE
Make the various language lists a bit more consistent

### DIFF
--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -147,6 +147,7 @@
               <li><a href="/user/languages/php/">PHP</a></li>
               <li><a href="/user/languages/python/">Python</a></li>
               <li><a href="/user/languages/ruby/">Ruby</a></li>
+              <li><a href="/user/languages/rust/">Rust</a></li>
               <li><a href="/user/languages/scala/">Scala</a></li>
               <li><a href="/user/languages/csharp/">Visual Basic</a></li>
             </ul>

--- a/user/getting-started.md
+++ b/user/getting-started.md
@@ -13,6 +13,7 @@ GitHub and offers first class support for:
 * [C++](/user/languages/cpp)
 * [Clojure](/user/languages/clojure)
 * [C#](/user/languages/csharp/)
+* [D](/user/languages/d)
 * [Erlang](/user/languages/erlang)
 * [F#](/user/languages/csharp/)
 * [Go](/user/languages/go)
@@ -20,16 +21,15 @@ GitHub and offers first class support for:
 * [Haskell](/user/languages/haskell)
 * [Java](/user/languages/java)
 * [JavaScript (with Node.js)](/user/languages/javascript-with-nodejs)
+* [Julia](/user/languages/julia)
 * [Objective-C](/user/languages/objective-c)
 * [Perl](/user/languages/perl)
 * [PHP](/user/languages/php)
 * [Python](/user/languages/python)
 * [Ruby](/user/languages/ruby)
+* [Rust](/user/languages/rust)
 * [Scala](/user/languages/scala)
 * [Visual Basic](/user/languages/csharp/)
-
-Community-contributed support is available for:
-* [Julia](/user/languages/julia)
 
 
 Travis CI's build environment provides different runtimes for different

--- a/user/languages/index.md
+++ b/user/languages/index.md
@@ -6,9 +6,16 @@ layout: en
 Here's a list of tutorials for using Travis CI with different programming
 languages:
 
+* [C](/user/languages/c)
+* [C++](/user/languages/cpp)
 * [Clojure](/user/languages/clojure)
+* [C#](/user/languages/csharp/)
+* [D](/user/languages/d)
 * [Erlang](/user/languages/erlang)
+* [F#](/user/languages/csharp/)
+* [Go](/user/languages/go)
 * [Groovy](/user/languages/groovy)
+* [Haskell](/user/languages/haskell)
 * [Java](/user/languages/java)
 * [JavaScript (with Node.js)](/user/languages/javascript-with-nodejs)
 * [Julia](/user/languages/julia)
@@ -17,5 +24,6 @@ languages:
 * [PHP](/user/languages/php)
 * [Python](/user/languages/python)
 * [Ruby](/user/languages/ruby)
-* [Rust](/usr/languages/rust)
+* [Rust](/user/languages/rust)
 * [Scala](/user/languages/scala)
+* [Visual Basic](/user/languages/csharp/)


### PR DESCRIPTION
The markdown didn't look quite right for Julia on its own at http://docs.travis-ci.com/user/getting-started/, so I went through the different language lists at various places in the docs and made them more consistent.
