### PR TITLE
Detailing some python tools we've added to the default 7.3 image

### DIFF
--- a/user/osx-ci-environment.md
+++ b/user/osx-ci-environment.md
@@ -194,6 +194,13 @@ Recent 1.7 version (usually the most recent)
 * rake
 * cocoapods
 
+## Python related tools
+- pyenv (via homebrew)
+- virtualenv (via pip)
+- numpy (via pip)
+- scipy (via pip)
+- tox (via pip)
+
 ## Xcode version
 
 Xcode 7.3.1 is installed with all available simulators and SDKs.


### PR DESCRIPTION
We added
- pyenv (via homebrew)
- virtualenv (via pip)
- numpy (via pip)
- scipy (via pip)
- tox (via pip)