### PR TITLE
Swap some of the .org and .com NAT IPs

### DIFF
--- a/user/ip-addresses.md
+++ b/user/ip-addresses.md
@@ -11,8 +11,8 @@ on the infrastructure your builds are running on:
 
 | Infrastructure                  | IP ranges                                                                                                                                                                  |
 | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Container-based (travis-ci.com) | `nat-com.aws-us-east-1.travisci.net` (`54.172.141.90/32` `52.3.133.20/32`) and `workers-nat-com-shared-2.aws-us-east-1.travisci.net` (`52.45.185.117/32` `52.54.31.11/32` `54.87.185.35/32` `54.82.137.203/32`) |
-| Container-based (travis-ci.org) | `nat-org.aws-us-east-1.travisci.net` (`52.0.240.122/32` `52.22.60.255/32`) and `workers-nat-org-shared-2.aws-us-east-1.travisci.net` (`52.45.220.64/32` `52.54.40.118/32` `54.89.89.104/32` `54.87.141.246/32`) |
+| Container-based (travis-ci.com) | `nat-com.aws-us-east-1.travisci.net` (`54.172.141.90/32` `52.3.133.20/32`) and `workers-nat-com-shared-2.aws-us-east-1.travisci.net` (`52.45.220.64/32` `52.54.40.118/32` `54.89.89.104/32` `54.82.137.203/32`) |
+| Container-based (travis-ci.org) | `nat-org.aws-us-east-1.travisci.net` (`52.0.240.122/32` `52.22.60.255/32`) and `workers-nat-org-shared-2.aws-us-east-1.travisci.net` (`52.45.185.117/32` `52.54.31.11/32` `54.87.185.35/32` `54.87.141.246/32`) |
 | OS X                            | `208.78.110.192/27`                                                                                                                                                        |
 | Sudo-enabled Linux              | N/A (see below)                                                                                                                                                            |
 


### PR DESCRIPTION
This updates the IPs to match the hostname they're assigned to

```
$ host workers-nat-org-shared-2.aws-us-east-1.travisci.net
workers-nat-org-shared-2.aws-us-east-1.travisci.net has address 54.87.141.246
workers-nat-org-shared-2.aws-us-east-1.travisci.net has address 52.45.185.117
workers-nat-org-shared-2.aws-us-east-1.travisci.net has address 52.54.31.11
workers-nat-org-shared-2.aws-us-east-1.travisci.net has address 54.87.185.35
$ host workers-nat-com-shared-2.aws-us-east-1.travisci.net
workers-nat-com-shared-2.aws-us-east-1.travisci.net has address 54.89.89.104
workers-nat-com-shared-2.aws-us-east-1.travisci.net has address 52.54.40.118
workers-nat-com-shared-2.aws-us-east-1.travisci.net has address 52.45.220.64
workers-nat-com-shared-2.aws-us-east-1.travisci.net has address 54.82.137.203
```