### PR TITLE
Make format between code snippets consistent

### DIFF
--- a/user/encryption-keys.md
+++ b/user/encryption-keys.md
@@ -65,7 +65,8 @@ We want to add campfire notifications to our .travis.yml file, but we don't want
 The entry should be in this format:
 
     notifications:
-      campfire: [subdomain]:[api token]@[room id]
+      campfire: 
+        rooms: [subdomain]:[api token]@[room id]
 
 For us, that is somedomain:abcxyz@14.
 


### PR DESCRIPTION
There is an issue on this page because all of the code snippets but this one involve "rooms" the child of "campfire". This pull requests fixes that discrepancy and makes all code snippets have "rooms" as a child of "campfire".