### PR TITLE
Fixes a broken screenshot link on the Caching page

### DIFF
--- a/user/caching.md
+++ b/user/caching.md
@@ -252,10 +252,8 @@ menu
 
 2. With [command line client](https://github.com/travis-ci/travis#readme):
 
-<figure>
   [ ![travis cache --delete](/images/cli-cache.png) ](/images/cli-cache.png)
   <figcaption>Running <tt>travis cache --delete</tt> inside the project directory.</figcaption>
-</figure>
 
 There is also a [corresponding API](https://api.travis-ci.com/#/repos/:owner_name/:name/caches) for clearing the cache.
 


### PR DESCRIPTION
The broken screenshot is on http://docs.travis-ci.com/user/caching/

It looks like this currently:

<img width="630" alt="banners_and_alerts_and_caching_dependencies_and_directories_-_travis_ci" src="https://cloud.githubusercontent.com/assets/7666402/11023024/5609c6a2-8665-11e5-9c20-c1eba5274d0f.png">

It should look like this:

<img width="755" alt="caching_dependencies_and_directories_-_travis_ci" src="https://cloud.githubusercontent.com/assets/7666402/11023027/73f8c140-8665-11e5-84ad-51b46b37b5be.png">