### PR TITLE
Add s3_region to minimal configuration example

### DIFF
--- a/user/uploading-artifacts.md
+++ b/user/uploading-artifacts.md
@@ -14,6 +14,7 @@ For a minimal configuration, all you need to do is add the following to your `.t
 
     addons:
       artifacts: true
+      s3_region: (AWS S3 Region)
 
 and add the following environment variables in the repository settings:
 

--- a/user/uploading-artifacts.md
+++ b/user/uploading-artifacts.md
@@ -14,7 +14,7 @@ For a minimal configuration, all you need to do is add the following to your `.t
 
     addons:
       artifacts: true
-      s3_region: (AWS S3 Region)
+      s3_region: "us-west-1" # defaults to "us-east-1"
 
 and add the following environment variables in the repository settings:
 


### PR DESCRIPTION
Hello,

I stumbled around a good bit trying to get artifact upload working and it would have been really helpful to have the documentation mention needing the field ```s3_region```.

Hope this helps someone.