### PR TITLE
Fix the Rust versions example

### DIFF
--- a/user/languages/rust.md
+++ b/user/languages/rust.md
@@ -35,7 +35,7 @@ build in the `TRAVIS_RUST_VERSION` environment variable.
 
 You can also test against a particular Rust release:
 
-````yaml
+```yaml
 language: rust
 rust:
   - 1.0.0


### PR DESCRIPTION
Drop an apostrophe to make sure jekyll picks
up the code block.