### PR TITLE
Revert "display direct `p` children of `li` as inline, fix line break in lists"

### DIFF
--- a/assets/stylesheets/_base.sass
+++ b/assets/stylesheets/_base.sass
@@ -76,9 +76,6 @@ li ul
   padding-left: 2.5em
   list-style-position: outside
 
-li > p
-  display: inline
-
 table
   width: 100%
 


### PR DESCRIPTION
Reverts travis-ci/docs-travis-ci-com#1045