### PR TITLE
Update for CVE-2016-8655

### DIFF
--- a/user/build-environment-updates/2016-12-08.md
+++ b/user/build-environment-updates/2016-12-08.md
@@ -10,7 +10,7 @@ date: 2016-12-08
 
 ### Schedule
 
-[2016-12-08  UTC](http://everytimezone.com/#2016-12-6,180,cn3)
+[2016-12-08 18:45 UTC](http://everytimezone.com/#2016-12-8,405,cn3)
 
 
 ### Details

--- a/user/build-environment-updates/2016-12-08.md
+++ b/user/build-environment-updates/2016-12-08.md
@@ -1,0 +1,24 @@
+---
+title: Build Environment Update History
+layout: en
+permalink: /user/build-environment-updates/2016-12-08/
+category: build_env_updates
+date: 2016-12-08
+---
+
+## 2016-12-08
+
+### Schedule
+
+[2016-12-08  UTC](http://everytimezone.com/#2016-12-6,180,cn3)
+
+
+### Details
+
+[CVE-2016-8655](https://security-tracker.debian.org/tracker/CVE-2016-8655) was announced and contains a potential _root escalation vulnerability_. We are proactively updating the kernel version to a fixed kernel to ensure that any potential risk is minimized for our users.
+
+This update applies to container-based Ubuntu Trusty and Precise Docker host environment, and is considered a bugfix update, since it's only changing the kernel version that the Docker containers run inside.
+
+### Fixed
+
+- Updated kernel version of `4.8.7` to `4.8.12`

--- a/user/build-environment-updates/2016-12-08.md
+++ b/user/build-environment-updates/2016-12-08.md
@@ -15,7 +15,9 @@ date: 2016-12-08
 
 ### Details
 
-[CVE-2016-8655](https://security-tracker.debian.org/tracker/CVE-2016-8655) was announced and contains a potential _root escalation vulnerability_. We are proactively updating the kernel version to a fixed kernel to ensure that any potential risk is minimized for our users.
+[CVE-2016-8655](https://security-tracker.debian.org/tracker/CVE-2016-8655) was announced on Wed, Dec 7, 2017.
+
+The CVE details an exploit which represents a potential risk of Travis CI users using container-based builds to get escalated privileges to the container host. We at Travis CI have found no evidence of being vulnerable to this exploit, but are proactively updating the kernel version to a fixed kernel to ensure any potential risk is minimized for our users.
 
 This update applies to container-based Ubuntu Trusty and Precise Docker host environment, and is considered a bugfix update, since it's only changing the kernel version that the Docker containers run inside.
 


### PR DESCRIPTION
-  kernel upgrade from `4.8.7` to `4.8.12` for [CVE-2016-8655](https://security-tracker.debian.org/tracker/CVE-2016-8655)