### PR TITLE
Docker: document steps to update to last version and route to Trusty

### DIFF
--- a/user/docker.md
+++ b/user/docker.md
@@ -187,7 +187,6 @@ updating `docker-engine` in the `before_install` step of your `.travis.yml`:
 before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine
-  - docker --version # for verification
 ```
 
 > Check what version of Docker you're running with `docker --version`

--- a/user/docker.md
+++ b/user/docker.md
@@ -180,7 +180,6 @@ before_install:
 
 ### Installing a newer Docker version
 
-The pre-installed Docker version is possibly not the latest.
 You can upgrade to the latest version and use any new Docker features by manually
 updating `docker-engine` in the `before_install` step of your `.travis.yml`:
 
@@ -190,6 +189,8 @@ before_install:
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine
   - docker --version # for verification
 ```
+
+> Check what version of Docker you're running with `docker --version`
 
 #### Examples
 

--- a/user/docker.md
+++ b/user/docker.md
@@ -162,7 +162,8 @@ docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" registry.example.com
 
 The [Docker Compose](https://docs.docker.com/compose/) tool is also [installed in the Docker enabled environment](/user/trusty-ci-environment/#Docker).
 
-If needed, you can easily replace this preinstalled version of `docker-compose` by adding the following `before_install` step to your `.travis.yml`:
+If needed, you can easily replace this preinstalled version of `docker-compose`
+by adding the following `before_install` step to your `.travis.yml`:
 
 ```yaml
 env:
@@ -173,6 +174,19 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+```
+
+### Installing a newer Docker version
+
+The Trusty sudo-required environment comes with Docker 1.12 pre-installed.
+You can upgrade to the latest version and use any new Docker features by manually
+updating `docker-engine` in the `before_install` step of your `.travis.yml`:
+
+```yaml
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine
+  - docker --version # for verification
 ```
 
 #### Examples

--- a/user/docker.md
+++ b/user/docker.md
@@ -180,7 +180,7 @@ before_install:
 
 ### Installing a newer Docker version
 
-The Trusty sudo-required environment comes with Docker 1.12 pre-installed.
+The pre-installed Docker version is possibly not the latest.
 You can upgrade to the latest version and use any new Docker features by manually
 updating `docker-engine` in the `before_install` step of your `.travis.yml`:
 

--- a/user/docker.md
+++ b/user/docker.md
@@ -21,6 +21,8 @@ services:
 Then you can add `- docker` commands to your build as shown in the following
 examples.
 
+> Travis CI automatically routes builds to run on Trusty when `services: docker` is configured.
+
 ### Using a Docker Image from a Repository in a Build
 
 This [example repository](https://github.com/travis-ci/docker-sinatra) runs two


### PR DESCRIPTION
Closes https://github.com/travis-ci/docs-travis-ci-com/issues/953
Closes https://github.com/travis-ci/docs-travis-ci-com/issues/1017

This PR adds a section with the required steps to update to the last Docker version. The Docker version preinstalled in Trusty sudo-required is:

```
$ docker --version
Docker version 1.12.3, build 6b644ec
```

Also, I'm including a note about builds with `services: docker` configured being routed by Trusty. I've seen a couple questions about this lately, as users seem confused because they're setting `dist: precise` but this is ignored. For the record, this is done here: https://github.com/travis-ci/travis-api/blob/d9b80d82f1b88d3b8fd1f05da4b5e74bfda68b9e/lib/travis/model/build/config/dist.rb#L10-L11

This looks like:

![image](https://cloud.githubusercontent.com/assets/1730320/24051055/25a8637c-0b31-11e7-8331-7e0426e1b550.png)


and

![image](https://cloud.githubusercontent.com/assets/1730320/24051064/2c1c72a2-0b31-11e7-933f-572276df9e39.png)


Any feedback would be appreciated, @plaindocs! 💛 