### PR TITLE
Update best-practices-security.md

### DIFF
--- a/user/best-practices-security.md
+++ b/user/best-practices-security.md
@@ -15,7 +15,7 @@ Despite our best efforts, there are however many ways in which secure informatio
 
 * settings which duplicate commands to standard output, such as `set -x` or `set -v` in your bash scripts
 * displaying environment variables, by running `env` or `printenv`
-* printing secrets within the code, for example `echo $SECRET_KEY`
+* printing secrets within the code, for example `echo "$SECRET_KEY"`
 * using tools that print secrets on error output, such as `php -i`
 * git commands like `git fetch` or `git push` may expose tokens or other secure environment variables
 * mistakes in string escaping


### PR DESCRIPTION
Since when this file is for security purpose, it's better to use best practice.

Leaving variable un-quoted in shell script is bad practice and is source of many security implications, please do not make the user think it's the right way.