### PR TITLE
Change instructions about whitelisting packages

### DIFF
--- a/user/migrating-from-legacy.md
+++ b/user/migrating-from-legacy.md
@@ -74,7 +74,7 @@ addons:
 ```
 
 The aliases for the allowed sources (such as `deadsnakes` above) are managed in a
-[whitelist](https://github.com/travis-ci/apt-source-whitelist), and any attempts to add disallowed sources will result in a log message indicating how to submit sources for approval.
+[whitelist](https://github.com/travis-ci/apt-source-whitelist). If you need additional sources you must use `sudo: required`.
 
 ### Adding APT Packages
 


### PR DESCRIPTION
The whitelist is not being extended, so suggest the recommended workaround of `sudo: required`.