### PR TITLE
Python: do not default to dead nosetests, suggest pytest instead

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -30,7 +30,7 @@ Travis CI supports Python versions 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, as well as rece
     # command to install dependencies
     install: "pip install -r requirements.txt"
     # command to run tests
-    script: nosetests
+    script: pytest
 
 As time goes, new releases come out and we provision more Python versions and/or implementations, aliases like `3.2` will float and point to different exact versions, patch levels and so on.
 
@@ -63,7 +63,7 @@ To test your project against PyPy, add "pypy" or "pypy3" to the list of Pythons 
       - pip install .
       - pip install -r requirements.txt
     # command to run tests
-    script: nosetests
+    script: pytest
 
 
 ## Default Python Version
@@ -75,10 +75,10 @@ If you leave the `python` key out of your `.travis.yml`, Travis CI will use Pyth
 Python projects need to provide the `script` key in their `.travis.yml` to
 specify what command to run tests with.
 
-For example, if your project uses nosetests:
+For example, if your project uses pytest:
 
     # command to run tests
-    script: nosetests
+    script: pytest
 
 if it uses `make test` instead:
 


### PR DESCRIPTION
[Nosetests has been in maintenance mode for quite a while now](http://nose.readthedocs.io/en/latest/) with the [last contribution many many months ago](https://github.com/nose-devs/nose).

Therefore I don't think Travis docs should default to nose (which is likely to be picked up by new users) but instead promote pytest, an alternative with a very active community and active development.