### PR TITLE
add hack for building all branches

### DIFF
--- a/user/build-configuration.md
+++ b/user/build-configuration.md
@@ -343,7 +343,7 @@ You can either white- or blacklist branches that you want to be built:
         - legacy
         - experimental
 
-    # whitelist
+    # safelist
     branches:
       only:
         - master
@@ -351,7 +351,7 @@ You can either white- or blacklist branches that you want to be built:
 
 If you specify both, "except" will be ignored. Please note that currently (for historical reasons), `.travis.yml` needs to be present *on all active branches* of your project.
 
-Note that the `gh-pages` branch will not be built unless you add it to the whitelist (`branches.only`), or force all branches to build:
+Note that the `gh-pages` branch will not be built unless you add it to the safelist (`branches.only`), or force all branches to build:
 
     branches:
       only:

--- a/user/build-configuration.md
+++ b/user/build-configuration.md
@@ -351,10 +351,11 @@ You can either white- or blacklist branches that you want to be built:
 
 If you specify both, "except" will be ignored. Please note that currently (for historical reasons), `.travis.yml` needs to be present *on all active branches* of your project.
 
-Note that the `gh-pages` branch will not be built unless you add it to the safelist (`branches.only`), or force all branches to build:
+Note that the `gh-pages` branch will not be built unless you add it to the safelist (`branches.only`) explicitly. To have _all_ branches build:
 
     branches:
       only:
+        - gh-pages
         - /.*/
 
 ### Using regular expressions ###

--- a/user/build-configuration.md
+++ b/user/build-configuration.md
@@ -351,7 +351,11 @@ You can either white- or blacklist branches that you want to be built:
 
 If you specify both, "except" will be ignored. Please note that currently (for historical reasons), `.travis.yml` needs to be present *on all active branches* of your project.
 
-Note that the `gh-pages` branch will not be built unless you add it to the whitelist (`branches.only`).
+Note that the `gh-pages` branch will not be built unless you add it to the whitelist (`branches.only`), or force all branches to build:
+
+    branches:
+      only:
+        - /.*/
 
 ### Using regular expressions ###
 


### PR DESCRIPTION
The use case is Pages-only repositories, where the maintainers run the build with Travis, and want all branches and pull requests to be run.
