### PR TITLE
Fix link to Dart install page

### DIFF
--- a/user/languages/dart.md
+++ b/user/languages/dart.md
@@ -21,7 +21,7 @@ and cc @a14n @devoncarew and @sethladd.
 ## Choosing Dart versions to test against
 
 Dart workers on travis-ci.org download and install the Dart SDK binaries.
-(See [Dart Download Archive](https://www.dartlang.org/install/archive/)).
+(See [Dart Download Archive](https://www.dartlang.org/install)).
 
 To select one or more versions, use the `dart:` key in your `.travis.yml` file.
 For example:


### PR DESCRIPTION
To address documentation test failures [like this one](https://travis-ci.org/travis-ci/docs-travis-ci-com/builds/145087411#L207).