### PR TITLE
remove on_start from slack notifications

### DIFF
--- a/user/notifications.md
+++ b/user/notifications.md
@@ -494,7 +494,6 @@ You can specify multiple channels as well.
           - <account>:<token>#general
         on_success: [always|never|change] # default: always
         on_failure: [always|never|change] # default: always
-        on_start: [always|never|change]   # default: never
 
 As always, it's recommended to encrypt the credentials with our
 [travis](https://github.com/travis-ci/travis#readme) command line client.


### PR DESCRIPTION
This information was incorrectly copied from the `webhooks` section.
Our Slack notification addon is not intended to support `on_start` notifications.