### PR TITLE
Specify that Rubinius can only be installed on a Trusty system

### DIFF
--- a/user/languages/ruby.md
+++ b/user/languages/ruby.md
@@ -94,6 +94,9 @@ Note that the syntax of `rbx-19mode` isn't supported anymore.
 
 Rubinius will be installed via a download currently.
 
+> Note that Rubinius can only be installed on a Trusty system; set `dist: trusty`
+> in your `.travis.yml` file.
+
 ### JRuby: C extensions are not supported
 
 Please note that **C extensions are not supported in JRuby** on Travis CI. The


### PR DESCRIPTION
Hello,

Your support on Twitter kindly told me that Rubinius can only be installed on a Trusty system but I didn't find that information in the documentation so I just took the liberty to add it.

Have a nice day ! :-)