### PR TITLE
document that .ruby-version is a beta feature

### DIFF
--- a/user/languages/ruby.md
+++ b/user/languages/ruby.md
@@ -64,7 +64,7 @@ a workaround, specify `rbx-2` instead.
 
 If the ruby version is not specified by the `rvm` key as described above, Travis CI
 will consult `.ruby-version` in the root of the repository and use the indicated
-Ruby runtime.
+Ruby runtime. This is a beta feature and may be removed in the future.
 
 ### Choosing Rubies that aren't installed
 


### PR DESCRIPTION
It's marked as such in build output. I looked at some [other examples](https://docs.travis-ci.com/#stq=beta&stp=1) of documented beta features, and there doesn't seem to be a consistent pattern. This PR simply adds the sentence from the build output here in the documentation.

This PR is the inverse of https://github.com/travis-ci/travis-build/pull/558.