### PR TITLE
Add support of OpenJDK 8

### DIFF
--- a/user/ci-environment.md
+++ b/user/ci-environment.md
@@ -232,9 +232,10 @@ in order to minimize frictions when images are updated:
 ### JDK
 
 * Oracle JDK 7 (oraclejdk7)
-* OpenJDK 7 (openjdk7)
-* OpenJDK 6 (openjdk6)
 * Oracle JDK 8 (oraclejdk8)
+* OpenJDK 6 (openjdk6)
+* OpenJDK 7 (openjdk7)
+* OpenJDK 8 (openjdk8)
 
 OracleJDK 7 is the default because we have a much more recent patch level compared to OpenJDK 7 from the Ubuntu repositories. Sun/Oracle JDK 6 is not provided because
 it reached End of Life in fall 2012.

--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -10,7 +10,7 @@ This guide covers build environment and configuration topics specific to Java pr
 
 ## Overview
 
-Travis CI environment provides Oracle JDK 7 (default), Oracle JDK 8, OpenJDK 6, OpenJDK 7, Gradle 2.0, Maven 3.2 and Ant 1.8.
+Travis CI environment provides Oracle JDK 7 (default), Oracle JDK 8, OpenJDK 6, OpenJDK 7, OpenJDK 8, Gradle 2.0, Maven 3.2 and Ant 1.8.
 Java project builder has reasonably good defaults for projects that use Gradle, Maven or Ant,
 so quite often you won't have to configure anything beyond
 
@@ -89,6 +89,7 @@ To test against multiple JDKs, use the `jdk:` key in `.travis.yml`. For example,
     jdk:
       - oraclejdk8
       - oraclejdk7
+      - openjdk8
       - openjdk6
 
 To test against OpenJDK 7 and Oracle JDK 7:
@@ -97,7 +98,7 @@ To test against OpenJDK 7 and Oracle JDK 7:
       - openjdk7
       - oraclejdk7
 
-Travis CI provides OpenJDK 6, OpenJDK 7, Oracle JDK 7, and Oracle JDK 8. Sun JDK 6 is not provided, because it is EOL as of November 2012.
+Travis CI provides OpenJDK 6, OpenJDK 7, OpenJDK 8 (without JavaFX/OpenJFX), Oracle JDK 7, and Oracle JDK 8. Sun JDK 6 is not provided, because it is EOL as of November 2012.
 
 JDK 7 is backwards compatible, we think it's time for all projects to start testing against JDK 7 first and JDK 6 if resources permit.
 


### PR DESCRIPTION
To be merged when OpenJDK8 will be indeed added to build environment.

See https://github.com/travis-ci/travis-cookbooks/pull/494