### PR TITLE
Added missing _ to before_install

### DIFF
--- a/user/multi-os.md
+++ b/user/multi-os.md
@@ -86,7 +86,7 @@ addons:
     packages:
       - graphviz
 
-before install:
+before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install graphviz; fi
 


### PR DESCRIPTION
The `before_install` step was missing an underscore.