### PR TITLE
Make clearer how to update the travis-web project for matrix expansion

### DIFF
--- a/user/languages/community-supported-languages.md
+++ b/user/languages/community-supported-languages.md
@@ -76,9 +76,9 @@ realize support for builds in a new language.
     to have this information visible to the end user.
 
     To make this happen, you need to tell `travis-web` to pick up the value
-    from the job's data and display it.
-
-    See [this PR](https://github.com/travis-ci/travis-web/pull/313) for an example.
+    from the job's data and display it.  Clone the `travis-web` repository,
+    add your language to the `app/utils/keys-map.coffee` file and submit a
+    pull request for this change.
 
 
 It is important to note that languages are configured at build time,


### PR DESCRIPTION
The pull request cited in the section about how to update the `travis-web`
project for language matrix expansion points to a commit to a file which no
longer exists.  It is thus hard to find the correct file to update.  This
change updates the text to mention the file which currently needs to be
edited in order to add a new language to the list of language configuration
keys, and thus hopefully reduces confusion on the part of the user.