### PR TITLE
Rename "standard" environment to "sudo-enabled"

### DIFF
--- a/user/ci-environment.md
+++ b/user/ci-environment.md
@@ -41,7 +41,7 @@ The following table summarizes the differences between the virtual environments:
 <table><thead>
 <tr>
 <th></th>
-<th>Standard</th>
+<th>Sudo-enabled</th>
 <th>Container-based</th>
 <th>OS X</th>
 <th>Trusty beta</th>


### PR DESCRIPTION
The naming of "standard" is very misleading, especially because it is not the _default_ environment.
