### PR TITLE
fix github handshake redirect parameter

### DIFF
--- a/slate/source/index.md
+++ b/slate/source/index.md
@@ -397,7 +397,7 @@ Some client libraries will automate this handshake for you.
 </script>
 ```
 
-You can also trigger a full OAuth handshake between Travis CI and GitHub by opening `/auth/handshake` in a web browser. The endpoint takes an optional `redirect_to` query parameter, which takes a URL the web browser will end up on if the handshake is successful.
+You can also trigger a full OAuth handshake between Travis CI and GitHub by opening `/auth/handshake` in a web browser. The endpoint takes an optional `redirect_uri` query parameter, which takes a URL the web browser will end up on if the handshake is successful.
 
 There is an alternative version of this that will try to run the handshake in a hidden iframe and using `window.postMessage` to hand the token to the website embedding the iframe. **This endpoint will only work for whitelisted websites.**
 


### PR DESCRIPTION
This parameter was documented as `redirect_to` but is actually `redirect_uri`. Using `redirect_to` results in a dead-end at `https://api.travis-ci.com/redirect?to` so you never get a round trip. Digging deeper, we found a reference to `redirect_uri` in the ruby client: https://github.com/travis-ci/travis-api/blob/master/lib/travis/api/app/endpoint/authorization.rb#L90-L108

It looks like the html is generated with middleman so I didn't include a change to `index.html` in this PR, but if that is needed too, i'll update the commit to encompass both changes.