### PR TITLE
Clarify which Ruby versions are installed

### DIFF
--- a/user/languages/ruby.md
+++ b/user/languages/ruby.md
@@ -18,7 +18,7 @@ configuration](/user/customizing-the-build/) guides first.
 
 The Ruby VM provides recent versions of:
 
-- Ruby: 2.2.x, 2.1.x, 2.0.0, 1.9.3, 1.9.2 and 1.8.7
+- Ruby: 2.2.0, 2.1.x, 2.0.0, 1.9.3, 1.9.2 and 1.8.7
 - JRuby: 1.7.x (1.8 and 1.9 mode)
 - Ruby Enterprise Edition: 1.8.7 2012.02
 


### PR DESCRIPTION
The "Supported Ruby Versions" section claims that "recent" versions of ruby-2.2.x are installed, when in reality only 2.2.0 is and not 2.2.1, 2.2.2, or 2.2.3. I changed that line to clarify that just 2.2.0 is installed.