### PR TITLE
Removed x86 emulator from samples

### DIFF
--- a/user/languages/android.md
+++ b/user/languages/android.md
@@ -83,7 +83,7 @@ android:
   components:
     - build-tools-20.0.0
     - android-L
-    - sys-img-armeabi-v7a-android-22
+    - sys-img-armeabi-v7a-android-tv-l
     - add-on
     - extra
   licenses:

--- a/user/languages/android.md
+++ b/user/languages/android.md
@@ -56,6 +56,7 @@ android:
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests
     - sys-img-armeabi-v7a-android-22
+    - sys-img-armeabi-v7a-android-17
 ```
 
 ### How to install Android SDK components

--- a/user/languages/android.md
+++ b/user/languages/android.md
@@ -56,7 +56,6 @@ android:
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests
     - sys-img-armeabi-v7a-android-22
-    - sys-img-x86-android-17
 ```
 
 ### How to install Android SDK components
@@ -84,7 +83,7 @@ android:
   components:
     - build-tools-20.0.0
     - android-L
-    - sys-img-x86-android-tv-l
+    - sys-img-armeabi-v7a-android-22
     - add-on
     - extra
   licenses:


### PR DESCRIPTION
x86 emulators aren't supported yet on Travis CI. See travis-ci/travis-ci#1419.

Based on feedback from [HS 44939](https://secure.helpscout.net/conversation/282411357/44939/?folderId=30784).