### PR TITLE
Document merge_mode for triggering builds via API

### DIFF
--- a/user/triggering-builds.md
+++ b/user/triggering-builds.md
@@ -131,16 +131,3 @@ With the `merge_mode` set to `deep_merge`, the resulting build configuration wil
 ```
 
 I.e. the `env` section from the API request has been merged into the existing section.
-
-### Requests triggered with API and webhooks
-
-Due to a way we use tokens for webhooks authentication, a token needs to be
-passed manually as a param for webhooks to work properly. An example request
-with token passed as a param would look like:
-
-```json
-"request": {
-  "branch": "master",
-  "token": "a-token"
-}
-```

--- a/user/triggering-builds.md
+++ b/user/triggering-builds.md
@@ -1,21 +1,23 @@
 ---
-title: Triggering builds through the API
+title: Triggering builds with the API
 permalink: /user/triggering-builds/
 layout: en
 ---
 
-Trigger Travis CI builds using the API (*v3 only*) by sending a POST request to `/repo/{slug|id}/requests`.
+Trigger Travis CI builds using V3 of the Travis CI API by sending a POST request to `/repo/{slug|id}/requests`.
 
-Before using the Travis CI API you need to use the [command line client](https://github.com/travis-ci/travis.rb#readme) to get an API token:
+Before using the Travis CI API, get an authorization token from the  [command line client](https://github.com/travis-ci/travis.rb#readme):
 
 ```bash
 travis login --org
 travis token --org
 ```
 
-If you are using Travis CI with a private repository use `--pro` instead of `--org` and use `https://api.travis-ci.com` for all endpoints.
+If you are using Travis CI with a private repository use `--pro` instead of `--org` and use `https://api.travis-ci.com` for all endpoints. See the [API V3 Getting Started Guide](https://developer.travis-ci.org/gettingstarted) for more information.
 
-Here is a script for sending a minimal request to the master branch of the `travis-ci/travis-core` repository:
+Here is a script for sending a minimal request to the master branch of the `travis-ci/travis-core` repository.
+
+> If you want to run any of the examples scripts yourself, change the `xxxxxx` in the example to the authentication token you generated and change the repository slug to your own repository.
 
 ```bash
 body='{
@@ -39,7 +41,7 @@ This request triggers a build of the most recent commit on the master branch of 
 
 ### Customizing the commit message
 
-You can specify a commit message like so:
+You can specify a commit message in the request body:
 
 ```bash
 body='{
@@ -54,11 +56,11 @@ body='{
 
 You can also customize the build configuration.
 
-For controlling how the original build configuration (in the `.travis.yml` file), and the configuration given in your API request are combined you can choose one out of 3 merge modes:
+Choose one of the following merge modes to determine how the original build configuration (in the `.travis.yml` file), and the configuration specified in your API request are combined :
 
-* `replace` replaces the full, original build configuration with the given configuration
-* `merge` replaces sections in the original configuration with the given section (default)
-* `deep_merge` deep merges the given configuration into the build configuration
+* `replace` replaces the full, original build configuration with the configuration in the API request body
+* `merge` (*default*) replaces sections in the original configuration with the configuration in the API request body
+* `deep_merge` merges the configuration in the API request body into the build configuration
 
 For example, given that the `.travis.yml` file contains the following configuration:
 
@@ -86,7 +88,7 @@ body='{
 
 #### Merge mode: replace
 
-With the `merge_mode` set to `replace` the resulting build configuration will be the following.
+With the `merge_mode` set to `replace` the resulting combined build configuration is:
 
 ```json
 {
@@ -97,11 +99,11 @@ With the `merge_mode` set to `replace` the resulting build configuration will be
 }
 ```
 
-I.e. the full configuration has been replaced by the configuration from the API request.
+The full configuration has been replaced by the configuration from the API request.
 
 #### Merge mode: merge (default)
 
-With the `merge_mode` set to `merge`, or not given a `merge_mode` (default), the resulting build configuration will be the following.
+With the `merge_mode` set to `merge`, or not given a `merge_mode` (default), the resulting build configuration is:
 
 ```json
 {
@@ -113,11 +115,12 @@ With the `merge_mode` set to `merge`, or not given a `merge_mode` (default), the
 }
 ```
 
-I.e. each of the top level sections have been replaced with the ones given in the API request, other top level sections will remain the same.
+Each of the top level sections have been replaced with the ones from
+ the API request, other top level sections remain the same.
 
 #### Merge mode: deep_merge
 
-With the `merge_mode` set to `deep_merge`, the resulting build configuration will be the following.
+With the `merge_mode` set to `deep_merge`, the resulting build configuration is:
 
 ```json
 {
@@ -130,4 +133,4 @@ With the `merge_mode` set to `deep_merge`, the resulting build configuration wil
 }
 ```
 
-I.e. the `env` section from the API request has been merged into the existing section.
+The `env` section from the API request has been merged into the existing `env` section.


### PR DESCRIPTION
This documents the `merge_mode` that can now be passed to API when triggering build requests.