### PR TITLE
add newer HHVM LST versions to the list

### DIFF
--- a/user/languages/php.md
+++ b/user/languages/php.md
@@ -61,6 +61,7 @@ In addition, depending on the Ubuntu release, you can test with more HHVM versio
 language: php
 php:
   - hhvm-3.3
+  - hhvm-3.6
 ```
 
 #### HHVM versions on Trusty
@@ -75,6 +76,8 @@ php:
   - hhvm-3.6
   - hhvm-3.9
   - hhvm-3.12
+  - hhvm-3.15
+  - hhvm-3.18
   - hhvm-nightly
 ```
 


### PR DESCRIPTION
- add newer HHVM LST versions to the list
- hhvm 3.6 is available on precise