### PR TITLE
Remove mention of `release` option under julia: key

### DIFF
--- a/user/languages/julia.md
+++ b/user/languages/julia.md
@@ -29,7 +29,6 @@ versions, use the `julia:` key in your `.travis.yml` file, for example:
 ```yaml
 language: julia
 julia:
-  - release
   - nightly
   - 0.3
   - 0.3.10

--- a/user/languages/julia.md
+++ b/user/languages/julia.md
@@ -30,8 +30,8 @@ versions, use the `julia:` key in your `.travis.yml` file, for example:
 language: julia
 julia:
   - nightly
-  - 0.3
-  - 0.3.10
+  - 0.5
+  - 0.5.2
 ```
 
 If the version number contains one `.`, then the latest release for that minor version


### PR DESCRIPTION
The way Julia's package manager works, the minimum supported Julia version for a package is set in a `REQUIRE` file. The Julia versions tested on Travis should generally start with the minimum supported Julia version (consistent with `REQUIRE`), plus anything newer that the package maintainer wants to also support and test against. The use of `release` is a bit harmful in that respect, since packages that haven't seen any activity in a while will gradually stop testing against the release Julia versions that they claim to support according to their `REQUIRE` file. We've modified the package template's `.travis.yml` to instead favor using specific version numbers. I'll be submitting a set of pull requests to existing packages to encourage them to do the same. Once it's no longer in use, I would like to deprecate and eventually remove the option from the `language: julia` code on Travis. If a package author doesn't care what they're testing against, they can leave off the `julia:` key and we'll adjust the default when new releases are available, as we would have done to update the `release` value.

If we wanted to get really fancy we could maybe look into parsing the `REQUIRE` file if present to automatically decide which versions Travis should test against, but the format of that information is due to change somewhat soon.

cc @staticfloat @ninjin @simonbyrne 