### PR TITLE
Add more AWS permissions to Lambda deploy guide

### DIFF
--- a/user/deployment/lambda.md
+++ b/user/deployment/lambda.md
@@ -52,7 +52,8 @@ The AWS user that Travis deploys as must have the following IAM permissions in o
                 "lambda:ListFunctions",
                 "lambda:CreateFunction",
                 "lambda:UploadFunction",
-                "lambda:UpdateFunctionConfiguration"
+                "lambda:UpdateFunctionConfiguration",
+                "lambda:UpdateFunctionCode"
             ],
             "Resource": [
                 "*"

--- a/user/deployment/lambda.md
+++ b/user/deployment/lambda.md
@@ -49,6 +49,8 @@ The AWS user that Travis deploys as must have the following IAM permissions in o
             "Sid": "DeployCode",
             "Effect": "Allow",
             "Action": [
+                "lambda:ListFunctions",
+                "lambda:CreateFunction",
                 "lambda:UploadFunction"
             ],
             "Resource": [

--- a/user/deployment/lambda.md
+++ b/user/deployment/lambda.md
@@ -51,7 +51,8 @@ The AWS user that Travis deploys as must have the following IAM permissions in o
             "Action": [
                 "lambda:ListFunctions",
                 "lambda:CreateFunction",
-                "lambda:UploadFunction"
+                "lambda:UploadFunction",
+                "lambda:UpdateFunctionConfiguration"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
In a recent attempt to deploy a Lambda via Travis-CI, we found that the Travis user needed more permissions than `user/deployment/lambda.md` describes.