### PR TITLE
Update travis.yml example to match doc description

### DIFF
--- a/user/docker.md
+++ b/user/docker.md
@@ -58,7 +58,7 @@ before_install:
 - docker pull carlad/sinatra
 - docker run -d -p 127.0.0.1:80:4567 carlad/sinatra /bin/sh -c "cd /root/sinatra; bundle exec foreman start;"
 - docker ps -a
-- docker run carlad/sinatra /bin/sh -c "cd /root/sinatra; bundle exec rake test"
+- docker run carlad/sinatra /bin/sh -c "cd /root/sinatra; bundle exec foreman start"
 
 script:
 - bundle exec rake test


### PR DESCRIPTION
Update travis.yml example to start the sinatra app in `before_install`, and run the test suite in `script`.
Currently the test suite is shown in both `before_install` and `script`.