### PR TITLE
Removed -e flag from docker login command

### DIFF
--- a/user/docker.md
+++ b/user/docker.md
@@ -125,7 +125,6 @@ the repository settings environment variables, which may be set up through the
 web or locally via the Travis CLI, e.g.:
 
 ```bash
-travis env set DOCKER_EMAIL me@example.com
 travis env set DOCKER_USERNAME myusername
 travis env set DOCKER_PASSWORD secretsecret
 ```
@@ -134,7 +133,7 @@ Within your `.travis.yml` prior to attempting a `docker push` or perhaps before
 `docker pull` of a private image, e.g.:
 
 ```bash
-docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 ```
 
 #### Branch Based Registry Pushes
@@ -145,7 +144,7 @@ use the `after_success` section of your `.travis.yml`:
 ```yaml
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
-    docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
     docker push USER/REPO;
     fi
 ```
@@ -156,7 +155,7 @@ When pushing to a private registry, be sure to specify the hostname in the
 `docker login` command, e.g.:
 
 ```bash
-docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" registry.example.com
+docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" registry.example.com
 ```
 
 ### Using Docker Compose


### PR DESCRIPTION
If you add the -e flag you get the following warning:

> Flag --email has been deprecated, will be removed in 1.13.