### PR TITLE
mysql and postgresql use services:

### DIFF
--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -29,7 +29,14 @@ or to start several services:
 
 ### MySQL
 
-MySQL on Travis CI is **started on boot**, binds to 127.0.0.1 and requires authentication. You can connect using the username "travis" or "root" and a blank password.  
+To use MySQL include the following `services` entry in `.travis.yml`:
+
+    services:
+      - mysql
+
+Note: MySQL on Travis CI is currently **started on boot** however this may not always be the case.
+
+MySQL binds to 127.0.0.1 and requires authentication. You can connect using the username "travis" or "root" and a blank password.  
 
 >Note that the "travis" user does not have full MySQL privileges that the "root" user does.
 
@@ -65,9 +72,14 @@ before_install:
 ### PostgreSQL
 
 
+To use PostgreSQL include the following `services` entry in `.travis.yml`:
+
+    services:
+      - postgresql
+
 #### Selecting a PostgreSQL Version
 
-By default, the build environment will have version 9.1 running already.
+By default, the build environment will have version 9.1 installed.
 
 You can easily choose a different version by way of your .travis.yml.
 

--- a/user/using-postgresql.md
+++ b/user/using-postgresql.md
@@ -23,6 +23,9 @@ To select a different version than the default, use the following setting in you
     addons:
       postgresql: "9.3"
 
+    services:
+      - postgresql
+
 This selects PostgreSQL 9.3 as the version your build expects to be running.
 
 **Available selections are "9.1", "9.2", "9.3" and "9.4"**. Make sure to only specify the major and the minor version, without the patch release.


### PR DESCRIPTION
Part of travis-ci/travis-ci/issues/2959 to provide more memory to
instances that don't use mysql and postgresql is to get new builds
to have services: mysql and services: postgresql as part of the
configuration.