### PR TITLE
Add notes to optimise PHP runs by disabling XDebug

### DIFF
--- a/user/languages/php.md
+++ b/user/languages/php.md
@@ -191,6 +191,9 @@ For PHP versions up to 5.6, these extensions are available.
 * [redis.so](http://pecl.php.net/package/redis)
 
 Please note that these extensions are not enabled by default with the exception of xdebug.
+
+### Enabling preinstalled PHP extensions
+
 You need to enable them by adding an `extension="<extension>.so"` line to a PHP configuration file (for the current PHP version).
 The easiest way to do this is by using `phpenv` to add a custom config file which enables and eventually configure the extension:
 
@@ -205,6 +208,8 @@ And myconfig.ini:
 You can also use this one line command:
 
     echo "extension = <extension>.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
+### Disabling preinstalled PHP extensions
 
 To disable xdebug, add this to your configuration:
 

--- a/user/speeding-up-the-build.md
+++ b/user/speeding-up-the-build.md
@@ -136,3 +136,33 @@ order to make it faster, you may try caching the dependencies.
 You can either use our [built-in caching](/user/caching/) or roll your own on S3. If you
 want to roll your own and you use Ruby with Bundler, check out [the great WAD project](https://github.com/Fingertips/WAD).
 For other languages, you can use s3 tools directly to upload and download the dependencies.
+
+## Environment-specific ways to speed up your build
+
+In addition to the optimizations implemented by Travis, there are also
+several environment-specific ways you may consider increasing the speed of
+your tests.
+
+### PHP optimisations
+
+PHP VM images on travis-ci.org provide several PHP versions which include
+XDebug. The XDebug extension is useful if you wish to generate code coverage
+reports in your Travis builds, but it has been shown to have a negative effect
+upon performance.
+
+You may wish to consider
+[disabling the PHP XDebug extension](/user/languages/php#Disabling-preinstalled-PHP-extensions) for your
+builds if:
+
+- you are not generating code coverage reports in your Travis tests; or
+- you are testing on PHP 7.0 or above and are able to use the [PHP Debugger (phpdbg)](http://phpdbg.com/)
+which may be faster.
+
+#### Using phpdbg example
+
+    before_script:
+      - phpenv config-rm xdebug.ini
+      - composer install
+
+    script:
+      - phpdbg -qrr phpunit


### PR DESCRIPTION
XDebug is required for code coverage generation, and has a high impact upon
test performance. Composer recommend disabling XDebug when running composer
(https://getcomposer.org/doc/articles/troubleshooting.md#xdebug-impact-on-composer),
and huge benefits can be seen by running phpunit without xdebug enabled.

These changes:
* add information to this effect to the Speeding up the build page; and
* improve organisation of the PHP page to enable direct linking for
  disabling PHP extensions in travis.yml.