### PR TITLE
First version of the SQ add-on doc

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -87,6 +87,7 @@
         <li><a href="/user/status-images/">Showing Build Status Images</a></li>
         <li><a href="/user/code-climate/">Code Climate</a></li>
         <li><a href="/user/sauce-connect/">Sauce Labs</a></li>
+        <li><a href="/user/sonarqube/">SonarQube.com</a></li>
         <li><a href="/user/build-feeds/">Atom Feeds</a></li>
         <li><a href="/user/cc-menu">CCMenu / CCTray Feeds</a></li>
         <li><a href="/user/integration/platformio/">Embedded Builds with PlatformIO</a></li>

--- a/user/sonarqube.md
+++ b/user/sonarqube.md
@@ -13,7 +13,7 @@ Triggering the analysis is done thanks to a **SonarQube Scanner** - just like ev
 
 ### Using the SonarQube Scanner
 
-Most projects will use the SonarQube Scanner, and here is the simplest `.travis.yml` file to trigger the analysis in this case:
+Most projects will use the SonarQube Scanner. Provided that you have previously created a `sonar-project.properties` file for your project (see the [documentation](http://redirect.sonarsource.com/doc/install-configure-scanner.html)), here is the simplest `.travis.yml` file to trigger the analysis:
 
     addons:
       sonarqube: true
@@ -29,7 +29,7 @@ The `SONAR_TOKEN` parameter is a user token that you will have created for your 
 
 ### Using the SonarQube Scanner for Maven
 
-Lost of Java projects build with Maven. In that case, a simple `.travis.yml` file would look like:
+Lost of Java projects build with Maven. In that case, a simple `.travis.yml` file like the following one would do the job:
 
     addons:
       sonarqube: true

--- a/user/sonarqube.md
+++ b/user/sonarqube.md
@@ -3,43 +3,45 @@ title: Using SonarQube.com with Travis CI
 layout: en
 permalink: /user/sonarqube/
 ---
-**[SonarQube.com](https://sonarqube.com)** is the cloud service based on [SonarQube](http://www.sonarqube.org), the widely adopted "continuous inspection" open source platform that allows developers to find bugs, vulnerabilities and code smells in more than 20 different languages. It offers all the dashboards and tools to continuously track modifications of your code to make sure your code will only get better and better over time.
+[SonarQube.com](https://sonarqube.com) is the cloud service based on [SonarQube](http://www.sonarqube.org), the widely adopted "continuous inspection" open source platform that allows developers to detect bugs, vulnerabilities and code smells in more than 20 different languages.
 
-SonarQube.com is free for open-source projects. The only requirement is to have a GitHub account to connect to the service. It is then up to you to trigger the analysis, and this is where this Travis CI add-on simplifies your user experience.
+Please refer to the [SonarQube documentation](http://redirect.sonarsource.com/doc/analyzing-source-code.html) for more details on how to configure different scanners.
 
-## Trigger an analysis
+## Inspecting code with the SonarQube Scanner
 
-Triggering the analysis is done thanks to a **SonarQube Scanner** - just like everyone would do for any SonarQube analysis. Depending on the build technology that you are using, you will use one SonarQube Scanner or another. Please refer to the [online documentation for SonarQube Scanners](http://redirect.sonarsource.com/doc/analyzing-source-code.html) in order to have more details.  
+Before inspecting your code, you need to:
 
-### Using the SonarQube Scanner
+1. Create a user token for your account on SonarQube.com.
+1. [Encrypt this token](/user/encryption-keys/#Usage) in a `SONAR_TOKEN` variable.
+1. Create a `sonar-project.properties` file for your project (see the [documentation](http://redirect.sonarsource.com/doc/install-configure-scanner.html)).
 
-Most projects will use the SonarQube Scanner. Provided that you have previously created a `sonar-project.properties` file for your project (see the [documentation](http://redirect.sonarsource.com/doc/install-configure-scanner.html)), here is the simplest `.travis.yml` file to trigger the analysis:
+Then add the following lines to your `.travis.yml` file to trigger the analysis:
 
-    addons:
-      sonarqube: true
-    env:
-      global:
-        - secure: ********* # defines SONAR_TOKEN=abcdef0123456789
+```yaml
+addons:
+  sonarqube: true
+env:
+  global:
+    - secure: ********* # defines SONAR_TOKEN=abcdef0123456789
+script:
+  # other script steps might be done before running the actual SonarQube analysis
+  - sonar-scanner -Dsonar.login=$SONAR_TOKEN
+```
 
-    script:
-      # other script steps might be done before running the actual SonarQube analysis
-      - sonar-scanner -Dsonar.login=$SONAR_TOKEN
+### SonarQube Scanner for Maven
 
-The `SONAR_TOKEN` parameter is a user token that you will have created for your account on your SonarQube.com. Note that you might as well have defined it an environment variable in the Travis settings of your project instead of putting it right into the `.travis.yml` file.
+Lots of Java projects build with Maven. To add a SonarQube inspection to your Maven build, add the following to your `.travis.yml` file:
 
-### Using the SonarQube Scanner for Maven
-
-Lost of Java projects build with Maven. In that case, a simple `.travis.yml` file like the following one would do the job:
-
-    addons:
-      sonarqube: true
-    env:
-      global:
-        - secure: ********* # defines SONAR_TOKEN=abcdef0123456789
-
-    script:
-      # the following command line builds the project, runs the tests with coverage and then execute the SonarQube analysis
-      - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.login=$SONAR_TOKEN
+```yaml
+addons:
+  sonarqube: true
+env:
+  global:
+    - secure: ********* # defines SONAR_TOKEN=abcdef0123456789
+script:
+  # the following command line builds the project, runs the tests with coverage and then execute the SonarQube analysis
+  - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.login=$SONAR_TOKEN
+```
 
 ## Upcoming improvements
 

--- a/user/sonarqube.md
+++ b/user/sonarqube.md
@@ -7,28 +7,39 @@ permalink: /user/sonarqube/
 
 SonarQube.com is free for open-source projects. The only requirement is to have a GitHub account to connect to the service. It is then up to you to trigger the analysis, and this is where this Travis CI add-on simplifies your user experience.
 
-## Activate the add-on
+## Trigger an analysis
 
-Simply add the following lines to your `.travis.yml` file:
+Triggering the analysis is done thanks to a **SonarQube Scanner** - just like everyone would do for any SonarQube analysis. Depending on the build technology that you are using, you will use one SonarQube Scanner or another. Please refer to the [online documentation for SonarQube Scanners](http://redirect.sonarsource.com/doc/analyzing-source-code.html) in order to have more details.  
+
+### Using the SonarQube Scanner
+
+Most projects will use the SonarQube Scanner, and here is the simplest `.travis.yml` file to trigger the analysis in this case:
 
     addons:
       sonarqube: true
-
-This will set up everything required to simply trigger the SonarQube analysis later on.
-
-## Trigger the analysis
-
-Triggering the analysis is done thanks to a **SonarQube Scanner** - just like everyone would do for any SonarQube analysis. Depending on the build technology that you are using, you will use [one SonarQube Scanner or another](http://redirect.sonarsource.com/doc/analyzing-source-code.html).  
-
-For example, using the standard [SonarQube Scanner](http://redirect.sonarsource.com/doc/install-configure-scanner.html), you can simply trigger the analysis this way:
+    env:
+      global:
+        - secure: ********* # defines SONAR_TOKEN=abcdef0123456789
 
     script:
+      # other script steps might be done before running the actual SonarQube analysis
       - sonar-scanner -Dsonar.login=$SONAR_TOKEN
 
-The `sonar-scanner` executable is installed and configured by the SonarQube add-on, nothing to do!
+The `SONAR_TOKEN` parameter is a user token that you will have created for your account on your SonarQube.com. Note that you might as well have defined it an environment variable in the Travis settings of your project instead of putting it right into the `.travis.yml` file.
 
-The `sonar.login` parameter is a user token that you will have created for your account on your SonarQube.com. In this example, you pass it as a `$SONAR_TOKEN` environment variable that you might have set in the Travis settings of your project or specified in the `.travis.yml` file using `travis encrypt` to secure it.
+### Using the SonarQube Scanner for Maven
 
+Lost of Java projects build with Maven. In that case, a simple `.travis.yml` file would look like:
+
+    addons:
+      sonarqube: true
+    env:
+      global:
+        - secure: ********* # defines SONAR_TOKEN=abcdef0123456789
+
+    script:
+      # the following command line builds the project, runs the tests with coverage and then execute the SonarQube analysis
+      - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar -Dsonar.login=$SONAR_TOKEN
 
 ## Upcoming improvements
 

--- a/user/sonarqube.md
+++ b/user/sonarqube.md
@@ -3,7 +3,7 @@ title: Using SonarQube.com with Travis CI
 layout: en
 permalink: /user/sonarqube/
 ---
-[SonarQube.com](https://sonarqube.com) is the cloud service based on [SonarQube](http://www.sonarqube.org), the widely adopted "continuous inspection" open source platform that allows developers to detect bugs, vulnerabilities and code smells in more than 20 different languages.
+[SonarQube.com](https://sonarqube.com) is a cloud service offered by [SonarSource](https://sonarsource.com) and based on [SonarQube](http://www.sonarqube.org). SonarQube is a widely open source platform to inspect continuously the quality of source code and detect bugs, vulnerabilities and code smells in more than 20 different languages.
 
 Please refer to the [SonarQube documentation](http://redirect.sonarsource.com/doc/analyzing-source-code.html) for more details on how to configure different scanners.
 

--- a/user/sonarqube.md
+++ b/user/sonarqube.md
@@ -3,7 +3,7 @@ title: Using SonarQube.com with Travis CI
 layout: en
 permalink: /user/sonarqube/
 ---
-[SonarQube.com](https://sonarqube.com) is a cloud service offered by [SonarSource](https://sonarsource.com) and based on [SonarQube](http://www.sonarqube.org). SonarQube is a widely open source platform to inspect continuously the quality of source code and detect bugs, vulnerabilities and code smells in more than 20 different languages.
+[SonarQube.com](https://sonarqube.com) is a cloud service offered by [SonarSource](https://sonarsource.com) and based on [SonarQube](http://www.sonarqube.org). SonarQube is a widely adopted open source platform to inspect continuously the quality of source code and detect bugs, vulnerabilities and code smells in more than 20 different languages.
 
 Please refer to the [SonarQube documentation](http://redirect.sonarsource.com/doc/analyzing-source-code.html) for more details on how to configure different scanners.
 

--- a/user/sonarqube.md
+++ b/user/sonarqube.md
@@ -1,0 +1,39 @@
+---
+title: Using SonarQube.com with Travis CI
+layout: en
+permalink: /user/sonarqube/
+---
+**[SonarQube.com](https://sonarqube.com)** is the cloud service based on [SonarQube](http://www.sonarqube.org), the widely adopted "continuous inspection" open source platform that allows developers to find bugs, vulnerabilities and code smells in more than 20 different languages. It offers all the dashboards and tools to continuously track modifications of your code to make sure your code will only get better and better over time.
+
+SonarQube.com is free for open-source projects. The only requirement is to have a GitHub account to connect to the service. It is then up to you to trigger the analysis, and this is where this Travis CI add-on simplifies your user experience.
+
+## Activate the add-on
+
+Simply add the following lines to your `.travis.yml` file:
+
+    addons:
+      sonarqube: true
+
+This will set up everything required to simply trigger the SonarQube analysis later on.
+
+## Trigger the analysis
+
+Triggering the analysis is done thanks to a **SonarQube Scanner** - just like everyone would do for any SonarQube analysis. Depending on the build technology that you are using, you will use [one SonarQube Scanner or another](http://redirect.sonarsource.com/doc/analyzing-source-code.html).  
+
+For example, using the standard [SonarQube Scanner](http://redirect.sonarsource.com/doc/install-configure-scanner.html), you can simply trigger the analysis this way:
+
+    script:
+      - sonar-scanner -Dsonar.login=$SONAR_TOKEN
+
+The `sonar-scanner` executable is installed and configured by the SonarQube add-on, nothing to do!
+
+The `sonar.login` parameter is a user token that you will have created for your account on your SonarQube.com. In this example, you pass it as a `$SONAR_TOKEN` environment variable that you might have set in the Travis settings of your project or specified in the `.travis.yml` file using `travis encrypt` to secure it.
+
+
+## Upcoming improvements
+
+Next versions of this add-on will provide the following features:
+
+ * Remove the need to pass the `sonar.login` parameter in the command-line
+ * Proper and transparent management of branches (currently, you will have to use the `sonar.branch` parameter to properly analyze different branches of your repository)
+ * Less configuration and scripting required to analyze pull requests


### PR DESCRIPTION
@BanzaiMan Here's a first version of the documentation page for the SonarQube add-on. Feel free to give feedback on it.

@dbmeneses and @henryju: as this is markdown, you can just go on the sonarqube.md file and click on "View" to have something readable and give feedback. Thanks.