### PR TITLE
Fix broken links to PostgreSQL documentation

### DIFF
--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -113,7 +113,7 @@
 
             <h2>Services and Databases</h2>
             <ul>
-              <li><a href="/user/using-postgresql/">Using PostgreSQL</a></li>
+              <li><a href="/user/postgresql/">Using PostgreSQL</a></li>
               <li><a href="/user/firefox/">Firefox</a></li>
               <li><a href="/user/hosts/">Custom Host Names</a></li>
             </ul>

--- a/user/addons.md
+++ b/user/addons.md
@@ -9,5 +9,5 @@ moved:
 
 * [Sauce Connect](/user/sauce-connect)
 * [Custom Host Names](/user/hosts/)
-* [PostgreSQL](/user/using-postgresql/)
+* [PostgreSQL](/user/postgresql/)
 * [Firefox](/user/firefox/)

--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -91,7 +91,7 @@ before_install:
 
 ### PostgreSQL
 
-[Using PostgreSQL is covered in a separate guide](/user/using-postgresql).
+[Using PostgreSQL is covered in a separate guide](/user/postgresql).
 
 ### SQLite3
 


### PR DESCRIPTION
This commit:

https://github.com/travis-ci/docs-travis-ci-com/commit/846f1ded4a416b591a36c20f54c4baead11251a8

broke the links to the PostgreSQL documentation.
