### PR TITLE
Fixed incorrect use of TRAVIS_PULL_REQUEST.

### DIFF
--- a/user/pull-requests.md
+++ b/user/pull-requests.md
@@ -52,7 +52,7 @@ Here's an example of how to structure a build command for this purpose:
 
 ```yaml
 script:
-   - 'if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then bash ./travis/run_on_pull_requests; fi'
+   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash ./travis/run_on_pull_requests; fi'
    - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./travis/run_on_non_pull_requests; fi'
 ```
 


### PR DESCRIPTION
Due to the documentation of environment variables `TRAVIS_PULL_REQUEST` returns either a number of the pull request or `false` if it's not a pull request. Therefore the check `= "true"` won't work as expected.