### PR TITLE
Update trusty-ci-environment.md

### DIFF
--- a/user/trusty-ci-environment.md
+++ b/user/trusty-ci-environment.md
@@ -19,7 +19,6 @@ Or, if you want to route to the sudo-less beta, add:
 ```yaml
 dist: trusty
 sudo: false
-group: beta
 ```
 
 This is enabled for both public and private repositories.
@@ -92,7 +91,6 @@ Or, if you want to route to the container-based beta:
 ```yaml
 dist: trusty
 sudo: false
-group: beta
 ```
 
 ## Environment common to all Trusty images


### PR DESCRIPTION
As tested, and according to https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/, group: beta isn't needed.