### PR TITLE
Add note that users must use the MySQL 5.6 instructions for Trusty

### DIFF
--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -50,6 +50,9 @@ MySQL binds to 127.0.0.1 and requires authentication. You can connect using the 
 
 >Note that the "travis" user does not have full MySQL privileges that the "root" user does.
 
+> If you are using the Trusty image (to use Docker or for some other reason) you must
+> use the MySQL 5.6 instructions.
+
 ### Using MySQL with ActiveRecord
 
 `config/database.yml` example for Ruby projects using ActiveRecord:


### PR DESCRIPTION
I added Docker to my builds which switched me to the Trusty image. It took me a while to figure out why MySQL stopped working with the default MySQL instructions. This note tells users that they must install MySQL themselves on Trusty.