### PR TITLE
sudo is required

### DIFF
--- a/user/languages/r.md
+++ b/user/languages/r.md
@@ -28,6 +28,7 @@ package doesn't need any dependencies beyond those specified in your
 `DESCRIPTION` file, your `.travis.yml` can simply be
 
     language: r
+    sudo: required
 
 The R environment comes with LaTeX and
 [pandoc](http://johnmacfarlane.net/pandoc/) preinstalled, making it easier to


### PR DESCRIPTION
R support in Travis CI currently requires `sudo`, so let's help first-time-users with a more complete basic configuration file.