### PR TITLE
Fix broken link in environment variables documentation

### DIFF
--- a/user/environment-variables.md
+++ b/user/environment-variables.md
@@ -120,6 +120,8 @@ The encryption scheme is explained in more detail in [Encryption keys](/user/enc
 
 ## Defining Variables in Repository Settings
 
+{: #Defining-Variables-in-Repository-Settings}
+
 Variables defined in repository settings are the same for all builds, and when you restart an old build, it uses the latest values. These variables are not automatically available to forks.
 
 Define variables in the Repository Settings that:


### PR DESCRIPTION
At the beginning of the [environment variables documentation](https://docs.travis-ci.com/user/environment-variables) there is a link to the element `#Defining-Variables-in-Repository-Settings`, which does not exist (link target: https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings).

When JavaScript is enabled, the link works anyway, but with this change the link works also if JavaScript is disabled/blocked (just like the other links on that page).