### PR TITLE
Use pushd/popd when compiling source dependency to preserve working dir

### DIFF
--- a/user/installing-dependencies.md
+++ b/user/installing-dependencies.md
@@ -173,7 +173,7 @@ To install something from source, you can follow similar steps. Here's an exampl
     install:
       - wget https://protobuf.googlecode.com/files/protobuf-2.4.1.tar.gz
       - tar -xzvf protobuf-2.4.1.tar.gz
-      - cd protobuf-2.4.1 && ./configure --prefix=/usr && make && sudo make install
+      - pushd protobuf-2.4.1 && ./configure --prefix=/usr && make && sudo make install && popd
 
 These three commands can be extracted into a shell script, let's name it `install-protobuf.sh`:
 
@@ -187,3 +187,5 @@ Once it's added to the repository, you can run it from your .travis.yml:
 
     before_install:
       - ./install-protobuf.sh
+
+Note that the first version uses `pushd` and `popd` to ensure that after the `install` section completes, the working directory is returned to its original value.  This is not necessary in the shell script, as it runs in a sub-shell and so does not alter the original working directory.


### PR DESCRIPTION
The example given in the docs causes a build failure because the working directory has been changed after installing a source dependency.  Using `pushd` and `popd` to restore the original working dir fixes the problem.