### PR TITLE
Note on CloudFoundry page that symbols in passwords must be escaped

### DIFF
--- a/user/deployment/cloudfoundry.md
+++ b/user/deployment/cloudfoundry.md
@@ -4,7 +4,7 @@ layout: en
 permalink: /user/deployment/cloudfoundry/
 ---
 
-You now have the amazing ability to deploy directly to [CloudFoundry](https://run.pivotal.io/) after a successful build on Travis CI
+You now have the amazing ability to deploy directly to [CloudFoundry](https://run.pivotal.io/) after a successful build on Travis CI.
 
 ## Getting on the Edge
 
@@ -12,17 +12,17 @@ Proper CloudFoundry support is currently included only in the edge version of Tr
 
 ## The Easy Way
 
-Go Grab the Travis gem from [GitHub](https://github.com/travis-ci/travis.rb) and run this command:
+Go grab [the Travis gem from GitHub](https://github.com/travis-ci/travis.rb) and run this command:
 
 `travis setup cloudfoundry`
 
-You will be asked to answer a few simple questions about your CloudFoundry setup and Travis will take care of the rest!
+You will be asked to answer a few simple questions about your CloudFoundry setup, and Travis will take care of the rest!
 
-Open up your newly created `.travis.yml` and add `edge: true` to enable the deploy tool.  See yml below for an example of how to do this.
+Open up your newly-created `.travis.yml` and add `edge: true` to enable the deploy tool.  See yml below for an example of how to do this.
 
 ## The Slightly Harder Way
 
-So you want to write your own `.travis.yml`, fine.  Here is the minimum required to get up and running
+So you want to write your own `.travis.yml`, fine.  Here is the minimum required to get up and running:
 
 ```
  deploy:
@@ -37,11 +37,13 @@ So you want to write your own `.travis.yml`, fine.  Here is the minimum required
 
 ***Make sure that you encrypt your password before pushing your updated .travis.yml to GitHub.***
 
-This can be easily accomplished using the Travis gem above and running:
+You can do this using the Travis gem above and running:
 
 ```
 travis encrypt --add deploy.password
 ```
+
+If your password includes symbols (such as braces, parentheses, backslashes, and pipe symbols), [you must escape those symbols before running `travis encrypt`](/user/encryption-keys/#Note-on-escaping-certain-symbols).
 
 ### Conditional releases
 


### PR DESCRIPTION
I work on a Cloud Foundry deployment (cloud.gov), and a couple of our users ran into potential security problems because they didn't receive clear documentation about the need to escape special symbols in passwords run through `travis encrypt`. This change adds a reminder about that to the Cloud Foundry page, with a link to the main info about escaping symbols (https://docs.travis-ci.com/user/encryption-keys#Note-on-escaping-certain-symbols).

(For additional context, see https://github.com/18F/cg-site/pull/637 for the update I made to our local Cloud Foundry docs, and https://github.com/18F/cg-product/issues/517 for the user reports.)

This edit also includes minor copyedits since I was already editing the page.