### PR TITLE
Fix "go_build" vs "gobuild_args" disparity

### DIFF
--- a/user/languages/go.md
+++ b/user/languages/go.md
@@ -131,7 +131,7 @@ to omit the `-v` flag, override the `script:` key in `.travis.yml` like this:
 The arguments passed to the default `go test` command may be overridden by specifying `gobuild_args:` at the top level
 of the config, e.g.:
 
-    go_build: -x -ldflags "-X main.VersionString v1.2.3"
+    gobuild_args: -x -ldflags "-X main.VersionString v1.2.3"
 
 which will result in the script step being:
 


### PR DESCRIPTION
See https://github.com/travis-ci/travis-build/blob/305921ecd5eaf1feb4801cc0ed0b8d1561ab741c/lib/travis/build/script/go.rb#L78 for where it's actually used. :+1: