### PR TITLE
Corrected Crystal's filename for dependencies

### DIFF
--- a/user/languages/crystal.md
+++ b/user/languages/crystal.md
@@ -24,7 +24,7 @@ and cc [@asterite](https://github.com/asterite),
 ## Basic configuration
 
 If your Crystal project doesn't need any dependencies beyond those specified in
-your `Projectfile`, your `.travis.yml` can simply be
+your `shard.yml`, your `.travis.yml` can simply be
 
     language: crystal
 


### PR DESCRIPTION
Starting from [0.8.0](https://github.com/manastech/crystal/releases/tag/0.8.0) release Crystal use `shard.yml` file to define dependencies. AFAIK other mentioned behavior haven't been changed. 

/cc @will 