### PR TITLE
Add Nix page to programming language documentation

### DIFF
--- a/user/languages/community-supported-languages.md
+++ b/user/languages/community-supported-languages.md
@@ -117,6 +117,7 @@ In alphabetical order, they are:
 1. [Dart](../dart)
 1. [Haxe](../haxe)
 1. [Julia](../julia)
+1. [Nix](../nix)
 1. [Perl 6](../perl6)
 1. [R](../r)
 1. [Smalltalk](../smalltalk)

--- a/user/languages/nix.md
+++ b/user/languages/nix.md
@@ -19,13 +19,13 @@ and cc @domenkozar @garbas and @matthewbauer .
 
 ## Overview
 
-To set up Travis to provide the Nix environment, add the following line to `.travis.yml`:
+To install the Nix store and set up a basic single-user profile, set the `language` key in `.travis.yml` to `nix`.
 
 ```yaml
 language: nix
 ```
 
-This will install the Nix store and set up a basic single-user profile. The default channel for "nixpkgs" will be "nixpkgs-unstable". More information on configuring channels is provided in the manual below.
+The default channel for `nixpkgs` will be `nixpkgs-unstable`.
 
 ## Provided Tools
 
@@ -37,11 +37,13 @@ The following command line tools are available in the Nix environment:
 * nix-store
 * nix-channel
 
-More information on writing Nix expression and how each of the above tools works is available in the [Nix manual](https://NixOS.org/nix/manual/).
+## Default Nix Version
+
+Currently, only version "1.11.2" of Nix is provided. In the future, it may be possible to configure different versions with `.travis.yml`.
 
 ## Default Target
 
-In addition, the default script will attempt to build all derivations in "default.nix" in the root of the repository using the "nix-build" tool. This can be overridden by adding a "script" key to the .yaml file:
+The default build script is `nix-build` which builds everything in the `default.nix` file of the repository root. This can be overridden by setting the `script` key in the `.travis.yml` file. For example,
 
 ```yaml
 language: nix
@@ -50,6 +52,10 @@ script: nix-build -A tarball release.nix
 
 The above configuration will attempt to build the attribute "tarball" from the Nix expression in release.nix.
 
-## Default Nix Version
+## Nix manual
 
-Currently, only version "1.11.2" of Nix is provided. In the future, it may be possible to configure different versions with .travis.yml.
+More information on writing Nix expressions and how each of the above tools works is available in the [Nix manual](https://nixos.org/nix/manual/).
+
+## Examples
+
+* [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/.travis.yml)

--- a/user/languages/nix.md
+++ b/user/languages/nix.md
@@ -1,0 +1,55 @@
+---
+title: Building a Nix Project
+layout: en
+permalink: /user/languages/nix/
+---
+
+### What This Guide Covers
+
+This guide covers build environment and configuration topics specific to Nix projects. Please make sure to read our [Getting Started](/user/getting-started/) and [general build configuration](/user/customizing-the-build/) guides first.
+
+<div id="toc"></div>
+
+### Community-Supported Warning
+
+Travis CI support for Nix is contributed by the community and may be removed
+or altered at any time. If you run into any problems, please report them in the
+[Travis CI issue tracker](https://github.com/travis-ci/travis-ci/issues/new?labels=community:nix)
+and cc @domenkozar @garbas and @matthewbauer .
+
+## Overview
+
+To set up Travis to provide the Nix environment, add the following line to `.travis.yml`:
+
+```yaml
+language: nix
+```
+
+This will install the Nix store and set up a basic single-user profile. The default channel for "nixpkgs" will be "nixpkgs-unstable". More information on configuring channels is provided in the manual below.
+
+## Provided Tools
+
+The following command line tools are available in the Nix environment:
+
+* nix-env
+* nix-build
+* nix-shell
+* nix-store
+* nix-channel
+
+More information on writing Nix expression and how each of the above tools works is available in the [Nix manual](https://NixOS.org/nix/manual/).
+
+## Default Target
+
+In addition, the default script will attempt to build all derivations in "default.nix" in the root of the repository using the "nix-build" tool. This can be overridden by adding a "script" key to the .yaml file:
+
+```yaml
+language: nix
+script: nix-build -A tarball release.nix
+```
+
+The above configuration will attempt to build the attribute "tarball" from the Nix expression in release.nix.
+
+## Default Nix Version
+
+Currently, only version "1.11.2" of Nix is provided. In the future, it may be possible to configure different versions with .travis.yml.


### PR DESCRIPTION
This adds a basic Nix page detailing how to setup and use the Nix
language with Travis projects. This is a companion PR to travis-ci/travis-build#745.