### PR TITLE
update instructions for getting api key

### DIFF
--- a/user/deployment/npm.md
+++ b/user/deployment/npm.md
@@ -25,8 +25,11 @@ commits, like so:
 
 If you tag a commit locally, remember to run `git push --tags` to ensure that your tags are uploaded to Github.
 
-You can retrieve your api key by running `npm login`. Your api key will now be present in your ~/.npmrc. It is recommended to encrypt that key.
-Assuming you have the Travis CI command line client installed, you can do it like this:
+You can get your api key by running the following command, filling in `username` and `password` with your npm credentials:
+
+    echo -n "username:password" | base64
+
+It is recommended to encrypt that key. Assuming you have the Travis CI command line client installed, you can do it like this:
 
     travis encrypt --add deploy.api_key
 


### PR DESCRIPTION
When you generate a new .npmrc, the _auth key no longer exists. Instead there is a _password key. The _auth property had contained the base64 encoded string composed of username:password. The _password property only contains the base64 encoded password, without the username.

This updates the instructions in a way that works for both versions.