### PR TITLE
Add documentation for Perl 6

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -16,6 +16,7 @@ JavaScript <small>(with Node.js)</small>: "/user/languages/javascript-with-nodej
 Julia: "/user/languages/julia"
 Objective-C: "/user/languages/objective-c"
 Perl: "/user/languages/perl"
+Perl6: "/user/languages/perl6"
 PHP: "/user/languages/php"
 Python: "/user/languages/python"
 R: "/user/languages/r"

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -23,7 +23,7 @@ versions that your projects can be tested against. To specify them, use the
       - 2015.05
       - 2015.04
 
-As time goes, new releases come out and we upgrade both rakudobrew and
+Over time, new releases come out and we upgrade both rakudobrew and
 Perls, aliases like `2015.04` will float and point to different exact
 versions, patch levels and so on.
 

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -1,0 +1,79 @@
+---
+title: Building a Perl 6 Project
+layout: en
+permalink: /user/languages/perl6/
+---
+
+### What This Guide Covers
+
+This guide covers build environment and configuration topics specific to
+Perl 6 projects. Please make sure to read our [Getting Started](/user/getting-started/)
+and [general build configuration](/user/build-configuration/) guides first.
+
+## Choosing Perl 6 versions to test against
+
+Perl 6 workers on travis-ci.org use
+[rakudobrew](https://github.com/tadzik/rakudobrew) to provide several Perl 6
+versions that your projects can be tested against. To specify them, use the
+`perl6:` key in your `.travis.yml` file, for example:
+
+    language: perl6
+    perl6:
+      - latest
+      - 2015.05
+      - 2015.04
+
+As time goes, new releases come out and we upgrade both rakudobrew and
+Perls, aliases like `2015.04` will float and point to different exact
+versions, patch levels and so on.
+
+For precise versions pre-installed on the VM, please consult "Build system
+information" in the build log.
+
+## Perl 6 Stack
+
+At present the Perl 6 that is built is [Rakudo](http://rakudo.org/) upon
+[NQP](https://github.com/perl6/nqp/) with the [MoarVM](http://moarvm.org/)
+backend.  Future support for the
+[JVM](http://en.wikipedia.org/wiki/Java_virtual_machine) backend is planned.
+
+## Default Perl 6 Version
+
+If you leave the `perl6` key out of your `.travis.yml`, Travis CI will use
+the latest Rakudo Perl 6.
+
+## Default Test Script
+
+By default, the following command will be used to run the project's tests:
+
+    PERL6LIB=lib prove --exec=perl6 -r t
+
+## Dependency Management
+
+### Travis CI uses panda
+
+By default Travis CI uses `panda` to manage your project's dependencies. It
+is possible to override dependency installation command as described in the
+[general build configuration](/user/build-configuration/) guide.
+
+### When Overriding Build Commands, Do Not Use sudo
+
+When overriding the `install:` key to tweak dependency installation
+commands, do not use sudo.  Travis CI Environment has Perl 6 versions
+installed via rakudobrew in a non-privileged user `$HOME` directory. Using
+sudo will result in dependencies being installed in unexpected (for the
+Travis CI Perl 6 builder) locations and they won't load.
+
+## Build Matrix
+
+For Perl 6 projects, `env` and `perl6` can be given as arrays to construct a
+build matrix.
+
+## Environment Variable
+
+The Perl 6 version a job is using is available via:
+
+    TRAVIS_PERL6_VERSION
+
+## Examples
+

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -58,7 +58,6 @@ either downloading and installing your dependencies as part of the `install`
 step, or you could use [panda](https://github.com/tadzik/panda) (the Perl 6
 module package manager) like so:
 
-### When Overriding Build Commands, Do Not Use sudo
     install:
         - rakudobrew build-panda
         - panda install <Module1> <Module2>
@@ -84,6 +83,7 @@ Further information about overriding dependency installation commands is
 described in the [general build configuration](/user/build-configuration/)
 guide.
 
+### When overriding build commands, do not use sudo
 
 When overriding the `install:` key to tweak dependency installation
 commands, do not use sudo.  Travis CI Environment has Perl 6 versions

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -50,13 +50,40 @@ By default, the following command will be used to run the project's tests:
 
 ## Dependency Management
 
-### Travis CI uses panda
+### There is currently no automated dependency management
 
-By default Travis CI uses `panda` to manage your project's dependencies. It
-is possible to override dependency installation command as described in the
-[general build configuration](/user/build-configuration/) guide.
+At present, by default Travis CI does not automatically manage your
+project's dependencies.  It is possible to manage dependencies yourself by
+either downloading and installing your dependencies as part of the `install`
+step, or you could use [panda](https://github.com/tadzik/panda) (the Perl 6
+module package manager) like so:
 
 ### When Overriding Build Commands, Do Not Use sudo
+    install:
+        - rakudobrew build-panda
+        - panda install <Module1> <Module2>
+
+this will install the latest `panda` version.
+
+It is sometimes necessary to match the `panda` version to that of Rakudo;
+new Rakudo features could be used in the most up to date `panda` which
+aren't available in the version of Rakudo you are using.  For instance, to
+test a module against Rakudo 2015.04, you would have a `.travis.yml` which
+looks something like this:
+
+    language: perl6
+    perl6:
+        - 2015.04
+    install:
+        - rakudobrew panda-install 2015.04
+
+Now your `panda` will match your Rakudo version and should install
+the relevant dependencies successfully.
+
+Further information about overriding dependency installation commands is
+described in the [general build configuration](/user/build-configuration/)
+guide.
+
 
 When overriding the `install:` key to tweak dependency installation
 commands, do not use sudo.  Travis CI Environment has Perl 6 versions

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -46,7 +46,7 @@ the latest Rakudo Perl 6.
 
 By default, the following command will be used to run the project's tests:
 
-    panda-test
+    PERL6LIB=lib prove -v -r --exec=perl6 t/
 
 ## Dependency Management
 

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -94,7 +94,7 @@ Travis CI Perl 6 builder) locations and they won't load.
 ## Build Matrix
 
 For Perl 6 projects, `env` and `perl6` can be given as arrays to construct a
-build matrix.
+build matrix. (As yet untested).
 
 ## Environment Variable
 

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -104,3 +104,31 @@ The Perl 6 version a job is using is available via:
 
 ## Examples
 
+### Build and test with the latest Rakudo
+
+    language: perl6
+
+### Build and test with multiple Rakudo versions
+
+    language: perl6
+    perl6:
+        - 2015.06
+        - 2015.05
+
+### Build and test with matching Rakudo and panda versions
+
+    language: perl6
+    perl6:
+        - 2015.03
+    install:
+        - rakudobrew build-panda 2015.03
+
+### Build and test with the latest Rakudo, but with non-standard lib and test dirs
+
+Use e.g. `src/` for the module library code, and `tests/` as the test
+directory.  Please note that it is standard practice to put the module
+library code under `lib/` and the tests under `t/`.
+
+    language: perl6
+    script:
+        - PERL6LIB=src prove -v -r --exec=perl6 tests/

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -46,7 +46,7 @@ the latest Rakudo Perl 6.
 
 By default, the following command will be used to run the project's tests:
 
-    PERL6LIB=lib prove --exec=perl6 -r t
+    panda-test
 
 ## Dependency Management
 

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -40,8 +40,8 @@ backend.  Future support for the
 
 ## Default Perl 6 Version
 
-If you leave the `perl6` key out of your `.travis.yml`, Travis CI will use
-the latest Rakudo Perl 6.
+If you leave the `perl6` key out of your `.travis.yml`, Travis CI will build
+Rakudo Perl 6 from the latest commit from the project's `nom` branch.
 
 ## Default Test Script
 

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -20,6 +20,7 @@ versions that your projects can be tested against. To specify them, use the
     language: perl6
     perl6:
       - latest
+      - 2015.06
       - 2015.05
       - 2015.04
 


### PR DESCRIPTION
This is the documentation to accompany the community-supported Travis build for Perl 6 (see https://github.com/travis-ci/travis-build/pull/415).