### PR TITLE
Fixed typo in header

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -371,7 +371,7 @@ matrix:
     env: DB=mysql
 ```
 
-### Explicity Including Jobs
+### Explicitly Including Jobs
 
 It is also possible to include entries into the matrix with `matrix.include`:
 


### PR DESCRIPTION
[Here](https://docs.travis-ci.com/user/customizing-the-build#Explicity-Including-Jobs):

"Explicity Including Jobs" should be "Explicitly Including Jobs".