### PR TITLE
Fast finish only determines the status of a build if required jobs finished

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -509,14 +509,14 @@ Without the top-level `env`, no job will be allowed to fail.
 
 If some rows in the build matrix are allowed to fail, the build won't be marked as finished until they have completed.
 
-To set the build to finish as soon as possible, add `fast_finish: true` to the `matrix` section of your `.travis.yml` like this:
+To mark the build as finished as soon as possible, add `fast_finish: true` to the `matrix` section of your `.travis.yml` like this:
 
 ```yaml
 matrix:
   fast_finish: true
 ```
 
-Now, a build will finish as soon as the only jobs left allow failures.
+Now, a build result will be determined as soon as all the required jobs finish, based on these results, while the rest of the `allow_failures` jobs continue to run.
 
 ## Implementing Complex Build Steps
 

--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -516,7 +516,7 @@ matrix:
   fast_finish: true
 ```
 
-Now, a build will finish as soon as a job has failed, or when the only jobs left allow failures.
+Now, a build will finish as soon as the only jobs left allow failures.
 
 ## Implementing Complex Build Steps
 

--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -516,7 +516,7 @@ matrix:
   fast_finish: true
 ```
 
-Now, a build result will be determined as soon as all the required jobs finish, based on these results, while the rest of the `allow_failures` jobs continue to run.
+Now, the build result will be determined as soon as all the required jobs finish, based on these results, while the rest of the `allow_failures` jobs continue to run.
 
 ## Implementing Complex Build Steps
 


### PR DESCRIPTION
After some confusion with the `fast_finish` feature, it seems that some people (me included) were understanding that activating `fast_finish` in a build would stop a build as soon as one job fails.

However, after some tests and [from @BanzaiMan's comments:](https://github.com/travis-ci/travis-ci/issues/7231#issuecomment-275745395)

> fast_finish sets the build results when all the required jobs finish, without waiting for all the jobs (which may be allowed to fail) to finish.

`fast_finish` does only have an effect for builds in which there are `allowed_failures`, but not for a regular build in which all jobs are required.

Another confusion here is that `fast_finish` does not cancel the remaining jobs, it sets the result of the build, but the remaining jobs (allowed failures) will still run.

In this PR I'm updating a little bit the `fast_finish` section and adding some suggestions from @BanzaiMan :)
