### PR TITLE
Adding Private GitHub OAuth scopes

### DIFF
--- a/user/github-oauth-scopes.md
+++ b/user/github-oauth-scopes.md
@@ -85,3 +85,5 @@ On <https://travis-ci.com> we ask for the following permissions:
 
     Grants read and write access to code, commit statuses, collaborators, and
     deployment statuses for public and private repositories and organizations.
+
+    We need this level of access because GitHub does not provide the `read:org` (read-only) scope for private repositories.

--- a/user/github-oauth-scopes.md
+++ b/user/github-oauth-scopes.md
@@ -3,30 +3,25 @@ title: Travis CI's use of GitHub API Scopes
 layout: en
 permalink: /user/github-oauth-scopes/
 ---
-When you sign in on Travis CI, we ask for a few permissions to access your data.
 
-This page provides an overview of which we ask for and why.
+When you sign in to Travis CI for the first time, we ask for permissions to access
+some of your data on GitHub. Read the [GitHub API Scope Documentation](https://developer.github.com/v3/oauth/#scopes)
+ for general information about this, or pick an explanation of what data we need and why we need it.
 
-### Travis CI for Open Source
+<div id="toc"></div>
 
-On <https://travis-ci.org> we currently ask for the following permissions.
+## Travis CI for Open Source Projects
 
-Note that for open source projects, we don't have any write access to your
-source code or your profile.
+On <https://travis-ci.org> we ask for the following permissions:
 
-Make sure to check with [GitHub API's documentation](/user/github-oauth-scopes/)
-for additional details on the scopes we use.
+* `user:email` (read-only)
 
-* `user:email`
+    We synchronize your email addresses so we can email you build
+    notifications.
 
-    We synchronize your email addresses for the purpose of emailing you build
-    notifications. They're currently not being used for any other means.
+    Your email address can be hidden from the GitHub profile, which also hides it from us.
 
-    We ask for this permission, because without it, we may have no means of
-    sending you the build notifications. Your email address can be hidden from
-    the GitHub profile, which in turns hides it from us as well.
-
-* `read:org`
+* `read:org` (read-only)
 
     When you're logged in on Travis CI, we show you all of your repositories,
     including the ones from any organization you're part of.
@@ -35,8 +30,8 @@ for additional details on the scopes we use.
     this scope. So to make sure we show you all of your repositories, we require
     this scope.
 
-    Note that this scope allows access to the basic information on both private
-    and public repositories, but not on any of the data and code stored in them.
+    Note that this scope allows access to the basic information about both private
+    and public repositories, but not on any of the data or code stored in them.
 
 * `repo_deployment`
 
@@ -59,3 +54,34 @@ for additional details on the scopes we use.
     Updating the webhook required for us to be notified from GitHub on new
     commits or pull requests requires this API scope. Additionally, your user
     needs to have admin access to the repository you want to enable.
+
+Note that for open source projects, we don't have any write access to your source
+code or your profile.
+
+## Travis CI for Private Projects
+
+On <https://travis-ci.com> we ask for the following permissions:
+
+* `user:email` (read-only)
+
+    We synchronize your email addresses so we can email you build
+    notifications.
+
+    Your email address can be hidden from the GitHub profile, which also hides it from us.
+
+* `read:org` (read-only)
+
+    When you're logged in on Travis CI, we show you all of your repositories,
+    including the ones from any organization you're part of.
+
+    The GitHub API hides any organizations you're a private member of without
+    this scope. So to make sure we show you all of your repositories, we require
+    this scope.
+
+    Note that this scope allows access to the basic information about both private
+    and public repositories, but not on any of the data or code stored in them.
+
+* `repo`
+
+    Grants read and write access to code, commit statuses, collaborators, and
+    deployment statuses for public and private repositories and organizations.


### PR DESCRIPTION
We should have private repo scopes as well as open source as per travis-pro/team-sapphire/issues/214

@sinthetix could you take a look at this? 