### PR TITLE
Reformat R documentation

### DIFF
--- a/user/languages/r.md
+++ b/user/languages/r.md
@@ -7,26 +7,23 @@ permalink: /user/languages/r/
 ### What This Guide Covers
 
 This guide covers build environment and configuration topics specific to R
-projects. Please make sure to read our
-[Getting Started](/user/getting-started/) and
-[general build configuration](/user/customizing-the-build/) guides first.
+projects. Please make sure to read our [Getting
+Started](/user/getting-started/) and [general build
+configuration](/user/customizing-the-build/) guides first.
 
 ### Community-Supported Warning
 
 Travis CI support for R is contributed by the community and may be removed or
 altered at any time. If you run into any problems, please report them in the
-[Travis CI issue
-tracker](https://github.com/travis-ci/travis-ci/issues/new?labels=community:r)
-and cc [@craigcitro](https://github.com/craigcitro),
-[@hadley](https://github.com/hadley), and
-[@jimhester](https://github.com/jimhester).
+[Travis CI issue tracker][github] and cc [@craigcitro][github 2],
+[@hadley][github 3], and [@jimhester][github 4].
 
 ## Basic configuration
 
 R support in Travis CI is designed to make it easy to test [R
-packages](http://cran.r-project.org/doc/manuals/R-exts.html). If your R package
-doesn't need any system dependencies beyond those specified in your
-`DESCRIPTION` file, your `.travis.yml` can simply be
+packages][r-project]. If your R package doesn't need any system dependencies
+beyond those specified in your `DESCRIPTION` file, your `.travis.yml` can
+simply be
 
 ```yaml
 language: r
@@ -49,10 +46,9 @@ This job is running on container-based infrastructure, which does not allow use 
 You will need to set `sudo: false` in order to use the container based builds
 and package caching.
 
-The R environment comes with [LaTeX](https://www.tug.org/texlive/) and
-[pandoc](http://johnmacfarlane.net/pandoc/) pre-installed, making it easier to
-use packages like [RMarkdown](http://rmarkdown.rstudio.com/) or
-[knitr](http://yihui.name/knitr/).
+The R environment comes with [LaTeX][tug] and [pandoc][johnmacfarlane]
+pre-installed, making it easier to use packages like [RMarkdown][rstudio] or
+[knitr][yihui].
 
 ## Configuration options
 
@@ -83,10 +79,9 @@ in the build log.
 
 By default, Travis CI will find all R packages listed as dependencies in your
 package's `DESCRIPTION` file, and install them from CRAN. You can include
-dependencies on packages in development by listing them in the `Remotes:` field in your
-`DESCRIPTION`. See the [Remotes
-Vignette](https://github.com/hadley/devtools/blob/master/vignettes/dependencies.Rmd#package-remotes)
-for more information on using development remotes in your package.
+dependencies on packages in development by listing them in the `Remotes:` field
+in your `DESCRIPTION`. See the [Remotes Vignette][github 5] for more
+information on using development remotes in your package.
 
 Most of the time you should not need to specify any additional dependencies in
 your `.travis.yml`.
@@ -94,9 +89,8 @@ your `.travis.yml`.
 ### LaTeX/TexLive Packages
 
 The included TexLive distribution contains only a [limited set of default
-packages](https://github.com/yihui/ubuntu-bin/blob/master/TeXLive.pkgs). If
-your vignettes require additional TexLive packages you can install them using
-`tlmgr install` in the `before_install` step.
+packages][github 6]. If your vignettes require additional TexLive packages you
+can install them using `tlmgr install` in the `before_install` step.
 
 ```yaml
 language: r
@@ -106,15 +100,15 @@ before_install:
 ```
 
 The best way to figure out what packages you may need is to look at the
-packages listed in the LaTeX error message and search for them on
-[CTAN](https://www.ctan.org/). Packages often have a `Contained in:` field that
-indicates the package group you need to install.
+packages listed in the LaTeX error message and search for them on [CTAN][ctan].
+Packages often have a `Contained in:` field that indicates the package group
+you need to install.
 
 ### Pandoc ###
 
 The default pandoc version installed is `1.15.2`. Alternative [pandoc
-releases](https://github.com/jgm/pandoc/releases) can be installed by setting
-the `pandoc_version` to the desired version.
+releases][github 7] can be installed by setting the `pandoc_version` to the
+desired version.
 
 ```yaml
 language: r
@@ -147,8 +141,8 @@ bioc_required: true
 ```
 
 If your package is detected as a Bioconductor package, Travis CI will first
-configure Bioconductor, and then use a Bioconductor repo in place of the usual
-CRAN repo when installing dependencies.
+configure Bioconductor, and then use the Bioconductor repositories in place of
+the usual CRAN repository when installing dependencies.
 
 There are two ways to signal to Travis CI that your package is a Bioconductor
 package:
@@ -161,8 +155,8 @@ package:
 
 If you want to test with the Bioconductor devel branch you can set the variable
 `bioc_use_devel: true`. *Note* Bioconductor branches are tied to [specific R
-versions](https://www.bioconductor.org/developers/how-to/useDevel), so you may
-also have to use `r: devel` to use the devel version of R.
+versions][bioconductor], so you may also have to use `r: devel` to use the
+devel version of R.
 
 ### Miscellaneous
 
@@ -203,7 +197,7 @@ processed in order, so entries can depend on dependencies in a previous list.
 
 * `r_binary_packages`: A list of R packages to install as binary packages on
   linux builds, via Michael Rutter's
-  [cran2deb4ubuntu PPA](https://launchpad.net/~marutter/+archive/ubuntu/c2d4u).
+  [cran2deb4ubuntu PPA][launchpad].
   These installs will be faster than source installs, but may not always be
   the most recent version. Specify the name just as you would when installing
   from CRAN. On OS X builds and builds without `sudo: required`, these packages
@@ -211,12 +205,12 @@ processed in order, so entries can depend on dependencies in a previous list.
 
 * `r_packages`: A list of R packages to install via `install.packages`.
 
-* `bioc_packages`: A list of [Bioconductor](http://www.bioconductor.org/)
+* `bioc_packages`: A list of [Bioconductor][bioconductor 2]
   packages to install.
 
 * `r_github_packages`: A list of packages to install directly from GitHub,
   using `devtools::install_github` from the
-  [devtools package](https://github.com/hadley/devtools). The package names
+  [devtools package][github 8]. The package names
   here should be of the form `user/repo`.
 
 ## Examples
@@ -232,20 +226,34 @@ cache: packages
 
 ## Converting from r-travis
 
-If you've already been using
-[r-travis](https://github.com/craigcitro/r-travis) to test your R package,
-you're encouraged to switch to using the native support described here. We've
-written a
-[porting guide](https://github.com/craigcitro/r-travis/wiki/Porting-to-native-R-support-in-Travis)
-to help you modify your `.travis.yml`.
+If you've already been using [r-travis][] to test your R package, you're
+encouraged to switch to using the native support described here. We've written
+a [porting guide][github 9] to help you modify your `.travis.yml`.
 
 ## Acknowledgements
 
-R support for Travis CI was originally based on the
-[r-travis](https://github.com/craigcitro/r-travis) project, and thanks are due
-to all the
-[contributors](https://github.com/craigcitro/r-travis/graphs/contributors).
-For more information on moving from r-travis to native support, see the
-[porting guide](https://github.com/craigcitro/r-travis/wiki/Porting-to-native-R-support-in-Travis).
+R support for Travis CI was originally based on the [r-travis][] project, and
+thanks are due to all the [contributors][github 10]. For more information on
+moving from r-travis to native support, see the [porting guide][github 9].
 
+[bioconductor]: https://www.bioconductor.org/developers/how-to/useDevel
+[bioconductor 2]: http://www.bioconductor.org/
 [container]: /user/workers/container-based-infrastructure/
+[ctan]: https://www.ctan.org/
+[github]: https://github.com/travis-ci/travis-ci/issues/new?labels=community:r
+[github 2]: https://github.com/craigcitro
+[github 3]: https://github.com/hadley
+[github 4]: https://github.com/jimhester
+[github 5]: https://github.com/hadley/devtools/blob/master/vignettes/dependencies.Rmd#package-remotes
+[github 6]: https://github.com/yihui/ubuntu-bin/blob/master/TeXLive.pkgs
+[github 7]: https://github.com/jgm/pandoc/releases
+[github 8]: https://github.com/hadley/devtools
+[github 9]: https://github.com/craigcitro/r-travis/wiki/Porting-to-native-R-support-in-Travis
+[github 10]: https://github.com/craigcitro/r-travis/graphs/contributors
+[johnmacfarlane]: http://johnmacfarlane.net/pandoc/
+[launchpad]: https://launchpad.net/~marutter/+archive/ubuntu/c2d4u
+[r-project]: http://cran.r-project.org/doc/manuals/R-exts.html
+[r-travis]: https://github.com/craigcitro/r-travis
+[rstudio]: http://rmarkdown.rstudio.com/
+[tug]: https://www.tug.org/texlive/
+[yihui]: http://yihui.name/knitr/

--- a/user/languages/r.md
+++ b/user/languages/r.md
@@ -28,14 +28,14 @@ package doesn't need any system dependencies beyond those specified in your
 `DESCRIPTION` file, your `.travis.yml` can simply be
 
 ```yaml
-language: R
+language: r
 ```
 
 Using the package cache to store R package dependencies can significantly speed up build times and
 is recommended for most builds.
 
 ```yaml
-language: R
+language: r
 cache: packages
 ```
 
@@ -95,7 +95,7 @@ your vignettes require additional TexLive packages you can install them using
 `tlmgr install` in the `before_install` step.
 
 ```yaml
-language: R
+language: r
 
 before_install:
   - tlmgr install index
@@ -113,7 +113,7 @@ releases](https://github.com/jgm/pandoc/releases) can be installed by setting
 the `pandoc_version` to the desired version.
 
 ```yaml
-language: R
+language: r
 pandoc_version: 1.16
 ```
 
@@ -138,7 +138,7 @@ when building and checking your package:
 A simple Bioconductor package should generally only need the following `.travis.yml`:
 
 ```yaml
-language: R
+language: r
 bioc_required: true
 ```
 
@@ -222,7 +222,7 @@ of the package cache to speed up subsequent build times. For most projects
 these two lines are sufficient.
 
 ```yaml
-language: R
+language: r
 cache: packages
 ```
 

--- a/user/languages/r.md
+++ b/user/languages/r.md
@@ -60,11 +60,15 @@ Travis CI supports a number of configuration options for your R package.
 
 Travis CI supports R versions `3.1.3`, `3.2.3` and `devel` on Linux Precise builds.
 The names `oldrel` and `3.1` are aliased to `3.1.2` and the names `release` and `3.2` are aliased
-to `3.2.3`. Matrix builds are not currently supported.
+to `3.2.3`. Matrix builds _are_ supported for R builds. However both instances
+of `r` must be in _lowercase_.
 
 ```yaml
-language: R
-r: devel
+language: r
+r:
+  - oldrel
+  - release
+  - devel
 ```
 
 As new minor versions are released, aliases will float and point to the most current minor release.

--- a/user/languages/r.md
+++ b/user/languages/r.md
@@ -15,24 +15,25 @@ projects. Please make sure to read our
 
 Travis CI support for R is contributed by the community and may be removed or
 altered at any time. If you run into any problems, please report them in the
-[Travis CI issue tracker](https://github.com/travis-ci/travis-ci/issues/new?labels=community:r)
+[Travis CI issue
+tracker](https://github.com/travis-ci/travis-ci/issues/new?labels=community:r)
 and cc [@craigcitro](https://github.com/craigcitro),
 [@hadley](https://github.com/hadley), and
 [@jimhester](https://github.com/jimhester).
 
 ## Basic configuration
 
-R support in Travis CI is designed to make it easy to test
-[R packages](http://cran.r-project.org/doc/manuals/R-exts.html). If your R
-package doesn't need any system dependencies beyond those specified in your
+R support in Travis CI is designed to make it easy to test [R
+packages](http://cran.r-project.org/doc/manuals/R-exts.html). If your R package
+doesn't need any system dependencies beyond those specified in your
 `DESCRIPTION` file, your `.travis.yml` can simply be
 
 ```yaml
 language: r
 ```
 
-Using the package cache to store R package dependencies can significantly speed up build times and
-is recommended for most builds.
+Using the package cache to store R package dependencies can significantly speed
+up build times and is recommended for most builds.
 
 ```yaml
 language: r
@@ -45,7 +46,8 @@ This job is running on container-based infrastructure, which does not allow use 
 'sudo', setuid and setguid executables.
 ```
 
-You will need to set `sudo: false` in order to use the container based builds and use package caching.
+You will need to set `sudo: false` in order to use the container based builds
+and package caching.
 
 The R environment comes with [LaTeX](https://www.tug.org/texlive/) and
 [pandoc](http://johnmacfarlane.net/pandoc/) pre-installed, making it easier to
@@ -58,10 +60,10 @@ Travis CI supports a number of configuration options for your R package.
 
 ### R Versions ###
 
-Travis CI supports R versions `3.1.3`, `3.2.3` and `devel` on Linux Precise builds.
-The names `oldrel` and `3.1` are aliased to `3.1.2` and the names `release` and `3.2` are aliased
-to `3.2.3`. Matrix builds _are_ supported for R builds. However both instances
-of `r` must be in _lowercase_.
+Travis CI supports R versions `3.1.3`, `3.2.3` and `devel` on Linux Precise
+builds. The names `oldrel` and `3.1` are aliased to `3.1.2` and the names
+`release` and `3.2` are aliased to `3.2.3`. Matrix builds _are_ supported for R
+builds, however both instances of `r` must be in _lowercase_.
 
 ```yaml
 language: r
@@ -71,9 +73,11 @@ r:
   - devel
 ```
 
-As new minor versions are released, aliases will float and point to the most current minor release.
+As new minor versions are released, aliases will float and point to the most
+current minor release.
 
-For exact versions used for a build, please consult "Build system information" in the build log.
+For exact versions used for a build, please consult "Build system information"
+in the build log.
 
 ### Dependencies
 


### PR DESCRIPTION
- Fixes documentation about matrix builds
- examples use lowercase `r`.
- makes the markdown easier to read