### PR TITLE
Fix installation step documentation

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -73,7 +73,7 @@ When one of the steps fails, the build stops immediately and is marked as [error
 You can skip the installation step entirely by adding the following to your `.travis.yml`:
 
 ```yaml
-install: true
+install: false
 ```
 
 ## Customizing the Build Step


### PR DESCRIPTION
I guess you must use `install: false` instead of `install: true` to skip it