### PR TITLE
Fix Maven CLI arguments

### DIFF
--- a/user/languages/groovy.md
+++ b/user/languages/groovy.md
@@ -68,7 +68,7 @@ cache:
 if your project has `pom.xml` file in the repository root but no `build.gradle`, Travis CI Groovy builder will use Maven 3 to build it. By default it will use
 
 ```bash
-mvn test
+mvn test -B
 ```
 
 to run your test suite. This can be overridden as described in the [general build configuration](/user/customizing-the-build/) guide.
@@ -78,7 +78,7 @@ to run your test suite. This can be overridden as described in the [general buil
 Before running tests, Groovy builder will execute
 
 ```bash
-mvn install -DskipTests=true
+mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 ```
 
 to install your project's dependencies with Maven.

--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -27,13 +27,13 @@ language: java
 If your project has `pom.xml` file in the repository root but no `build.gradle`, Travis CI builds your project with Maven 3:
 
 ```bash
-mvn test
+mvn test -B
 ```
 
 If your project also includes the `mvnw` wrapper script in the repository root, Travis CI uses that instead:
 
 ```bash
-./mvnw test
+./mvnw test -B
 ```
 
 > The default command does not generate JavaDoc (`-Dmaven.javadoc.skip=true`).


### PR DESCRIPTION
Synchronize the documentation with what is currently executed by default.

The code can be found here:
https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/shared/jvm.rb
