### PR TITLE
Add note about %2F requirement in request URL

### DIFF
--- a/user/triggering-builds.md
+++ b/user/triggering-builds.md
@@ -34,6 +34,8 @@ curl -s -X POST \
   https://api.travis-ci.org/repo/travis-ci%2Ftravis-core/requests
 ```
 
+> The %2F in the request URL is required so that the owner and repository name in the repository slug are interpreted as a single URL segment.
+
 This request triggers a build of the most recent commit on the master branch of the `travis-ci/travis-core` repository, using the `.travis.yml` file in the master branch.
 
 You can also add to or override configuration in the `.travis.yml` file, or change the commit message.


### PR DESCRIPTION
Since %2F is the escaped form of a slash, people are assuming
it can just be converted to a slash. That results in failures,
though, because the slug needs to be treated as a single URL
segment.