### PR TITLE
[user/artifacts] Add a note about file names and delimiter

### DIFF
--- a/user/uploading-artifacts.md
+++ b/user/uploading-artifacts.md
@@ -44,6 +44,9 @@ or as an environment variable in repository settings:
     # ':'-delimited paths, e.g.
     ARTIFACTS_PATHS="./logs:./build:/var/log"
 
+Please keep in mind that in the example above, colon (`:`) is used as a
+delimiter which means file names cannot contain this character.
+
 ### Debugging
 
 If you'd like to see more detail about what the artifacts addon is


### PR DESCRIPTION
Right now the example which explains how to upload specific files uses colon (":") as a delimiter meaning it won't work with files which contain colon in the name.

This minor PR adds a note which clarifies this.

On a related note - I didn't test it out, but it seems like Travis assumes colon as a delimiter. Is this true? Or can you use arbitrary character (\0 or \n seems like a better default delimiter)? If you can't, can you escape paths which contain with a delimited (e.g. with double quotes)?