### PR TITLE
Fix example script for excluding tests that rely on secure vars

### DIFF
--- a/user/pull-requests.md
+++ b/user/pull-requests.md
@@ -50,7 +50,7 @@ environment variables are available, or disable them for pull requests entirely.
 Here's an example of how to structure a build command for this purpose:
 
     script:
-      - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && bundle exec rake tests:integration || false'
+      - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && bundle exec rake tests:integration || true'
 
 The environment variable `${TRAVIS_PULL_REQUEST}` is set to `"false"`
 when the build is for a normal branch commit. When the build is for a


### PR DESCRIPTION
The example, as given in our docs, will always fail the build when run on a pull request. I think that's not the intention behind the example script.

```
bash-3.2$ TRAVIS_PULL_REQUEST="true"; [ "${TRAVIS_PULL_REQUEST}" = "false" ] && echo "Secure vars available" || true; echo $?
0
bash-3.2$ TRAVIS_PULL_REQUEST="false"; [ "${TRAVIS_PULL_REQUEST}" = "false" ] && echo "Secure vars available" || true; echo $?
Secure vars available
0
```

In the case when `$TRAVIS_PULL_REQUEST` is `true` (or anything else) one still would want the tests to pass, I guess, so it should default to `true`, not `false`.