### PR TITLE
Update notifications.md

### DIFF
--- a/user/notifications.md
+++ b/user/notifications.md
@@ -429,7 +429,7 @@ As with other notification types you can specify when webhook payloads will be s
           - http://hooks.mydomain.com/events
         on_success: [always|never|change] # default: always
         on_failure: [always|never|change] # default: always
-        on_start: [true|false] # default: false
+        on_start: [always|never|change] # default: always
 
 ### Webhooks Delivery Format
 


### PR DESCRIPTION
According to travis-lint, on_start should be always, never, or change:

https://github.com/travis-ci/travis-yaml/blob/44e072dd42a69dc11a9a6cd0f57899b6b4c95d5d/SPEC.md#notificationswebhookson_start

I'm not certain that the default is always, but I assumed it probably is based on the previous two lines.