### PR TITLE
do not recommend --user pip install in container-based

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -106,8 +106,7 @@ By default Travis CI uses `pip` to manage python dependencies. If you have a
 `requirements.txt` file, Travis CI runs `pip install -r requirements.txt`
 during the `install` phase of the build.
 
-Note: If you're running in the container-based infrastructure without access to
-`sudo` you need to install dependencies in the home directory instead:
+You can manually override this default `install` phase, for example:
 
 ```yaml
 install: pip install --user -r requirements.txt


### PR DESCRIPTION
This reverts the tip given at https://github.com/travis-ci/docs-travis-ci-com/issues/361