### PR TITLE
Job entities don't contain duration

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -1344,10 +1344,6 @@ Overall size of above caches: 371.08 MiB
 <td>time the job finished</td>
 </tr>
 <tr>
-<td>duration</td>
-<td>job duration</td>
-</tr>
-<tr>
 <td>queue</td>
 <td>job queue</td>
 </tr>


### PR DESCRIPTION
References:
- https://github.com/travis-ci/travis-api/blob/master/lib/travis/api/v2/http/build.rb#L65-L78
- https://github.com/travis-ci/travis-api/blob/master/lib/travis/api/v2/http/job.rb#L27-L41
- https://github.com/travis-ci/travis-api/blob/master/lib/travis/api/v2/http/jobs.rb#L26-L39