### PR TITLE
Point to apt plug-in for customizing containers

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -147,7 +147,8 @@ before_install:
 	- sudo apt-get install -qq [packages list]
 ```
 
-> Note that this feature is not available for builds that are running on [Container-based workers](/user/ci-environment/#Virtualization-environments)
+> Note that this feature is not available for builds that are running on [Container-based workers](/user/ci-environment/#Virtualization-environments).
+> Look into [using the `apt` plug-in](/user/apt/) instead.
 
 All virtual machines are snapshotted and returned to their intial state after each build.
 


### PR DESCRIPTION
The notice that using `apt` with `sudo` is not suitable for container-based
environments needs a pointer to what to use instead.

I searched literally for days and finally gave up on using containers.  This needs to be easier to find, especially from the page where you are directed by the dialog box which recommends to use containers instead.