### PR TITLE
Clarify local git deployment method in Azure Web Apps deployment documentation

### DIFF
--- a/user/deployment/azure-web-apps.md
+++ b/user/deployment/azure-web-apps.md
@@ -6,7 +6,7 @@ permalink: /user/deployment/azure-web-apps/
 
 Travis CI can automatically deploy your [Azure Web App](https://azure.microsoft.com/en-us/services/app-service/web/) after a successful build.
 
-For a minimal configuration, all you need to do is add the following to your `.travis.yml`:
+For a minimal configuration, all you need to do is enable [Local Git Deployment](https://azure.microsoft.com/en-us/documentation/articles/app-service-deploy-local-git/) and add the following to your `.travis.yml`:
 
     deploy:
       provider: azure_web_apps


### PR DESCRIPTION
It's important to note that you must have local git deployment enabled for this provider to work. This is not enabled by default, so you must enable it using the instructions provided in the link or the deployment will fail. 