### PR TITLE
Remove extra dash in the command line switch.

### DIFF
--- a/user/encrypting-files.md
+++ b/user/encrypting-files.md
@@ -132,7 +132,7 @@ env:
   global:
     secure: ... encoded secret ...
 before_install:
-  - echo $super_secret_password | gpg --pass-phrase-fd 0 super_secret.txt.gpg
+  - echo $super_secret_password | gpg --passphrase-fd 0 super_secret.txt.gpg
 ```
 
 The encrypted file is called `super_secret.txt.gpg` and has to be committed to the repository.


### PR DESCRIPTION
Fix the following `gpg` invocation error:

```
gpg: Invalid option "--pass-phrase-fd"
```

As per the https://www.gnupg.org/documentation/manpage.html, there is no dash (- present in the command line switch name.