### PR TITLE
Add Argument Examples to Script Deployments

### DIFF
--- a/user/deployment/script.md
+++ b/user/deployment/script.md
@@ -24,9 +24,9 @@ If you need to run multiple commands, write a executable wrapper script that run
 If the script returns a nonzero status, deployment is considered
 a failure, and the build will be marked as "errored".
 
-## Passing Arguments to Script Deployments
+## Passing Arguments to the Script
 
-It's possible to pass arguments to a script deployment.
+It is possible to pass arguments to a script deployment.
 
 ```yaml
 deploy:
@@ -42,7 +42,7 @@ deploy:
       branch: master
 ```
 
-These arguments have access to all the usual [environment variables](/user/environment-variables/#Default-Environment-Variables).
+The script has access to all the usual [environment variables](/user/environment-variables/#Default-Environment-Variables).
 
 ```yaml
 deploy:

--- a/user/deployment/script.md
+++ b/user/deployment/script.md
@@ -24,6 +24,35 @@ If you need to run multiple commands, write a executable wrapper script that run
 If the script returns a nonzero status, deployment is considered
 a failure, and the build will be marked as "errored".
 
+## Passing Arguments to Script Deployments
+
+It's possible to pass arguments to a script deployment.
+
+```yaml
+deploy:
+  # deploy develop to the staging environment
+  - provider: script
+    script: scripts/deploy.sh staging
+    on:
+      branch: develop
+  # deploy master to production
+  - provider: script
+    script: scripts/deploy.sh production
+    on:
+      branch: master
+```
+
+These arguments have access to all the usual [environment variables](/user/environment-variables/#Default-Environment-Variables).
+
+```yaml
+deploy:
+  provider: script
+  script: scripts/deploy.sh production $TRAVIS_TAG
+  on:
+    tags: true
+    all_branches: true
+```
+
 ## Deployment is executed by Ruby 1.9.3
 
 In order to ensure that deployments are executed reliably, we use a version of Ruby that is pre-installed on all of our build images.


### PR DESCRIPTION
An example with simple arguments as well as an example using one of Travis' built in environment variables.

See https://twitter.com/chrisguitarguy/status/824980175813218304

We pay for travis-ci.com and were trying to use the same deploy script to push to multiple environments. You can pass arguments to a script deployment which was not at all clear in the docs and took me trying it out to make sure.

Anyway, I think it's worth it to include some examples. Show how flexible a script deployment really is.