### PR TITLE
Remove the $ before GITHUB_TOKEN

### DIFF
--- a/user/deployment/pages.md
+++ b/user/deployment/pages.md
@@ -17,7 +17,7 @@ For a minimal configuration, add the following to your `.travis.yml`:
 deploy:
   provider: pages
   skip_cleanup: true
-  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  github_token: GITHUB_TOKEN # Set in travis-ci.org dashboard
   on:
     branch: master
 ```


### PR DESCRIPTION
The `$` that precedes `GITHUB_TOKEN` was causing an error at build time