### PR TITLE
feat(doc): Add note about safelisting branches and tags

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -257,6 +257,8 @@ branches:
   - stable
 ```
 
+> Note that _safelisting_ will cause tagged commits to be _skipped_. You can use a regex to safelist tags (e.g. the regex `/^v\d+\.\d+(\.\d+)?(-\S*)?$/` matches tag `v1.0`). See more about using regural expressions below.
+
 If you specify both, `only` takes precedence over `except`. By default, the `gh-pages` branch is not built unless you add it to the safelist.
 
 To have _all_ branches build:


### PR DESCRIPTION
Add a note in the `Safelisting or blocklisting branches` section that notifies the user that safelisting branches causes tagged commits to be skipped. Also, propose an example regex that allows specific tags to be safelisted.