### PR TITLE
Fixed syntax error, removed unused tags

### DIFF
--- a/user/apps.md
+++ b/user/apps.md
@@ -316,12 +316,9 @@ By CCNet and ThoughtWorks Inc.
 * [website](http://www.cruisecontrolnet.org/projects/cctray)
 * [sourceforge](http://sourceforge.net/projects/ccnet/files/CruiseControl.NET%20Releases/CruiseControl.NET%201.8.4/)
 * [tutorial](/user/cc-menu/)
-</figcation>
-</figure>
 
-<figure class="app">
-![Siren of Shame](/images/apps/siren-windows.jpg)
-<figcation>
+![Siren of Shame](/images/apps/siren-windows.jpg){:.app}
+
 ### Siren of Shame (Windows 8)
 
 Gamification for your builds<br>
@@ -329,8 +326,6 @@ By Automated Architecture
 
 * [website](http://sirenofshame.com/)
 * [windows 8 store](http://apps.microsoft.com/windows/en-US/app/siren-of-shame/1af0feaf-0801-4ad3-8a95-3f1226e313b9)
-</figcation>
-</figure>
 
 <a name='commandline'></a>
 # Command Line Tools


### PR DESCRIPTION
Fixes this: ![screenshot](http://i.imgur.com/swL8uQx.png) 

Also figcation and figure were only used in this one place in the file, they've been removed.

http://docs.travis-ci.com/user/apps/#Windows