### PR TITLE
Meteor docs: Add .meteor to path. Allows meteor package tests to run.

### DIFF
--- a/user/languages/javascript-with-nodejs.md
+++ b/user/languages/javascript-with-nodejs.md
@@ -123,7 +123,6 @@ For example, you can use the following `.travis.yml` file .
     before_script:
       - "export PATH=$HOME/.meteor:$PATH"
 
-
 The `before_install` script will make sure the required dependencies are installed.
 
 The related source code can be found at the [travis-ci-meteor-packages](https://github.com/arunoda/travis-ci-meteor-packages) repository.

--- a/user/languages/javascript-with-nodejs.md
+++ b/user/languages/javascript-with-nodejs.md
@@ -120,6 +120,9 @@ For example, you can use the following `.travis.yml` file .
       - "0.12"
     before_install:
       - "curl -L https://raw.githubusercontent.com/arunoda/travis-ci-meteor-packages/master/configure.sh | /bin/sh"
+    before_script:
+      - "export PATH=$HOME/.meteor:$PATH"
+
 
 The `before_install` script will make sure the required dependencies are installed.
 


### PR DESCRIPTION
Update instructions for building Meteor Packages. Adding `$HOME/.meteor` to PATH gets tests for Meteor Packages to run.