### PR TITLE
Update Androd SDK version to 22, buildtools to 22.0.1

### DIFF
--- a/user/languages/android.md
+++ b/user/languages/android.md
@@ -38,7 +38,7 @@ Here is an example `.travis.yml` for an Android project:
         - build-tools-19.1.0
 
         # The SDK version used to compile your project
-        - android-19
+        - android-22
 
         # Additional components
         - extra-google-google_play_services
@@ -48,7 +48,7 @@ Here is an example `.travis.yml` for an Android project:
 
         # Specify at least one system image,
         # if you need to run emulator(s) during your tests
-        - sys-img-armeabi-v7a-android-19
+        - sys-img-armeabi-v7a-android-22
         - sys-img-x86-android-17
 
 
@@ -91,7 +91,9 @@ For more flexibility, the licenses can also be referenced with regular expressio
 While the following components are preinstalled, the exact list may change without prior notice. To ensure the stability of your build environment, we recommend that you explicitly specify the required components for your project.
 
 - platform-tools
-- build-tools-21.1.1
+- build-tools-22.0.1
+- android-22
+- sys-img-armeabi-v7a-android-22
 - android-21
 - sys-img-armeabi-v7a-android-21
 - android-20
@@ -120,7 +122,7 @@ If you feel adventurous, you may use the script [`/usr/local/bin/android-wait-fo
 
     # Emulator Management: Create, Start and Wait
     before_script:
-      - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
+      - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
       - emulator -avd test -no-skin -no-audio -no-window &
       - android-wait-for-emulator
       - adb shell input keyevent 82 &


### PR DESCRIPTION
Android SDK version along with buildtools version have been updated in all examples, since they represent the latest available official versions from Google (https://developer.android.com/tools/sdk/tools-notes.html) 

Notice: this can be merged as soon as https://github.com/travis-ci/travis-cookbooks/pull/490 is merged.