### PR TITLE
Added workaround for code signing to work on our macOS Sierra VMs

### DIFF
--- a/user/common-build-problems.md
+++ b/user/common-build-problems.md
@@ -171,7 +171,7 @@ or
 osx_image: xcode8.2
 ```
 
-The following lines can be seen in the build log:
+The following lines in your build log possibly indicate an occurence of this issue:
 
 **Example: Signing**
 ```

--- a/user/common-build-problems.md
+++ b/user/common-build-problems.md
@@ -136,7 +136,7 @@ end
 bundler_args: --without development debug
 ```
 
-## Mac: Code Signing Errors
+## Mac: OS X Mavericks (10.9) Code Signing Errors
 
 With Mavericks, quite a lot has changed in terms of code signing and the keychain application.
 
@@ -156,6 +156,98 @@ security unlock-keychain -p travis $KEY_CHAIN
 # Set keychain locking timeout to 3600 seconds
 security set-keychain-settings -t 3600 -u $KEY_CHAIN
 ```
+
+## Mac: macOS Sierra (10.12) Code Signing Errors
+
+With the introduction of macOS Sierra (10.12) on our infrastructure, we've seen build jobs that were hanging at the codesigning step of the build process. Here's some information on how to recognize this issue and fix it.
+
+Your build is running on macOS Sierra (10.12) if the following `osx_image` values are in your .travis.yml file:
+
+```yaml
+osx_image: xcode8.1
+```
+or
+```yaml
+osx_image: xcode8.2
+```
+
+The following lines can be seen in the build log:
+
+**Example: Signing**
+```
+▸ Signing /Users/travis/Library/Developer/Xcode/DerivedData/PresenterKit-ggzwtlifkopsnbffbqrmtydtmafv/Build/Intermediates/CodeCoverage/Products/Debug-iphonesimulator/project.xctest
+
+No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
+Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
+
+The build has been terminated
+```
+
+**Example: Embed Pods Frameworks**
+```
+▸ Running script '[CP] Embed Pods Frameworks'
+
+No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
+Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
+
+The build has been terminated
+```
+
+To fix this issue, you will need to add the following command **after** you have imported your certificate:
+
+```
+security set-key-partition-list -S apple-tool:,apple: -s -k keychainPass keychainName
+```
+
+Where:
+- `keychainPass` is the password of your keychain
+- `keychainName` is the name of your keychain
+
+Here's an example to put the command in context:
+
+```bash
+# Create the keychain with a password
+security create-keychain -p travis ios-build.keychain
+
+# Make the custom keychain default, so xcodebuild will use it for signing
+security default-keychain -s ios-build.keychain
+
+# Unlock the keychain
+security unlock-keychain -p travis ios-build.keychain
+
+# Add certificates to keychain and allow codesign to access them
+security import ./Provisioning/certs/apple.cer -k ~/Library/Keychains/ios-build.keychain -T /usr/bin/codesign
+security import ./Provisioning/certs/distribution.cer -k ~/Library/Keychains/ios-build.keychain -T /usr/bin/codesign
+security import ./Provisioning/certs/distribution.p12 -k ~/Library/Keychains/ios-build.keychain -P $KEY_PASSWORD -T /usr/bin/codesign
+
+security set-key-partition-list -S apple-tool:,apple: -s -k travis ios-build.keychain
+```
+
+**⚠️  IMPORTANT: It's mandatory to create a keychain with a password. ⚠️**
+
+### Fastlane
+
+If you are using [Fastlane](https://fastlane.tools/) to sign your app (e.g. with [Fastlane Match](https://github.com/fastlane/fastlane/tree/master/match)), you will need to do something similar to the following in your `Fastfile`:
+
+```
+    create_keychain(
+      name: ENV["MATCH_KEYCHAIN_NAME"],
+      password: ENV["MATCH_PASSWORD"],
+      default_keychain: true,
+      unlock: true,
+      timeout: 3600,
+      add_to_search_list: true
+    )
+
+    match(
+      type: "adhoc",
+      keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
+      keychain_password: ENV["MATCH_PASSWORD"],
+      readonly: true
+    )
+```
+
+You can also look [at the following GitHub issue](https://github.com/travis-ci/travis-ci/issues/6791#issuecomment-261071904) to get more details.
 
 ## Mac: Errors running CocoaPods
 

--- a/user/common-build-problems.md
+++ b/user/common-build-problems.md
@@ -203,7 +203,7 @@ Where:
 - `keychainPass` is the password of your keychain
 - `keychainName` is the name of your keychain
 
-Here's an example to put the command in context:
+Here's an example of where to put the command in context:
 
 ```bash
 # Create the keychain with a password
@@ -223,7 +223,7 @@ security import ./Provisioning/certs/distribution.p12 -k ~/Library/Keychains/ios
 security set-key-partition-list -S apple-tool:,apple: -s -k travis ios-build.keychain
 ```
 
-**⚠️  IMPORTANT: It's mandatory to create a keychain with a password. ⚠️**
+**⚠️  IMPORTANT: It's mandatory to create a keychain with a password for the command `security set-key-partition-list` to work. ⚠️**
 
 ### Fastlane
 

--- a/user/common-build-problems.md
+++ b/user/common-build-problems.md
@@ -223,7 +223,7 @@ security import ./Provisioning/certs/distribution.p12 -k ~/Library/Keychains/ios
 security set-key-partition-list -S apple-tool:,apple: -s -k travis ios-build.keychain
 ```
 
-**⚠️  IMPORTANT: It's mandatory to create a keychain with a password for the command `security set-key-partition-list` to work. ⚠️**
+> IMPORTANT: It's mandatory to create a keychain with a password for the command `security set-key-partition-list` to work.
 
 ### Fastlane
 

--- a/user/common-build-problems.md
+++ b/user/common-build-problems.md
@@ -247,7 +247,8 @@ If you are using [Fastlane](https://fastlane.tools/) to sign your app (e.g. with
     )
 ```
 
-You can also look [at the following GitHub issue](https://github.com/travis-ci/travis-ci/issues/6791#issuecomment-261071904) to get more details.
+You can also have more details in [this GitHub issue](https://github.com/travis-ci/travis-ci/issues/6791) starting at [this comment](https://github.com/travis-ci/travis-ci/issues/6791#issuecomment-261071904).
+
 
 ## Mac: Errors running CocoaPods
 


### PR DESCRIPTION
 i.e. `osx_image: xcode8.1 or xcode8.2`

See https://github.com/travis-ci/travis-ci/issues/6791