### PR TITLE
Remove note about .ruby-version only being respected if the version is pre-installed

### DIFF
--- a/user/languages/ruby.md
+++ b/user/languages/ruby.md
@@ -72,10 +72,6 @@ If the ruby version is not dictated by the `rvm` key as described above, Travis 
 will consult `.ruby-version` in the root of the repository and use the indicated
 Ruby runtime.
 
-This strategy works if the specified Ruby runtime is already installed on the
-worker.
-If it is not, your build will fail.
-
 ### Choosing Rubies that aren't installed
 
 While we pre-install some Rubies, you can install other versions by way of RVM's


### PR DESCRIPTION
Based on [the source code](https://github.com/travis-ci/travis-build/blob/fc9e9d07fbd3464a2a5ca45806d6dd4fa01fea1b/lib/travis/build/script/shared/rvm.rb#L85-L90), it doesn't matter if the version specified in `.ruby-version` is pre-installed on the worker or not, as it is just piped to `rvm use [...] --install --binary --fuzzy`.