### PR TITLE
Update Perl 6 docs

### DIFF
--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -23,12 +23,12 @@ versions that your projects can be tested against. To specify them, use the
 language: perl6
 perl6:
   - latest
-  - '2015.07'
-  - '2015.04'
+  - '2017.05'
+  - '2017.04'
 ```
 
 Over time, new releases come out and we upgrade both rakudobrew and
-Perls, aliases like `2015.07` will float and point to different exact
+Perls, aliases like `2017.05` will float and point to different exact
 versions, patch levels and so on.
 
 For precise versions pre-installed on the VM, please consult "Build system
@@ -136,8 +136,9 @@ perl6:
 ```yaml
 language: perl6
 perl6:
-    - latest
-    - '2015.03'
+    - '2017.05'
+    - '2017.04'
+
 install:
     - rakudobrew build-panda ${TRAVIS_PERL6_VERSION#latest}
     - panda installdeps .

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -61,33 +61,16 @@ PERL6LIB=lib prove -v -r --exec=perl6 t/
 At present, by default Travis CI does not automatically manage your
 project's dependencies.  It is possible to manage dependencies yourself by
 either downloading and installing your dependencies as part of the `install`
-step, or you could use [panda](https://github.com/tadzik/panda) (the Perl 6
+step, or you could use [zef](https://github.com/ugexe/zef) (the Perl 6
 module package manager) like so:
 
 ```yaml
 install:
-    - rakudobrew build-panda
-    - panda installdeps .
+    - rakudobrew build-zef
+    - zef --debug install .
 ```
 
-this will install the latest `panda` version.
-
-It is sometimes necessary to match the `panda` version to that of Rakudo;
-new Rakudo features could be used in the most up to date `panda` which
-aren't available in the version of Rakudo you are using.  For instance, to
-test a module against Rakudo 2015.04, you would have a `.travis.yml` which
-looks something like this:
-
-```yaml
-language: perl6
-perl6:
-    - '2015.07'
-install:
-    - rakudobrew build-panda 2015.07
-```
-
-Now your `panda` will match your Rakudo version and should install
-the relevant dependencies successfully.
+this will install the latest `zef` version.
 
 Further information about overriding dependency installation commands is
 described in the [general build configuration](/user/customizing-the-build/)
@@ -120,28 +103,27 @@ TRAVIS_PERL6_VERSION
 
 ```yaml
 language: perl6
+
+perl6:
+    - latest
+
+install:
+    - rakudobrew build-zef
+    - zef --debug install .
 ```
 
 ### Build and test with multiple Rakudo versions
 
 ```yaml
 language: perl6
-perl6:
-    - '2015.06'
-    - '2015.05'
-```
 
-### Build and test with matching Rakudo and panda versions
-
-```yaml
-language: perl6
 perl6:
     - '2017.05'
     - '2017.04'
 
 install:
-    - rakudobrew build-panda ${TRAVIS_PERL6_VERSION#latest}
-    - panda installdeps .
+    - rakudobrew build-zef
+    - zef --debug install .
 ```
 
 ### Build and test with the latest Rakudo, but with non-standard lib and test dirs
@@ -152,6 +134,7 @@ library code under `lib/` and the tests under `t/`.
 
 ```yaml
 language: perl6
+
 script:
     - PERL6LIB=src prove -v -r --exec=perl6 tests/
 ```


### PR DESCRIPTION
This PR gives the Perl 6 docs a much needed update.  The biggest change here is to replace the discontinued module installer (`panda`) with the current module installer (`zef`).