### PR TITLE
Improve panda usage examples

### DIFF
--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -20,12 +20,11 @@ versions that your projects can be tested against. To specify them, use the
     language: perl6
     perl6:
       - latest
-      - 2015.06
-      - 2015.05
+      - 2015.07
       - 2015.04
 
 Over time, new releases come out and we upgrade both rakudobrew and
-Perls, aliases like `2015.04` will float and point to different exact
+Perls, aliases like `2015.07` will float and point to different exact
 versions, patch levels and so on.
 
 For precise versions pre-installed on the VM, please consult "Build system
@@ -73,9 +72,9 @@ looks something like this:
 
     language: perl6
     perl6:
-        - 2015.04
+        - 2015.07
     install:
-        - rakudobrew panda-install 2015.04
+        - rakudobrew build-panda 2015.07
 
 Now your `panda` will match your Rakudo version and should install
 the relevant dependencies successfully.
@@ -120,9 +119,11 @@ The Perl 6 version a job is using is available via:
 
     language: perl6
     perl6:
+        - latest
         - 2015.03
     install:
-        - rakudobrew build-panda 2015.03
+        - rakudobrew build-panda ${TRAVIS_PERL6_VERSION#latest}
+        - panda installdeps .
 
 ### Build and test with the latest Rakudo, but with non-standard lib and test dirs
 


### PR DESCRIPTION
This fixes a wrong `rakudobrew` command, and provides a more realistic example use case for installing dependencies.