### PR TITLE
Add link to Django Webhook Signature Verifier

### DIFF
--- a/user/notifications.md
+++ b/user/notifications.md
@@ -571,6 +571,9 @@ payload.
 [WebhookSignatureVerifier](https://github.com/travis-ci/webhook-signature-verifier)
 is a small Sinatra app which shows you how this works.
 
+[Travis Webhook Checker](https://gist.github.com/andrewgross/8ba32af80ecccb894b82774782e7dcd4)
+is an example Django view which implements this in Python.
+
 ### Authorization for Webhooks (Deprecated)
 
 **Note: The `Authorization` header value described here is deprecated


### PR DESCRIPTION
Adds a link that shows a sample Python implementation inside a Django view, similar to the Sinatra app.  Feel free to take the code and stick it in a repo like the Sinatra app as well.