### PR TITLE
Better  `fqdn` default description for pages deployment

### DIFF
--- a/user/deployment/pages.md
+++ b/user/deployment/pages.md
@@ -43,7 +43,7 @@ or via [encrypted variables in
     directory
 * `repo`: Repo slug, defaults to current repo
 * `target_branch`: Branch to push force to, defaults to `gh-pages`
-* `fqdn`: Optional, no default, sets a main domain for your website
+* `fqdn`: Optional, sets a custom domain for your website, defaults to no custom domain support.
 * `project_name`: Defaults to value of `fqdn` or repo slug, used for metadata
 * `email`: Optional, comitter info, defaults to `deploy@travis-ci.org`
 * `name`: Optional, comitter, defaults to `Deployment Bot`


### PR DESCRIPTION
It's not so much that there's no default, but rather that the default is to _change_ the current GitHub custom domain setting to remove custom domain support.

It might be a bit friendly if an empty `fqdn` setting didn't change the GitHub configuration.