### PR TITLE
Update AWS Lambda documentation

### DIFF
--- a/user/deployment/lambda.md
+++ b/user/deployment/lambda.md
@@ -51,7 +51,10 @@ The AWS user that Travis deploys as must have the following IAM permissions in o
             "Sid": "DeployCode",
             "Effect": "Allow",
             "Action": [
-                "lambda:UploadFunction"
+                "lambda:ListFunctions",
+                "lambda:UploadFunction",
+                "lambda:UpdateFunctionCode",
+                "lambda:UpdateFunctionConfiguration"
             ],
             "Resource": [
                 "*"

--- a/user/deployment/lambda.md
+++ b/user/deployment/lambda.md
@@ -12,8 +12,10 @@ A minimal configuration is:
 deploy:
   provider: lambda
   function_name: "lambda-test"
+  region: "us-east-1"
   role: "arn:aws:iam::0123456789012:role/lambda_basic_execution"
-  handler_name: "index.handler"
+  runtime: "nodejs4.3"
+  handler_name: "handler"
   access_key_id: "AWS ACCESS KEY ID"
   secret_access_key: "AWS SECRET ACCESS KEY"
 ```

--- a/user/deployment/lambda.md
+++ b/user/deployment/lambda.md
@@ -48,16 +48,33 @@ The AWS user that Travis deploys as must have the following IAM permissions in o
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "ListExistingRolesAndPolicies",
+            "Effect": "Allow",
+            "Action": [
+                "iam:ListRolePolicies",
+                "iam:ListRoles"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "CreateAndListFunctions",
+            "Effect": "Allow",
+            "Action": [
+                "lambda:CreateFunction",
+                "lambda:ListFunctions"
+            ],
+            "Resource": "*"
+        },
+        {
             "Sid": "DeployCode",
             "Effect": "Allow",
             "Action": [
-                "lambda:ListFunctions",
                 "lambda:UploadFunction",
                 "lambda:UpdateFunctionCode",
                 "lambda:UpdateFunctionConfiguration"
             ],
             "Resource": [
-                "*"
+                "arn:aws:lambda:<region>:<account-id>:function:<name-of-function>"
             ]
         },
         {


### PR DESCRIPTION
Update AWS Lambda documentation to be more likely to be correct for most users after I found the "minimal configuration to be insufficient when followed.

  1. The ```region``` value should be present (even though it is optional) as the majority of users worldwide probably _aren't_ using ```us-east-1```.
  1. Using a value of ```index.handler``` causes ```index.index.handler``` to be used instead, causing the lambda to fail. ```handler``` is sufficient.
  1. Add the ```runtime``` value and set to  ```nodejs4.3``` as ```nodejs``` is now deprecated and causes [deployment to fail](https://travis-ci.org/martincostello/alexa-london-travel/builds/196336961#L333).