### PR TITLE
Use https:// (not git://) URLs

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -430,7 +430,7 @@ If your project uses Git submodules, make sure you use public Git URLs. For exam
 
 use
 
-    git://github.com/someuser/somelibrary.git
+    https://github.com/someuser/somelibrary.git
 
 Otherwise, Travis CI builders won't be able to clone your project because they don't have your private SSH key.
 


### PR DESCRIPTION
GitHub doesn't advertise `git://` URLs anywhere, and we don't encourage using them.

The preferred protocol for "Public URLs" is HTTPS.

Thanks! :v: 