### PR TITLE
Remove whitespace around list items

### DIFF
--- a/user/osx-ci-environment.md
+++ b/user/osx-ci-environment.md
@@ -192,12 +192,10 @@ Xcode {{ image.xcode_full_version }} is available by adding `osx_image: {{ image
 Our Xcode {{ image.xcode_full_version }} images have the following SDKs preinstalled:
 
 {% for sdk in image.sdks %}
-- {{ sdk }}
-{% endfor %}
+- {{ sdk }}{% endfor %}
 
 The Xcode {{ image.xcode_full_version }} image also comes with the following simulators:
 {% for simulator in image.simulators %}
-- {{ simulator }}
-{% endfor %}
+- {{ simulator }}{% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
As [reported by @solarce](https://travisci.slack.com/archives/teal/p1462462487001036
), Firefox was showing the text of each line item beneath its bullet. For example:

![image](https://cloud.githubusercontent.com/assets/43280/15049877/9085771c-12e8-11e6-9b42-4c4d8afc66b7.png)


This unsightly template formation seems required to prevent the generated whitespace being interpreted as paragraphs in Markdown. See this discussion:
https://github.com/Shopify/liquid/issues/216

Haml has `<` and `>` to handle this kind of thing, hopefully eventually Liquid will get something like it.