### PR TITLE
Match verb to plural in build-timeouts title

### DIFF
--- a/user/build-timeouts.md
+++ b/user/build-timeouts.md
@@ -1,5 +1,5 @@
 ---
-title: My builds is timing out
+title: My builds are timing out
 layout: en
 permalink: /user/build-timeouts/
 ---


### PR DESCRIPTION
This is a fix of a small grammatical error.