### PR TITLE
Adds warning that provider is experimental.

### DIFF
--- a/user/deployment/pages.md
+++ b/user/deployment/pages.md
@@ -4,7 +4,7 @@ layout: en
 permalink: /user/deployment/pages/
 ---
 
-> Deploying to GitHub Pages uses `git push --force` and overwrites the history on the`gh-pages` branch, which is usually only used for deployments. 
+> Deploying to GitHub Pages uses `git push --force` to overwrite the history on the *target* branch, so make sure you only deploy to a branch used for that specific purpose, such as `gh-pages`. 
 
 Travis CI can deploy your static files to [GitHub
 Pages](https://pages.github.com/) after a successful build.

--- a/user/deployment/pages.md
+++ b/user/deployment/pages.md
@@ -4,6 +4,8 @@ layout: en
 permalink: /user/deployment/pages/
 ---
 
+*This provider is experimental, use at your own judgement.*
+
 Travis CI can deploy your static files to [GitHub
 Pages](https://pages.github.com/) after a successful build.
 

--- a/user/deployment/pages.md
+++ b/user/deployment/pages.md
@@ -4,7 +4,7 @@ layout: en
 permalink: /user/deployment/pages/
 ---
 
-*This provider is experimental, use at your own judgement.*
+> Deploying to GitHub Pages uses `git push --force` and overwrites the history on the`gh-pages` branch, which is usually only used for deployments. 
 
 Travis CI can deploy your static files to [GitHub
 Pages](https://pages.github.com/) after a successful build.


### PR DESCRIPTION
Adds warning that provider is experimental.

Since https://github.com/travis-ci/dpl/commit/c6696b38d2c5e5941d2aa51edbac94b066a9c4d2  deployments will show:
> !!! GitHub Pages support is experimental !!!

We should either remove the experimental warning, or add something to the documentation -the warning took me by surprise. Not sure what the warning should say, maybe this will do, I'll leave that up to your judgement :smile:

/cc @BanzaiMan