### PR TITLE
Add elixir client

### DIFF
--- a/user/apps.md
+++ b/user/apps.md
@@ -11,7 +11,7 @@ There is a wide range of tools you can use to interact with Travis CI:
 - **[Desktop](#desktop)**: [Mac OS X](#Mac-OS-X), [Linux](#Linux), [Windows](#Windows), [Cross Platform](#Cross-Platform)
 - **[Command Line Tools](#commandline)**: [Full Clients](#Full-Clients), [Build Monitoring](#Build-Monitoring), [Generators](#Generators)
 - **[Plugins](#plugins)**: [Google Chrome](#Google-Chrome), [Mozilla Firefox](#Mozilla-Firefox), [Opera](#Opera), [Editors](#Editors), [Other](#Other)
-- **[Libraries](#libraries)**: [Ruby](#Ruby), [JavaScript](#JavaScript), [PHP](#PHP), [Python](#Python)
+- **[Libraries](#libraries)**: [Ruby](#Ruby), [JavaScript](#JavaScript), [PHP](#PHP), [Python](#Python), [Elixir](#Elixir)
   {: .toc-list}
 
 And if you don't find anything that fits your needs, you can also interact with our [API](/api/) directly.
@@ -548,3 +548,7 @@ By Eduardo Antonio Lundgren Melo and Zeno Rocha Bueno Netto
 ## Python
 
 - [TravisPy](http://travispy.readthedocs.org/en/latest/) by Fabio Menegazzo
+
+## Elixir
+
+- [travis.ex](https://github.com/localytics/travis.ex) by Kevin Deisz


### PR DESCRIPTION
We wrote an Elixir client (https://github.com/localytics/travis.ex and blog post http://eng.localytics.com/best-practices-and-common-mistakes-with-travis-ci/), and would love to get it into the docs! 