### PR TITLE
remove unsupported Python versions from documentation

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -14,7 +14,7 @@ Python builds are not available on the OSX environment.
 
 ## Choosing Python versions to test against
 
-Travis CI supports Python versions 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 3.6 as well as recent development versions.
+Travis CI supports Python versions 2.6, 2.7, 3.2, 3.3, 3.4 as well as recent development versions.
 
 ```yaml
 language: python
@@ -24,12 +24,6 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
-  - "3.5"
-  - "3.5-dev" # 3.5 development branch
-  - "3.6"
-  - "3.6-dev" # 3.6 development branch
-  - "3.7-dev" # 3.7 development branch
-  - "nightly" # currently points to 3.7-dev
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to run tests


### PR DESCRIPTION
Cf. <https://github.com/travis-ci/travis-ci/issues/4990>.