### PR TITLE
Fix typos & correct a link

### DIFF
--- a/user/ci-environment.md
+++ b/user/ci-environment.md
@@ -55,13 +55,13 @@ The following table summarizes the differences between the virtual environments:
 </tr>
 <tr>
 <td>Boot Time</td>
-<td>slightly slower then Container-based</td>
-<td>slightly faster that Standard</td>
+<td>slightly slower than Container-based</td>
+<td>slightly faster than Standard</td>
 <td>N/A</td>
 </tr>
 <tr>
 <td>File System</td>
-<td>SIMFS, which is case sensitive and can return directory entities in random order</td>
+<td>SIMFS, which is case-sensitive and can return directory entities in random order</td>
 <td>AUFS</td>
 <td>HFS+, which is case-insensitive and returns directory entities alphabetically</td>
 </tr>

--- a/user/getting-started.md
+++ b/user/getting-started.md
@@ -44,7 +44,7 @@ Or if you want a more complete guide to a particular language, pick one of these
 
 2. Check the [build status](https://travis-ci.org/repositories) page to see if your build passes or fails.
 
-You probably need to [customize your build](/user/customizing-the-build) by [installing dependencies](/user/installing-dependencies) or [setting up a Database](/user/database-setup/). Or maybe you just want more information about the [test environment](user/ci-environment/)?
+You probably need to [customize your build](/user/customizing-the-build) by [installing dependencies](/user/installing-dependencies) or [setting up a Database](/user/database-setup/). Or maybe you just want more information about the [test environment](/user/ci-environment/)?
 
 For any kind of questions feel free to join our IRC channel [#travis on chat.freenode.net](irc://chat.freenode.net/%23travis).
 


### PR DESCRIPTION
* A link from the getting started page was broken due to a missing leading
  slash
* Minor typos on the CI environment page