### PR TITLE
added section to osx build environment only on jdk_switcher

### DIFF
--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -119,7 +119,7 @@ jdk:
   - openjdk6
 ```
 
-> Note that testing against multiple Java versions is not supported on OSX.
+> Note that testing against multiple Java versions is not supported on OSX. See the [OS X Build Environment](/user/osx-ci-environment/#JDK-and-OS-X) for more details. 
 
 Travis CI provides OpenJDK 6, OpenJDK 7, Oracle JDK 7, and Oracle JDK 8. Sun JDK 6 is not provided, because it is EOL as of November 2012.
 

--- a/user/osx-ci-environment.md
+++ b/user/osx-ci-environment.md
@@ -47,7 +47,6 @@ NDA imposed on them. We do test them internally, and our goal is to make new
 versions available the same day they come out. If you have any further questions
 about Xcode pre-release availability, send us an email at support@travis-ci.com.
 
-
 ## Homebrew
 
 Homebrew is installed and updated every time the VMs are updated. It is
@@ -86,6 +85,9 @@ For example, if you always want the latest version of xctool, you can run this:
       - brew update
       - brew outdated xctool || brew upgrade xctool
 
+## JDK and OS X
+
+The JDK available in the OS X environment is tied to the OS X version. As such, `jdk_switcher` is not currently available on OS X. Instead, you can try using a different [OS X Version](#OS-X-Version) which has a different JDK. 
 
 ## Compilers and Build toolchain
 

--- a/user/osx-ci-environment.md
+++ b/user/osx-ci-environment.md
@@ -87,7 +87,7 @@ For example, if you always want the latest version of xctool, you can run this:
 
 ## JDK and OS X
 
-The JDK available in the OS X environment is tied to the OS X version. As such, `jdk_switcher` is not currently available on OS X. Instead, you can try using a different [OS X Version](#OS-X-Version) which has a different JDK. 
+The JDK available in the OS X environment is tied to the Xcode version selected for your build, it is not set independently. To use a particular JDK for your build, be sure to select an [OS X image](#OS-X-Version) which includes the version of Java that you need. 
 
 ## Compilers and Build toolchain
 


### PR DESCRIPTION
Created a short section on the osx environment page regarding jdk_switcher not being available, to serve in addition to the note on the java languages page