### PR TITLE
Add Note styles to protocol details on private dependencies

### DIFF
--- a/user/private-dependencies.md
+++ b/user/private-dependencies.md
@@ -17,7 +17,7 @@ If the dependency is also on GitHub, there are four different ways of being able
 | **[Password](#Password)**     | HTTPS    | all repos user has access to | password can be encrypted           |
 | **[API token](#API-Token)**   | HTTPS    | all repos user has access to | token can be encrypted              |
 
-For the SSH protocol, dependency URLs need to have the format of `git@github.com/…` whereas for the HTTPS protocol, they need to start with `https://…`.
+> For the SSH protocol, dependency URLs need to have the format of `git@github.com/…` whereas for the HTTPS protocol, they need to start with `https://…`.
 
 You can use a [dedicated CI user account](#Dedicated-User-Account) for all but the deploy key approach. This will allow you to limit the access to a well defined list of repositories and read access only.
 


### PR DESCRIPTION
I've seen a couple of reports today in which there was some confusion setting SSH keys to access private dependencies but the dependency URL wasn't updated appropriately to have the format to clone the submodules via SSH.

I thought that converting this paragraph to a note would highlight it. What do you think?

This change looks like:

![image](https://cloud.githubusercontent.com/assets/1730320/24208946/3554d2cc-0f25-11e7-9926-ac0484f4a29c.png)
