### PR TITLE
Perl 6 language documentation: more generic dependency installation

### DIFF
--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -60,7 +60,7 @@ module package manager) like so:
 
     install:
         - rakudobrew build-panda
-        - panda install <Module1> <Module2>
+        - panda installdeps .
 
 this will install the latest `panda` version.
 


### PR DESCRIPTION
Use the "installdeps" trick to install all declared dependencies,
instead of a list of hard-coded dependencies