### PR TITLE
Add note to use .com endpoint for Travis PRO - Triggering builds docs

### DIFF
--- a/user/triggering-builds.md
+++ b/user/triggering-builds.md
@@ -15,7 +15,7 @@ travis login --org
 travis token --org
 ```
 
-If you are using Travis CI with a private repository use `--pro` instead of `--org`
+If you are using Travis CI with a private repository use `--pro` instead of `--org` and use `https://api.travis-ci.com` for all endpoints.
 
 Here is a script for sending a minimal request to the master branch of the `travis-ci/travis-core` repository:
 


### PR DESCRIPTION
The "Triggering builds from the API" docs might be confusing for Travis PRO users, as the sample requests are made to the `.org` endpoint. I added a note for this, similar as it is done before for the CLI commands for Travis PRO.

The change looks like this:



![image](https://cloud.githubusercontent.com/assets/1730320/22146768/121c7a70-df06-11e6-92d9-3994ab21bca6.png)

