### PR TITLE
Created documentation for Smalltalk

### DIFF
--- a/user/languages/community-supported-languages.md
+++ b/user/languages/community-supported-languages.md
@@ -114,3 +114,4 @@ In alphabetical order, they are:
 1. [Julia](../julia)
 1. [Perl 6](../perl6)
 1. [R](../r)
+1. [Smalltalk](../r)

--- a/user/languages/community-supported-languages.md
+++ b/user/languages/community-supported-languages.md
@@ -114,4 +114,4 @@ In alphabetical order, they are:
 1. [Julia](../julia)
 1. [Perl 6](../perl6)
 1. [R](../r)
-1. [Smalltalk](../r)
+1. [Smalltalk](../smalltalk)

--- a/user/languages/index.md
+++ b/user/languages/index.md
@@ -29,4 +29,5 @@ languages:
 * [Ruby](/user/languages/ruby)
 * [Rust](/user/languages/rust)
 * [Scala](/user/languages/scala)
+* [Smalltalk](/user/languages/smalltalk)
 * [Visual Basic](/user/languages/csharp/)

--- a/user/languages/smalltalk.md
+++ b/user/languages/smalltalk.md
@@ -20,8 +20,8 @@ altered at any time. If you run into any problems, please report them in the
 
 ## Basic configuration
 
-For a minimum configuration you need to specify two parameters, the language which is smalltalk
-and your project specific baseline.
+For a minimum configuration you need to specify two parameters, the language
+and the baseline of your project.
 
 ```yaml
     language: smalltalk
@@ -43,15 +43,6 @@ the `SqueakTrunk`:
       - SqueakTrunk
     env:
       - BASELINE=MyProjectBaseline
-```
-
-Also you can specify on which operating systems your project is build
-by setting the os key.
-
-```yaml
-    os:
-      - linux
-      - osx
 ```
 
 ## Further information

