### PR TITLE
py.test is not needed on old plattforms

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -85,7 +85,7 @@ For example, if your project uses pytest:
 
 ```yaml
 # command to run tests
-script: pytest  # or py.test for Python versions 3.5 and below
+script: pytest
 ```
 
 if it uses `make test` instead:


### PR DESCRIPTION
It is available there, too.