### PR TITLE
Adding a clarification to the apt page about how to use `sources:` and `packages:` together

### DIFF
--- a/user/apt.md
+++ b/user/apt.md
@@ -10,6 +10,18 @@ When using the [container based infrastructure](/user/workers/container-based-in
 user-defined build phases such as `before_install`. This prevents installation of APT packages via `apt-get` as well as
 the addition of APT sources such as one might do with `apt-add-repository`.
 
+ > Note: When using APT sources and packages together, you need to make
+ > sure they are under the same key space in the YAML file. e.g.
+
+ > ``` yaml
+ > addons:
+ >  apt:
+ >    sources:
+ >    - ubuntu-toolchain-r-test
+ >    packages:
+ >    - gcc-4.8
+ >    - g++-4.8
+
 ## Adding APT Sources
 
 To add APT sources before your custom build steps, use the `addons.apt.sources` key, e.g.:


### PR DESCRIPTION
As part of investigating https://secure.helpscout.net/conversation/98485511/17130/ I determined that the duplicate nested keys was resulting in the issue and filed https://github.com/travis-ci/travis-yaml/issues/64.

I'm also adding a clarification to the apt page about how to use `sources:` and `packages:` together to hopefully avoid this particular case of confusion in the future