### PR TITLE
Update NAT IP addresses

### DIFF
--- a/user/ip-addresses.md
+++ b/user/ip-addresses.md
@@ -9,12 +9,12 @@ when you need them safelisted to access your internal resources. Since builds
 run in a variety of different infrastructures, the IP ranges to safelist depend
 on the infrastructure your builds are running on:
 
-| Infrastructure                          | IP ranges                                                                                                                                                                  |
-| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Container-based (travis-ci.com)         | `nat-com.aws-us-east-1.travisci.net` (`54.172.141.90/32` `52.3.133.20/32`) and `workers-nat-com-shared-2.aws-us-east-1.travisci.net` (`52.45.185.117/32` `52.54.31.11/32`) |
-| Container-based (travis-ci.org)         | `nat-org.aws-us-east-1.travisci.net` (`52.0.240.122/32` `52.22.60.255/32`) and `workers-nat-org-shared-2.aws-us-east-1.travisci.net` (`52.45.220.64/32` `52.54.40.118/32`) |
-| OS X                                    | `208.78.110.192/27`                                                                                                                                                        |
-| Sudo-enabled Linux                      | N/A (see below)                                                                                                                                                            |
+| Infrastructure                  | IP ranges                                                                                                                                                                  |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Container-based (travis-ci.com) | `nat-com.aws-us-east-1.travisci.net` (`54.172.141.90/32` `52.3.133.20/32`) and `workers-nat-com-shared-2.aws-us-east-1.travisci.net` (`52.45.185.117/32` `52.54.31.11/32`) |
+| Container-based (travis-ci.org) | `nat-org.aws-us-east-1.travisci.net` (`52.0.240.122/32` `52.22.60.255/32`) and `workers-nat-org-shared-2.aws-us-east-1.travisci.net` (`52.45.220.64/32` `52.54.40.118/32`) |
+| OS X                            | `208.78.110.192/27`                                                                                                                                                        |
+| Sudo-enabled Linux              | N/A (see below)                                                                                                                                                            |
 
 We do not have static public IP addresses available for jobs running on the
 sudo-enabled Linux infrastructure at this time, although Google has some further

--- a/user/ip-addresses.md
+++ b/user/ip-addresses.md
@@ -9,14 +9,12 @@ when you need them safelisted to access your internal resources. Since builds
 run in a variety of different infrastructures, the IP ranges to safelist depend
 on the infrastructure your builds are running on:
 
-| Infrastructure                          | IP ranges |
-| --------------------------------------- | -------------------------------------------------------------------------- |
-| Container-based Precise (travis-ci.com) | `nat-com.aws-us-east-1.travisci.net` (`54.172.141.90/32` `52.3.133.20/32`) |
-| Container-based Precise (travis-ci.org) | `nat-org.aws-us-east-1.travisci.net` (`52.0.240.122/32` `52.22.60.255/32`) |
-| Container-based Trusty (travis-ci.com)  | `workers-nat-com-shared-2.aws-us-east-1.travisci.net` (`52.45.185.117/32` `52.54.31.11/32`) |
-| Container-based Trusty (travis-ci.org)  | `workers-nat-org-shared-2.aws-us-east-1.travisci.net` (`52.45.220.64/32` `52.54.40.118/32`) |
-| OS X                                    | `208.78.110.192/27` |
-| Sudo-enabled Linux                      | N/A (see below) |
+| Infrastructure                          | IP ranges                                                                                                                                                                  |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Container-based (travis-ci.com)         | `nat-com.aws-us-east-1.travisci.net` (`54.172.141.90/32` `52.3.133.20/32`) and `workers-nat-com-shared-2.aws-us-east-1.travisci.net` (`52.45.185.117/32` `52.54.31.11/32`) |
+| Container-based (travis-ci.org)         | `nat-org.aws-us-east-1.travisci.net` (`52.0.240.122/32` `52.22.60.255/32`) and `workers-nat-org-shared-2.aws-us-east-1.travisci.net` (`52.45.220.64/32` `52.54.40.118/32`) |
+| OS X                                    | `208.78.110.192/27`                                                                                                                                                        |
+| Sudo-enabled Linux                      | N/A (see below)                                                                                                                                                            |
 
 We do not have static public IP addresses available for jobs running on the
 sudo-enabled Linux infrastructure at this time, although Google has some further

--- a/user/ip-addresses.md
+++ b/user/ip-addresses.md
@@ -4,17 +4,29 @@ layout: en
 permalink: /user/ip-addresses/
 ---
 
-Knowing the IP addresses of the build machines Travis CI uses can be helpful when you need them safelisted to access your internal resources. Since builds run in a variety of different infrastructures, the IP ranges to safelist depend on the infrastructure your builds are running on:
+Knowing the IP addresses of the build machines Travis CI uses can be helpful
+when you need them safelisted to access your internal resources. Since builds
+run in a variety of different infrastructures, the IP ranges to safelist depend
+on the infrastructure your builds are running on:
 
-| Infrastructure                  | IP ranges                                                                                          |
-| ------------------------------- | -------------------------------------------------------------------------------------------------- |
-| Container-based (travis-ci.com) | `nat-com.aws-us-east-1.travisci.net` (`54.172.141.90/32`, `52.3.133.20/32` as of March 14th, 2016) |
-| Container-based (travis-ci.org) | `nat-org.aws-us-east-1.travisci.net` (`52.0.240.122/32`, `52.22.60.255/32` as of March 14th, 2016) |
-| OS X                            | `208.78.110.192/27`                                                                                |
-| Sudo-enabled Linux              | N/A (see below)                                                                                    |
+| Infrastructure                          | IP ranges |
+| --------------------------------------- | -------------------------------------------------------------------------- |
+| Container-based Precise (travis-ci.com) | `nat-com.aws-us-east-1.travisci.net` (`54.172.141.90/32` `52.3.133.20/32`) |
+| Container-based Precise (travis-ci.org) | `nat-org.aws-us-east-1.travisci.net` (`52.0.240.122/32` `52.22.60.255/32`) |
+| Container-based Trusty (travis-ci.com)  | `workers-nat-com-shared-2.aws-us-east-1.travisci.net` (`52.45.185.117/32` `52.54.31.11/32`) |
+| Container-based Trusty (travis-ci.org)  | `workers-nat-org-shared-2.aws-us-east-1.travisci.net` (`52.45.220.64/32` `52.54.40.118/32`) |
+| OS X                                    | `208.78.110.192/27` |
+| Sudo-enabled Linux                      | N/A (see below) |
 
-We do not have static public IP addresses available for jobs running on the sudo-enabled Linux infrastructure at this time, although Google has some further [information on how to get those ranges here](https://cloud.google.com/compute/docs/faq#where_can_i_find_short_product_name_ip_ranges). We recommend using one of the other infrastructures if you need static IP addresses.
+We do not have static public IP addresses available for jobs running on the
+sudo-enabled Linux infrastructure at this time, although Google has some further
+[information on how to get those ranges
+here](https://cloud.google.com/compute/docs/faq#where_can_i_find_short_product_name_ip_ranges).
+We recommend using one of the other infrastructures if you need static IP
+addresses.
 
 Note that these ranges can change in the future.
 
-More details about our different infrastructures are available on the [virtualization environments page](/user/ci-environment/#Virtualization-environments).
+More details about our different infrastructures are available on the
+[virtualization environments
+page](/user/ci-environment/#Virtualization-environments).


### PR DESCRIPTION
<del>A potential problem with this update is that, with the rollout of replacement container-based ubuntu precise capacity, it may not make sense to call out a precise/trusty split.</del>

(already collapsed 'em)