### PR TITLE
[FIX] Quote encapsulate encryption value

### DIFF
--- a/user/encryption-keys.md
+++ b/user/encryption-keys.md
@@ -26,7 +26,7 @@ gem install travis
 Then, you can use `encrypt` command to encrypt data (This example assumes you are running the command in your project directory. If not, add `-r owner/project`):
 
 ```bash
-travis encrypt SOMEVAR=secretvalue
+travis encrypt SOMEVAR="secretvalue"
 ```
 
 This will output a string looking something like:


### PR DESCRIPTION
This is a simple PR:

* Encapsule encrypt string value in quotes in order to allow special chars

Alternatively, I could add another example block slightly below this one including some special chars & the quotes. 

I figured the more concise would be better, but I'll leave that decision to you maintainers & will make the change if requested 😄 