### PR TITLE
Specify database when activating PostGIS.

### DIFF
--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -165,7 +165,7 @@ You need to activate the extension in your `.travis.yml`:
 
 ```yaml
 before_script:
-  - psql -U postgres -c "create extension postgis"
+  - psql -U postgres -d travis_ci_test -c "create extension postgis"
 ```
 
 ### PostgreSQL and Locales


### PR DESCRIPTION
I may be wrong, but if you don't specify the database to activate the extension it does not work, I had the following error:

```
function postgis_lib_version() does not exist
```