### PR TITLE
Corrected port for vhost in php documentation

### DIFF
--- a/user/languages/php.md
+++ b/user/languages/php.md
@@ -250,7 +250,7 @@ Note that <code>sudo</code> is not available for builds that are running on the 
 You will need to have ``build/travis-ci-apache`` file that will configure your virtual host as usual, the important part for php-fpm is this:
 
 ```
-<VirtualHost *:80>
+<VirtualHost *:8080>
   # [...]
 
   DocumentRoot %TRAVIS_BUILD_DIR%


### PR DESCRIPTION
This caused me some trouble, it seems like the given port in the vhost configuration file is 8080 instead of 80.