### PR TITLE
Ducksboard references removed

### DIFF
--- a/user/apps.md
+++ b/user/apps.md
@@ -75,16 +75,6 @@ By Frederik Dietz
 - [website](http://fdietz.github.io/team_dashboard/)
 - [source code](https://github.com/fdietz/team_dashboard)
 
-### Ducksboard Travis
-
-![travis-light](/images/apps/ducksboard.jpg){:.app}
-
-Integrates Travis CI with Ducksboard<br>
-By Divshot, Inc.
-
-- [website](https://ducksboard-travis.herokuapp.com/)
-- [source code](https://github.com/divshot/ducksboard-travis)
-
 ### CI Status
 
 ![ci-status](/images/apps/ci-status.png){:.app}


### PR DESCRIPTION
Follow-up of https://github.com/travis-ci/docs-travis-ci-com/pull/892

After continued server errors, Ducksboard has been removed from the Apps
and Integrations page.  If all would get up again, we would welcome a
notification or PR.