### PR TITLE
Azure dpl Provider: `Verbose` option, add to providers list

### DIFF
--- a/_data/deployments.yml
+++ b/_data/deployments.yml
@@ -1,5 +1,6 @@
 anynines: "/user/deployment/anynines"
 Appfog: "/user/deployment/appfog"
+Azure Web Apps: "/user/deployment/azure-web-apps"
 biicode: "/user/deployment/biicode"
 bintray: "/user/deployment/bintray"
 Boxfuse: "/user/deployment/boxfuse"

--- a/user/deployment/azure-web-apps.md
+++ b/user/deployment/azure-web-apps.md
@@ -23,6 +23,14 @@ To define variables in Repository Settings, make sure you're logged in, navigate
   <figcaption>Environment Variables in the Repository Settings</figcaption>
 </figure>
 
+### Fetch Deployment Progress and Logs
+
+The Azure Web App provider can print Azure's deployment progress to your Travis log using the `verbose` option. However, Git will print your password if the authentication fails (it will not if you provide a correct user/password combination).
+
+    deploy:  
+      provider: azure_web_apps
+      verbose: true
+
 ### Branch to deploy from
 
 By default, Travis CI will only deploy from your **master** branch.


### PR DESCRIPTION
Adds information about the `verbose` option to the Azure Web App provider page. It also adds the small Azure provider to the list of supported providers.

(Should only be merged once https://github.com/travis-ci/dpl/pull/329 is merged)