### PR TITLE
Update javascript-with-nodejs.md to include ver 7

### DIFF
--- a/user/languages/javascript-with-nodejs.md
+++ b/user/languages/javascript-with-nodejs.md
@@ -17,6 +17,7 @@ releases in your `.travis.yml`:
 
 - `node` latest stable Node.js release
 - `iojs` latest stable io.js release
+- `7` latest 7.x release
 - `6` latest 6.x release
 - `5` latest 5.x release
 - `4` latest 4.x release
@@ -25,7 +26,7 @@ releases in your `.travis.yml`:
 language: node_js
 node_js:
   - "iojs"
-  - "6"
+  - "7"
 ```
 
 We also have many more [versions of
@@ -142,7 +143,7 @@ addons:
       - google-chrome-stable
 language: node_js
 node_js:
-  - "0.12"
+  - "7"
 env:
     - EMBER_VERSION=default
     - EMBER_VERSION=release
@@ -183,7 +184,7 @@ You can build your Meteor Apps on Travis CI and test against
 ```yaml
 language: node_js
 node_js:
-  - "0.12"
+  - "7"
 before_install:
   - "curl -L https://raw.githubusercontent.com/arunoda/travis-ci-laika/master/configure.sh | /bin/sh"
 services:
@@ -203,7 +204,7 @@ The following `before_install` script installs the required dependencies:
 ```yaml
 language: node_js
 node_js:
-  - "0.12"
+  - "7"
 before_install:
   - "curl -L https://raw.githubusercontent.com/arunoda/travis-ci-meteor-packages/master/configure.sh | /bin/sh"
 before_script:
@@ -223,6 +224,7 @@ If you need more specific control of Node.js version in your build, use any of
 the following available versions. Releases not shown in this list may be used if
 `nvm` can install them.
 
+- 7.7.x
 - 6.1.x
 - 6.0.x
 - 5.11.x
@@ -249,8 +251,8 @@ the following available versions. Releases not shown in this list may be used if
 - 0.6.x
 {: .column-3}
 
-Specifying only a major and minor version (e.g., "0.12") will run using the
-latest published patch release for that version.
+Specifying only a major (e.g., "7") or major.minor version (e.g., "7.7") will run using the
+latest published patch release for that version such as "7.7.1".
 [nvm](https://github.com/creationix/nvm) handles version resolution, so any
 version or [alias](https://github.com/creationix/nvm#usage) of Node.js or io.js
 that nvm can install is available.


### PR DESCRIPTION
Include information about newer versions, there were many references to 0.12 and no references to version 7