### PR TITLE
Improve xvfb docs

### DIFF
--- a/user/gui-and-headless-browsers.md
+++ b/user/gui-and-headless-browsers.md
@@ -52,9 +52,27 @@ For travis-web, our very own website, we use Sauce Labs to run browser tests on 
 
 To run tests requiring a graphical user interface on Travis CI, use `xvfb` (X
 Virtual Framebuffer) to imitate a display. If you need a browser, Firefox is
-installed on all Travis CI environments.
+[readily available](https://docs.travis-ci.com/user/firefox/) on all Travis CI 
+environments.
 
-Start `xvfb` in the `before_script` section of your `.travis.yml`:
+### Simple
+
+For simple cases, try wrapping your `script` call with `xvfb-run`, like so:
+
+```yaml
+script: xvfb-run make test
+```
+
+To set the screen resolution, try:
+
+```yaml
+script: xvfb-run --server-args="-screen 0 1024x768x24" make test
+```
+
+### Complex
+
+If you can't use `xvfb-run` for some reason, try calling `xvfb` itself, in the 
+`before_script` section of your `.travis.yml`:
 
 ```yaml
 before_script:


### PR DESCRIPTION
- point out `xvfb-run`
- link to Firefox docs (stock version is ancient)