### PR TITLE
Fix typo

### DIFF
--- a/user/encrypting-files.md
+++ b/user/encrypting-files.md
@@ -41,7 +41,7 @@ encrypting super_secret.txt for rkh/travis-encrypt-file-example
 storing result as super_secret.txt.enc
 storing secure env variables for decryption
 
-Please add the following to your build scirpt (before_install stage in your .travis.yml, for instance):
+Please add the following to your build script (before_install stage in your .travis.yml, for instance):
 
     openssl aes-256-cbc -K $encrypted_0a6446eb3ae3_key -iv $encrypted_0a6446eb3ae3_key -in super_secret.txt.enc -out super_secret.txt -d
 


### PR DESCRIPTION
If this output was copy/pasted directly from the output of a tool, it might be worth fixing it in that tool's source as well. But I grepped for `scirpt` in the ruby CLI source, I didn't find anything.