### PR TITLE
include node_modules in the caching page

### DIFF
--- a/user/caching.md
+++ b/user/caching.md
@@ -235,6 +235,7 @@ This does not work when caching [arbitrary directories](#Arbitrary-directories).
 cache:
   bundler: true
   directories:
+  - node_modules # NPM packages
   - vendor/something
   - .autoconf
 ```


### PR DESCRIPTION
This is a minor change, but I always end up Googling how to cache NPM packages in Travis, but this page doesn't come up. Basically including it here for better SEO :wink: since I figure it's a fairly common thing to want to cache.