### PR TITLE
Typo in spelling of "Bitbucket"

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -490,7 +490,7 @@ Build and test your open source projects hosted on GitHub on [travis-ci.org](htt
 
 Build and test your private repositories hosted on GitHub on [travis-ci.com](https://travis-ci.com/).
 
-Travis CI currently does not support git repositories hosted on Bitbucketc or GitLab, or other version control systems such as Mercurial.
+Travis CI currently does not support git repositories hosted on Bitbucket or GitLab, or other version control systems such as Mercurial.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Changed "Bitbucketc" to "Bitbucket"