### PR TITLE
`-no-skin` is removed from Android docs

### DIFF
--- a/user/languages/android.md
+++ b/user/languages/android.md
@@ -125,7 +125,7 @@ If you feel adventurous, you may use the script [`/usr/local/bin/android-wait-fo
     # Emulator Management: Create, Start and Wait
     before_script:
       - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a
-      - emulator -avd test -no-skin -no-audio -no-window &
+      - emulator -avd test -no-audio -no-window &
       - android-wait-for-emulator
       - adb shell input keyevent 82 &
 


### PR DESCRIPTION
`-no-skin` parameter removes the skin. This means that the emulator will be 320x480 pixel widthxheight and 320 density which messes up with most of the tests.
The default skin is 480x800 which is fine for most of the cases. 

`--skin WXGA720` can be used like below to make tests more trusted. This is the best emulator config that is found by default. 

    - echo no | android create avd --force -n test -t android-19 --abi armeabi-v7a --skin WXGA720