### PR TITLE
Fixing errors in network description

### DIFF
--- a/user/ci-environment.md
+++ b/user/ci-environment.md
@@ -110,8 +110,8 @@ All [Education Pack](https://education.travis-ci.com/) builds use Container-base
 
 ## Networking
 
-The virtual machines in the Legacy environment running the tests have IPv6 enabled. They do not have any external IPv4 address but are fully able to communicate with any external IPv4 service.
-The container-based, OSX, and GCE (both Precise and Trusty) builds do not currently have IPv6 connectivity.
+The virtual machines in the Legacy environment running the tests do not have IPv6 enabled. They do not have any external IPv4 address but are fully able to communicate with any external IPv4 service.
+The container-based, OSX, and GCE (both Precise and Trusty) builds have IPv6 connectivity.
 
 The IPv6 stack can have some impact on Java services in particular, where one might need to set the flag `java.net.preferIPv4Stack` to force the JVM to resort to the IPv4 stack should services show issues of not booting up or not being reachable via the network: `-Djava.net.preferIPv4Stack=true`.
 


### PR DESCRIPTION
Current docs are incorrect with regard to IPv6 networking.
- When running in legacy VM (e.g. using "sudo: required"), the following
  command output indicates that IPv6 is not available:
  
    $ cat /proc/net/if_inet6
- When running in the container-based environment (both Precise and Trusty),
  the following command output indicates that IPv6 is available:
  
    $ cat /proc/net/if_inet6
    00000000000000000000000000000001 01 80 10 80       lo
    fe800000000000009c859ffffe42cbae 1309 40 20 80     eth0
