### PR TITLE
Add android build cache

### DIFF
--- a/user/languages/android.md
+++ b/user/languages/android.md
@@ -187,6 +187,7 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+    - $HOME/.android/build-cache
 ```
 
 ## Default Test Command


### PR DESCRIPTION
The 2.3 android gradle plugin comes with a [new build cache](http://tools.android.com/tech-docs/build-cache).