### PR TITLE
Clarify how to encrypt a PyPI deplopyment password

### DIFF
--- a/user/deployment/pypi.md
+++ b/user/deployment/pypi.md
@@ -15,7 +15,7 @@ deploy:
   password: "Your password"
 ```
 
-However, that exposes your PyPI password to the world. We recommend you
+However, this exposes your PyPI password to the world. We recommend you
 encrypt your password using the Travis CI command line client:
 
 ```

--- a/user/deployment/pypi.md
+++ b/user/deployment/pypi.md
@@ -15,16 +15,16 @@ deploy:
   password: "Your password"
 ```
 
-However, that would expose your PyPI password to the world. We recommend you
+However, that exposes your PyPI password to the world. We recommend you
 encrypt your password using the Travis CI command line client:
 
 ```
 travis encrypt --add deploy.password
 ```
 
-This will prompt you to enter the password, and then print out an
-encrypted version of it which you should put in your ``.travis.yml`` file
-as described under [Encrypting Sensitive Data](/user/encryption-keys/):
+This prompts you to enter the password, and prints an encrypted version
+of it which you should put in your ``.travis.yml`` file as described
+under [Encrypting Sensitive Data](/user/encryption-keys/):
 
 ```
 deploy:

--- a/user/deployment/pypi.md
+++ b/user/deployment/pypi.md
@@ -15,6 +15,25 @@ deploy:
   password: "Your password"
 ```
 
+However, that would expose your PyPI password to the world. We recommend you
+encrypt your password using the Travis CI command line client:
+
+```
+travis encrypt --add deploy.password
+```
+
+This will prompt you to enter the password, and then print out an
+encrypted version of it which you should put in your ``.travis.yml`` file
+as described under [Encrypting Sensitive Data](/user/encryption-keys/):
+
+```
+deploy:
+  provider: pypi
+  user: "Your username"
+  password:
+    secure: "Your encrypted password"
+```
+
 Most likely, you would only want to deploy to PyPI when a new version of your
 package is cut. To do this, you can tell Travis CI to only deploy on tagged
 commits, like so:
@@ -29,14 +48,6 @@ deploy:
 ```
 
 If you tag a commit locally, remember to run `git push --tags` to ensure that your tags are uploaded to GitHub.
-
-Assuming you have the Travis CI command line client installed, you can encrypt your password like this:
-
-```
-travis encrypt --add deploy.password
-```
-
-You will be prompted to enter your password on the command line.
 
 You can also have the `travis` tool set up everything for you:
 


### PR DESCRIPTION
Warn that the minimal example is unsafe and explain how to use an
encrypted password instead, linking to the TravisCI documentation.