### PR TITLE
display direct `p` children of `li` as inline, fix line break in lists

### DIFF
--- a/assets/stylesheets/_base.sass
+++ b/assets/stylesheets/_base.sass
@@ -76,6 +76,9 @@ li ul
   padding-left: 2.5em
   list-style-position: outside
 
+li > p
+  display: inline
+
 table
   width: 100%
 


### PR DESCRIPTION
turns
![screen shot 2017-03-22 at 14 28 21](https://cloud.githubusercontent.com/assets/1006478/24200042/02b88b88-0f0c-11e7-942f-0a3f0c64ddc1.png)
into
![screen shot 2017-03-22 at 14 28 28](https://cloud.githubusercontent.com/assets/1006478/24200045/061925bc-0f0c-11e7-9720-381a717d6c81.png)
