### PR TITLE
Document commit_subject for IRC notifications

### DIFF
--- a/user/notifications.md
+++ b/user/notifications.md
@@ -149,6 +149,7 @@ You can interpolate the following variables:
 * *commit*: shortened commit SHA
 * *author*: commit author name
 * *commit_message*: commit message of build
+* *commit_subject*: first line of the commit message
 * *result*: result of build
 * *message*: travis message to the build
 * *duration*: duration of the build


### PR DESCRIPTION
Using commit_message breaks the notification if it contains a newline, so commit_subject is the far more useful key. Document it so people don't have to dive to https://github.com/travis-ci/travis-tasks/blob/master/lib/travis/addons/util/template.rb#L30