### PR TITLE
Note MPI and $CC & $CXX interaction

### DIFF
--- a/user/languages/c.md
+++ b/user/languages/c.md
@@ -77,3 +77,13 @@ to construct a build matrix.
 
 OpenMP projects should set the environment variable `OMP_NUM_THREADS` to a reasonably small value (say, 4).
 OpenMP detects the cores on the hosting hardware, rather than the VM on which your tests run.
+
+### MPI projects
+
+The default environment variable `$CC` is known to interfere with MPI projects.
+In this case, we recommend unsetting it:
+
+{% highlight yaml %}
+before_install:
+  - test -n $CC && unset CC
+{% endhighlight %}

--- a/user/languages/cpp.md
+++ b/user/languages/cpp.md
@@ -83,3 +83,14 @@ to construct a build matrix.
 
 OpenMP projects should set the environment variable `OMP_NUM_THREADS` to a reasonably small value (say, 4).
 OpenMP detects the cores on the hosting hardware, rather than the VM on which your tests run.
+
+### MPI projects
+
+The default environment variables `$CC` and `$CXX` are known to interfere with MPI projects.
+In this case, we recommend unsetting it:
+
+{% highlight yaml %}
+before_install:
+  - test -n $CC  && unset CC
+  - test -n $CXX && unset CXX
+{% endhighlight %}


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/4682 reports
that MPI builds will have a hard time if
CC and CXX are set.

Changing default behavior is not practical, and sneaking around
the user intentions to deal with this special case is wrought
with edge cases.

So we will document, so that users may find it and shape
their builds to their liking.