### PR TITLE
Clarify syntax around encrypting Slack notifications with channel specified

### DIFF
--- a/user/notifications.md
+++ b/user/notifications.md
@@ -452,6 +452,10 @@ As always, it's recommended to encrypt the credentials with our
 
     travis encrypt "<account>:<token>" --add notifications.slack.rooms
 
+Similarly, you can use the channel override syntax with encrypted credentials as well. 
+
+    travis encrypt "<account>:<token>#channel" --add notifications.slack.rooms
+
 Once everything's setup, push a new commit and you should see something like the
 screenshot below:
 


### PR DESCRIPTION
One of our Enterprise customers recently gave the feedback that the documentation for encrypting Slack notifications when a channel was specified was not immediately apparent, and took a bit to figure out.  This is an attempt at making that a little clearer with an example. 