### PR TITLE
Updating Xcode8 to GM Seed 8A218a

### DIFF
--- a/_data/xcodes.yml
+++ b/_data/xcodes.yml
@@ -2,7 +2,7 @@ osx_images:
   - image: xcode8
     xcode: "8"
     osx_version: "10.11"
-    xcode_full_version: "8beta6"
+    xcode_full_version: "8gm"
     sdks:
       - macosx10.11
       - iphoneos10.0


### PR DESCRIPTION
Includes:
- Xcode8 GM `8A218a`
- `brew update && brew upgrade` was run
- Updated CocoaPods to [`1.1.0.beta.2`](https://github.com/CocoaPods/CocoaPods/releases/tag/1.1.0.beta.2)
  - Ran `pod setup` in all the pre-installed Rubies.