### PR TITLE
Updated docs to match current firefox addons

### DIFF
--- a/user/firefox.md
+++ b/user/firefox.md
@@ -28,3 +28,7 @@ In addition to specific version numbers, there are 3 special aliases you can use
 * [`latest`](https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US)
 * [`latest-esr`](https://download.mozilla.org/?product=firefox-esr-latest&os=linux64&lang=en-US)
 * [`latest-beta`](https://download.mozilla.org/?product=firefox-beta-latest&os=linux64&lang=en-US)
+* [`latest-dev`](https://download.mozilla.org/?product=firefox-aurora-latest&os=linux64&lang=en-US)
+* [`latest-nightly`](https://download.mozilla.org/?product=firefox-nightly-latest&os=linux64&lang=en-US)
+
+For more information visit the [Mozilla Wiki](https://wiki.mozilla.org/Firefox/Channels#Developer_Edition_.28aka_Aurora.29).


### PR DESCRIPTION
This updates the firefox addons doc to match my patch adding firefox developer and nightly versions.