### PR TITLE
Fix apcu extension name

### DIFF
--- a/user/languages/php.md
+++ b/user/languages/php.md
@@ -237,7 +237,7 @@ See the [default configure options](https://github.com/travis-ci/travis-cookbook
 
 The following extensions are preinstalled for PHP 7.0 and nightly builds:
 
-- [apc.so](http://php.net/apc)
+- [apcu.so](http://php.net/apcu)
 - [memcached.so](http://php.net/memcached)
 - [mongodb.so](https://php.net/mongodb)
 - [amqp.so](http://php.net/amqp)


### PR DESCRIPTION
apc is not installable on PHP 7+.

See https://github.com/travis-ci/travis-ci/issues/7390