### PR TITLE
build-stages/deploy-npm: Remove "gem" property

### DIFF
--- a/user/build-stages/deploy-npm.md
+++ b/user/build-stages/deploy-npm.md
@@ -29,7 +29,6 @@ jobs:
       deploy:
         provider: npm
         api_key: $NPM_API_KEY
-        gem: travis-build-stages-demo
         on: deploy-npm-release
 ```
 


### PR DESCRIPTION
The `gem` property looks like a copy-paste issue since it's not documented anywhere on https://docs.travis-ci.com/user/deployment/npm