### PR TITLE
Add guides on how to disable yarn

### DIFF
--- a/user/languages/javascript-with-nodejs.md
+++ b/user/languages/javascript-with-nodejs.md
@@ -131,6 +131,12 @@ Note that `yarn` requires Node.js version 4 or later.
 If the job does not meet this requirement, `npm install` is used
 instead.
 
+If for some reason you want to disable Yarn despite the presence of `yarn.lock` file and the Node version is 4 or later, you need to manually set the `install` step to use `npm install` instead.
+
+```
+install: npm install
+```
+
 #### Caching with `yarn`
 
 You can cache `$HOME/.yarn-cache` with:


### PR DESCRIPTION
The example case is: if we're building a NodeJS app for AWS Lambda (which only supports up to v4.3).

On development machines we're using node v6 and yarn, but to deploy the app into Lambda we need to use node v4.3 in the `.travis.yml` file and force the usage of `npm install` since some of the dependencies will fail if installed using yarn.

This is one of those libraries:
```
error sol-redis-pool@0.3.2: The engine "node" is incompatible with this module. Expected version ">= 4.5.0".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```