### PR TITLE
Clarify route to sudo-required infrastructure for services: docker

### DIFF
--- a/user/docker.md
+++ b/user/docker.md
@@ -21,7 +21,7 @@ services:
 Then you can add `- docker` commands to your build as shown in the following
 examples.
 
-> Travis CI automatically routes builds to run on Trusty when `services: docker` is configured.
+> Travis CI automatically routes builds to run on Trusty `sudo: required` when `services: docker` is configured.
 
 ### Using a Docker Image from a Repository in a Build
 


### PR DESCRIPTION
Lately we included [this note about builds being routed to Trusty when services: docker was configured](https://github.com/travis-ci/docs-travis-ci-com/commit/bda572ba29615d3a188c49439a75ee3b533516e4), but I think this could be improved by detailing that the builds are actually routed to the Trusty `sudo: required` infrastructure.