### PR TITLE
Add canceled and errored states in webhook notifications

### DIFF
--- a/user/notifications.md
+++ b/user/notifications.md
@@ -674,6 +674,8 @@ Additionally a message will be present in the `status_message`/`result_message` 
 - *Broken*: The build completed in failure after a previously successful build
 - *Failed*: The build is the first build for a new branch and has failed
 - *Still Failing*: The build completed in failure after a previously failed build
+- *Canceled*: The build was canceled
+- *Errored*: The build has errored
 
 The `type` field can be used to find the event type that caused this build to
 run. Its value is one of `push`, `pull_request`, `cron`, or `api`.  For pull requests,


### PR DESCRIPTION
According to [Travis-Hub](https://github.com/travis-ci/travis-hub/blob/ac97c871a12330c05f64bc8a478e22c6dbf3562b/lib/travis/addons/serializer/webhook/build/message.rb#L22-L29), it seems we're missing the "Canceled" and "Errored" states in the webhook notification docs :)

The full list would be:
```ruby
pending:  'Pending',
passed:   'Passed',
failed:   'Failed',
broken:   'Broken',
fixed:    'Fixed',
failing:  'Still Failing',
errored:  'Errored',
canceled: 'Canceled'
```