### PR TITLE
APT add-on installs also in container-based builds

### DIFF
--- a/user/languages/r.md
+++ b/user/languages/r.md
@@ -115,6 +115,32 @@ language: r
 pandoc_version: 1.16
 ```
 
+### APT packages
+
+Use the [APT addon][apt-addon] (currently in beta)
+to install APT packages on both container-based (`sudo: false`)
+and standard (`sudo: required`) infrastructures.
+The snippet below installs a prerequisite for the R package `xml2`:
+
+```yaml
+addons:
+  apt:
+    packages:
+      - libxml2-dev
+```
+
+Note that the APT package needs to be white-listed for this to work
+on container-based infrastructure.
+This option is ignored on non-Linux builds.
+
+An alternative that works only on standard infrastructure is
+the `apt_packages` field:
+
+```yaml
+apt_packages:
+  - libxml2-dev
+```
+
 ### Package check options
 
 You can use the following top-level options to control what options are used
@@ -181,18 +207,7 @@ top-level entry in your `.travis.yml`; entries in these lists will be
 installed before building and testing your package. Note that these lists are
 processed in order, so entries can depend on dependencies in a previous list.
 
-* `apt_packages`: A list of packages to install via `apt-get`. Common examples
-  here include entries in `SystemRequirements`. This option is ignored on
-  non-linux builds and will not work if `sudo: false`. An option that works also
-  with `sudo: false` is the [APT addon][apt-addon].  The snippet below installs
-  a prerequisite for the R package `xml2`:
-
-```yaml
-addons:
-  apt:
-    packages:
-      - libxml2-dev
-```
+* `apt_packages`: See above
 
 * `brew_packages`: A list of packages to install via `brew`. This option is
   ignored on non-OS X builds.

--- a/user/languages/r.md
+++ b/user/languages/r.md
@@ -117,7 +117,7 @@ pandoc_version: 1.16
 
 ### APT packages
 
-Use the [APT addon][apt-addon] (currently in beta)
+Use the [APT addon][apt-addon]
 to install APT packages on both container-based (`sudo: false`)
 and standard (`sudo: required`) infrastructures.
 The snippet below installs a prerequisite for the R package `xml2`:

--- a/user/languages/r.md
+++ b/user/languages/r.md
@@ -184,7 +184,15 @@ processed in order, so entries can depend on dependencies in a previous list.
 * `apt_packages`: A list of packages to install via `apt-get`. Common examples
   here include entries in `SystemRequirements`. This option is ignored on
   non-linux builds and will not work if `sudo: false`. An option that works also
-  with `sudo: false` is the [APT addon][apt-addon].
+  with `sudo: false` is the [APT addon][apt-addon].  The snippet below installs
+  a prerequisite for the R package `xml2`:
+
+```yaml
+addons:
+  apt:
+    packages:
+      - libxml2-dev
+```
 
 * `brew_packages`: A list of packages to install via `brew`. This option is
   ignored on non-OS X builds.

--- a/user/languages/r.md
+++ b/user/languages/r.md
@@ -183,7 +183,8 @@ processed in order, so entries can depend on dependencies in a previous list.
 
 * `apt_packages`: A list of packages to install via `apt-get`. Common examples
   here include entries in `SystemRequirements`. This option is ignored on
-  non-linux builds and will not work if `sudo: false`.
+  non-linux builds and will not work if `sudo: false`. An option that works also
+  with `sudo: false` is the [APT addon][apt-addon].
 
 * `brew_packages`: A list of packages to install via `brew`. This option is
   ignored on non-OS X builds.
@@ -249,3 +250,4 @@ moving from r-travis to native support, see the [porting guide][github 9].
 [rstudio]: http://rmarkdown.rstudio.com/
 [tug]: https://www.tug.org/texlive/
 [yihui]: http://yihui.name/knitr/
+[apt-addon]: /user/installing-dependencies/#Installing-Packages-with-the-APT-Addon


### PR DESCRIPTION
See e.g. https://travis-ci.org/rstats-db/RMySQL/builds/119360508#L426

Not sure if I got the links right. Perhaps this information should be placed more prominently.

CC @jimhester @hadley @craigcitro