### PR TITLE
Deploy S3 - HTTP cache headers

### DIFF
--- a/user/deployment/s3.md
+++ b/user/deployment/s3.md
@@ -226,3 +226,19 @@ deploy:
 
 If the file is compressed with `gzip` or `compress`, it will be uploaded with
 the appropriate header.
+
+### HTTP cache control
+
+S3 uploads can optionally set  `Cache-Control` and `Expires` HTTP headers.
+
+Set HTTP header `Cache-Control` to suggest that the browser cache the file. Defaults to `no-cache`. Valid options are `no-cache`, `no-store`, `max-age=<seconds>`, `s-maxage=<seconds> no-transform`, `public`, `private`.
+
+`Expires` sets the date and time that the cached object is no longer cacheable. Defaults to not set. The date must be in the format `YYYY-MM-DD HH:MM:SS -ZONE`.
+
+{% highlight yaml %}
+deploy:
+  provider: s3
+  ..
+  cache_control: "max-age=31536000"
+  expires: "2012-12-21 00:00:00 -0000"
+{% endhighlight %}


### PR DESCRIPTION
I've tried to figure out if it is possible to set `Cache-Control` for S3 deploy, finally I've found that it is supported by deploy tool https://github.com/travis-ci/dpl#s3 but not documented.