### PR TITLE
Using meta tags to add indexing terms to swiftype

### DIFF
--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -10,6 +10,11 @@
     <script src="{{ "/assets/javascripts/site.js" | prepend: site.baseurl }}" type="text/javascript" charset="utf-8" defer></script>
     <script src="{{ "/assets/javascripts/main.js" | prepend: site.baseurl }}" type="text/javascript" charset="utf-8" defer></script>
     <link rel="alternate" type="application/atom+xml" href="/blog.xml">
+
+    {% for tag in page.swiftypetags %}
+	   <meta class="swiftype" name="tags" data-type="string" content="{{tag}}" />
+    {% endfor %}
+
     <script type="text/javascript">
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-24868285-6']);

--- a/user/languages/go.md
+++ b/user/languages/go.md
@@ -2,6 +2,7 @@
 title: Building a Go Project
 layout: en
 permalink: /user/languages/go/
+swiftypetags: golang
 ---
 
 ### What This Guide Covers


### PR DESCRIPTION
Proof of concept for adding metadata to pages in the Jekyll content not the Swiftype user interface.

There is an issue in that the tags are treated as one single tags, not split at the moment, (ie there is only ever ONE tag in the html), but that does not affect the search term inclusion we're using it for.