### PR TITLE
Rust: add example for workspace projects

### DIFF
--- a/user/languages/rust.md
+++ b/user/languages/rust.md
@@ -76,3 +76,13 @@ If you wish to override this, you can use the `script` setting:
 language: rust
 script: make all
 ```
+
+For example, if your project is a [workspace](http://doc.crates.io/manifest.html#the-workspace-section),
+you should pass `-all` to the build commands to build and test all of the member crates:
+
+```yaml
+language: rust
+script:
+  - cargo build --verbose --all
+  - cargo test --verbose --all
+```  


### PR DESCRIPTION
Rust projects can define a workspace which is a set of crates that will all share the same Cargo.lock and output directory. Without modifying the build script to pass `--all` to the various build commands, only the root crate will be built and tested. Or, if the workspace has no root crate, the build and test commands will fail with the following error:

error: manifest path `/path/to/crate/root` is a virtual manifest, but this command requires running against an actual package in this workspace