### PR TITLE
Update README.md for the bintray provider

### DIFF
--- a/user/deployment/bintray.md
+++ b/user/deployment/bintray.md
@@ -117,7 +117,7 @@ after_deploy:
     The files will be uploaded to Bintray under the gems folder.
     2. All files under build/docs. The files will be uploaded to Bintray under the docs folder.
 
-    Note: Regular expressions defined as part of the includePattern and excludePattern properties must be wrapped with brackets. */
+    Note: Regular expressions defined as part of the includePattern property must be wrapped with brackets. */
 
     "files":
         [


### PR DESCRIPTION
Hello, I am with JFrog (home of Bintray). There was a small change that was needed to be made for the documentation of the Bintray provider section:

"Removed small documentation mistake about having to use brackets for the excludePattern param in the bintray descriptor example."

We have verified this to be incorrect. There is no need to use brackets for the 'excludePattern' param.

Note - an equivalent PR was submitted to the travis-ci/dpl repository readme file.

Thank you.