### PR TITLE
Remove unnecessary reference to possible future change

### DIFF
--- a/user/caching.md
+++ b/user/caching.md
@@ -37,9 +37,7 @@ On Ruby and Objective-C projects, installing dependencies via [Bundler](http://b
 
 #### Enabling Bundler caching
 
-<s>Bundler caching is automatically enabled for Ruby projects that include a Gemfile.lock.</s> *(Bundler caching is [not yet](https://github.com/travis-ci/travis-build/pull/148) enabled automatically)*
-
-You can explicitly enable Bundler caching in your *.travis.yml*:
+To enable Bundler caching in your `.travis.yml`:
 
 ```yaml
 language: ruby


### PR DESCRIPTION
Removing the reference to https://github.com/travis-ci/travis-build/pull/148 where not a lot of movement has been seen.