--- a/user/languages/smalltalk.md
+++ b/user/languages/smalltalk.md
@@ -18,7 +18,7 @@ Travis CI support for Smalltalk is contributed by the community and may be remov
 altered at any time. If you run into any problems, please report them in the
 [Travis CI issue tracker](https://github.com/travis-ci/travis-ci/issues/new?labels=community:smalltalk)
 and cc [@bahnfahren](https://github.com/bahnfahren),
-[@christopher](https://github.com/christopher),
+[@chistopher](https://github.com/chistopher),
 [@fniephaus](https://github.com/fniephaus),
 [@jchromik](https://github.com/jchromik), and
 [@Nef10](https://github.com/Nef10) in the issue.

--- a/user/languages/smalltalk.md
+++ b/user/languages/smalltalk.md
@@ -16,7 +16,12 @@ We currently just support [Squeak/Smalltalk](http://squeak.org/).
 
 Travis CI support for Smalltalk is contributed by the community and may be removed or
 altered at any time. If you run into any problems, please report them in the
-[Travis CI issue tracker](https://github.com/travis-ci/travis-ci/issues/new?labels=community:crystal).
+[Travis CI issue tracker](https://github.com/travis-ci/travis-ci/issues/new?labels=community:smalltalk)
+and cc [@bahnfahren](https://github.com/bahnfahren),
+[@christopher](https://github.com/christopher),
+[@fniephaus](https://github.com/fniephaus),
+[@jchromik](https://github.com/jchromik), and
+[@Nef10](https://github.com/Nef10) in the issue.
 
 ## Basic configuration
 

--- a/user/languages/smalltalk.md
+++ b/user/languages/smalltalk.md
@@ -23,9 +23,11 @@ altered at any time. If you run into any problems, please report them in the
 For a minimum configuration you need to specify two parameters, the language which is smalltalk
 and your project specific baseline.
 
+```yaml
     language: smalltalk
     env:
       - BASELINE=MyProjectBaseline
+```
 
 ## Configuration options
 
@@ -34,19 +36,23 @@ to test projects against the SqueakTrunk, Squeak4.6 and Squeak4.5. To do so, set
 `smalltalk` key in `.travis.yml`. For example, to test against both Squeak5.0 and
 the SqueakTrunk:
 
+```yaml
     language: smalltalk
     smalltalk:
       - Squeak5.0
       - SqueakTrunk
     env:
       - BASELINE=MyProjectBaseline
+```
 
 Also you can specify on which operating systems your project is build
 by setting the os key.
 
+```yaml
     os:
       - linux
       - osx
+```
 
 ## Further information
 

--- a/user/languages/smalltalk.md
+++ b/user/languages/smalltalk.md
@@ -1,0 +1,54 @@
+---
+title: Building a Smalltalk Project
+layout: en
+permalink: /user/languages/smalltalk/
+---
+
+### What This Guide Covers
+
+This guide covers build environment and configuration topics specific to Smalltalk
+projects. Please make sure to read our
+[Getting Started](/user/getting-started/) and
+[general build configuration](/user/customizing-the-build/) guides first.
+We currently just support [Squeak/Smalltalk](http://squeak.org/).
+
+### Community-Supported Warning
+
+Travis CI support for Smalltalk is contributed by the community and may be removed or
+altered at any time. If you run into any problems, please report them in the
+[Travis CI issue tracker](https://github.com/travis-ci/travis-ci/issues/new?labels=community:crystal)
+
+## Basic configuration
+
+For a minimum configuration you need to specify two parameters, the language which is smalltalk
+and your project specific baseline.
+
+    language: smalltalk
+    env:
+      - BASELINE=MyProjectBaseline
+
+## Configuration options
+
+By default Travis CI will use Squeak5.0 release. It is also possible
+to test projects against the SqueakTrunk, Squeak4.6 and Squeak4.5. To do so, set the
+`smalltalk` key in `.travis.yml`. For example, to test against both Squeak5.0 and
+the SqueakTrunk:
+
+    language: smalltalk
+    smalltalk:
+      - Squeak5.0
+      - SqueakTrunk
+    env:
+      - BASELINE=MyProjectBaseline
+
+Also you can specify on which operating systems your project is build
+by setting the os key.
+
+    os:
+      - linux
+      - osx
+
+## Further information
+
+We are using [filetreeCI](https://github.com/hpi-swa/filetreeCI) for building Smalltalk projects.
+Additional configuration options can be found at filetreeCI's GitHub repository.

--- a/user/languages/smalltalk.md
+++ b/user/languages/smalltalk.md
@@ -16,7 +16,7 @@ We currently just support [Squeak/Smalltalk](http://squeak.org/).
 
 Travis CI support for Smalltalk is contributed by the community and may be removed or
 altered at any time. If you run into any problems, please report them in the
-[Travis CI issue tracker](https://github.com/travis-ci/travis-ci/issues/new?labels=community:crystal)
+[Travis CI issue tracker](https://github.com/travis-ci/travis-ci/issues/new?labels=community:crystal).
 
 ## Basic configuration
 
@@ -31,10 +31,10 @@ and your project specific baseline.
 
 ## Configuration options
 
-By default Travis CI will use Squeak5.0 release. It is also possible
-to test projects against the SqueakTrunk, Squeak4.6 and Squeak4.5. To do so, set the
-`smalltalk` key in `.travis.yml`. For example, to test against both Squeak5.0 and
-the SqueakTrunk:
+By default Travis CI will use `Squeak5.0` release. It is also possible
+to test projects against the `SqueakTrunk`, `Squeak4.6` and `Squeak4.5`. To do so, set the
+`smalltalk` key in `.travis.yml`. For example, to test against both `Squeak5.0` and
+the `SqueakTrunk`:
 
 ```yaml
     language: smalltalk
@@ -56,5 +56,5 @@ by setting the os key.
 
 ## Further information
 
-We are using [filetreeCI](https://github.com/hpi-swa/filetreeCI) for building Smalltalk projects.
-Additional configuration options can be found at filetreeCI's GitHub repository.
+We are using filetreeCI for building Smalltalk projects.
+Additional configuration options can be found at [filetreeCI's GitHub repository](https://github.com/hpi-swa/filetreeCI).

--- a/user/languages/smalltalk.md
+++ b/user/languages/smalltalk.md
@@ -32,7 +32,7 @@ and your project specific baseline.
 ## Configuration options
 
 By default Travis CI will use `Squeak5.0` release. It is also possible
-to test projects against the `SqueakTrunk`, `Squeak4.6` and `Squeak4.5`. To do so, set the
+to test projects against `SqueakTrunk`, `Squeak4.6` and `Squeak4.5`. To do so, set the
 `smalltalk` key in `.travis.yml`. For example, to test against both `Squeak5.0` and
 the `SqueakTrunk`:
 


### PR DESCRIPTION
We just created the documentation for Smalltalk support in Travis CI since we recognized it is still missing.
See here: [http://docs.travis-ci.com/user/languages/community-supported-languages/#List-of-community-supported-languages](http://docs.travis-ci.com/user/languages/community-supported-languages/#List-of-community-supported-languages)