### PR TITLE
Keep webhook payload up to date automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,15 @@ deploy:
   app: docs-travis-ci-com
   skip_cleanup: true
   on:
-    branch: gh-pages
+    branch:
+    - gh-pages
 notifications:
   slack:
     rooms:
       secure: LPNgf0Ra6Vu6I7XuK7tcnyFWJg+becx1RfAR35feWK81sru8TyuldQIt7uAKMA8tqFTP8j1Af7iz7UDokbCCfDNCX1GxdAWgXs+UKpwhO89nsidHAsCkW2lWSEM0E3xtOJDyNFoauiHxBKGKUsApJTnf39H+EW9tWrqN5W2sZg8=
     on_success: never
+  webhooks:
+    https://docs.travis-ci.com/update_doc_webhook_payload
 install:
   - bundle install --deployment
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ notifications:
       secure: LPNgf0Ra6Vu6I7XuK7tcnyFWJg+becx1RfAR35feWK81sru8TyuldQIt7uAKMA8tqFTP8j1Af7iz7UDokbCCfDNCX1GxdAWgXs+UKpwhO89nsidHAsCkW2lWSEM0E3xtOJDyNFoauiHxBKGKUsApJTnf39H+EW9tWrqN5W2sZg8=
     on_success: never
   webhooks:
-    https://docs.travis-ci.com/update_doc_webhook_payload
+    https://docs.travis-ci.com/update_webhook_payload_doc
 install:
   - bundle install --deployment
 before_script:

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'rack-jekyll'
 gem 'rack-ssl-enforcer'
 gem 'puma'
 
+gem 'faraday'
+
 gem 'rake'
 
 gem 'html-proofer', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,8 @@ GEM
     concurrent-ruby (1.0.5)
     ethon (0.10.1)
       ffi (>= 1.3.0)
+    faraday (0.12.0.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     forwardable-extended (2.6.0)
     html-proofer (3.6.0)
@@ -51,6 +53,7 @@ GEM
     mercenary (0.3.6)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    multipart-post (2.0.0)
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     parallel (1.11.1)
@@ -83,6 +86,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  faraday
   html-proofer (~> 3.0)
   jekyll (>= 3.1.6)
   jekyll-paginate
@@ -94,4 +98,4 @@ DEPENDENCIES
   rdiscount (>= 2.2.0.1)
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/_plugins/post_handler.rb
+++ b/_plugins/post_handler.rb
@@ -1,0 +1,30 @@
+require 'net/http'
+require 'base64'
+require 'openssl'
+
+class Handler
+  def call(env)
+    req = Rack::Request.new(env)
+    res = Rack::Response.new(["Not found"], 404)
+
+    return res unless req.post?
+
+    payload = JSON.load(req.body.read)['payload'].to_json
+    sig = Base64.decode64 env["HTTP_SIGNATURE"]
+
+    config_data = JSON.load Net::HTTP.get(URI('https://api.travis-ci.org/config'))
+    public_key = config_data["config"]["notifications"]["webhook"]["public_key"]
+
+    pkey = OpenSSL::PKey::RSA.new(public_key)
+
+    if pkey.verify(OpenSSL::Digest::SHA1.new, sig, payload)
+      # do stuff
+      res.body = ["Signature is valid"]
+      res.status = 200
+    else
+      res.body = ["Signature is invalid"]
+      res.status = 400
+    end
+    res
+  end
+end

--- a/_plugins/select_env_var_generator.rb
+++ b/_plugins/select_env_var_generator.rb
@@ -1,0 +1,12 @@
+class SelectEnvVarGenerator < Jekyll::Generator
+  ENVS = %w(
+    WEBHOOK_PAYLOAD_GIST_ID
+  )
+  def generate(site)
+    site.config['env'] = {}
+
+    ENVS.each do |env|
+      site.config['env'][env] = ENV[env]
+    end
+  end
+end

--- a/_plugins/webhoook_payload_doc_handler.rb
+++ b/_plugins/webhoook_payload_doc_handler.rb
@@ -5,7 +5,6 @@ require 'openssl'
 class WebhookPayloadDocHandler
   def call(env)
     req = Rack::Request.new(env)
-    res = Rack::Response.new(["Not found"], 404)
 
     return res unless req.post?
 
@@ -19,12 +18,19 @@ class WebhookPayloadDocHandler
 
     if pkey.verify(OpenSSL::Digest::SHA1.new, sig, payload)
       # do stuff
-      res.body = ["Signature is valid"]
-      res.status = 200
+      Rack::Response.new(
+        [{"result" => "success", "message" => "Signature is valid"}.to_json],
+        200,
+        {"Content-Type" => "application/json"}
+      )
     else
-      res.body = ["Signature is invalid"]
-      res.status = 400
+      Rack::Response.new(
+        [{"result" => "error", "message" => "Signature is invalid"}.to_json],
+        400,
+        {"Content-Type" => "application/json"}
+      )
     end
-    res
+  rescue
+    Rack::Response.new(["Internal server error"], 500)
   end
 end

--- a/_plugins/webhoook_payload_doc_handler.rb
+++ b/_plugins/webhoook_payload_doc_handler.rb
@@ -40,7 +40,7 @@ class WebhookPayloadDocHandler
       return gist_update_failure_response
     end
   rescue
-    Rack::Response.new(["Internal server error"], 500)
+    json_response(result: 'error', message: 'Internal server error', status: 500)
   end
 
   private
@@ -66,35 +66,27 @@ class WebhookPayloadDocHandler
     }.to_json
   end
 
-  def invalid_req_response
+  def json_response(result:, message:, status: 200)
     Rack::Response.new(
-      [{"result" => "error", "message" => "Invalid request"}.to_json],
-      400,
+      [{"result" => result, "message" => message}.to_json],
+      status,
       {"Content-Type" => "application/json"}
     )
+  end
+
+  def invalid_req_response
+    json_response(result: 'error', message: 'Invalid request.', status: 400)
   end
 
   def invalid_sig_response
-    Rack::Response.new(
-      [{"result" => "error", "message" => "Signature is invalid"}.to_json],
-      400,
-      {"Content-Type" => "application/json"}
-    )
+    json_response(result: 'error', message: 'Invalid signature.', status: 400)
   end
 
   def valid_sig_response
-    Rack::Response.new(
-      [{"result" => "success", "message" => "Signature is valid"}.to_json],
-      200,
-      {"Content-Type" => "application/json"}
-    )
+    json_response(result: 'success', message: 'Signature is valid.')
   end
 
   def gist_update_failure_response
-    Rack::Response.new(
-      [{"result" => "success", "message" => "Signature is valid, but gist update failed"}.to_json],
-      200,
-      {"Content-Type" => "application/json"}
-    )
+    json_response(result: 'success', message: 'Signature is valid, but gist update failed.')
   end
 end

--- a/_plugins/webhoook_payload_doc_handler.rb
+++ b/_plugins/webhoook_payload_doc_handler.rb
@@ -22,20 +22,20 @@ class WebhookPayloadDocHandler
 
     pkey = OpenSSL::PKey::RSA.new(public_key)
 
-    if pkey.verify(OpenSSL::Digest::SHA1.new, sig, payload)
-      # do stuff
-      Rack::Response.new(
-        [{"result" => "success", "message" => "Signature is valid"}.to_json],
-        200,
-        {"Content-Type" => "application/json"}
-      )
-    else
-      Rack::Response.new(
+    unless pkey.verify(OpenSSL::Digest::SHA1.new, sig, payload)
+      return Rack::Response.new(
         [{"result" => "error", "message" => "Signature is invalid"}.to_json],
         400,
         {"Content-Type" => "application/json"}
       )
     end
+
+    # do stuff
+    Rack::Response.new(
+      [{"result" => "success", "message" => "Signature is valid"}.to_json],
+      200,
+      {"Content-Type" => "application/json"}
+    )
   rescue
     Rack::Response.new(["Internal server error"], 500)
   end

--- a/_plugins/webhoook_payload_doc_handler.rb
+++ b/_plugins/webhoook_payload_doc_handler.rb
@@ -2,7 +2,7 @@ require 'net/http'
 require 'base64'
 require 'openssl'
 
-class Handler
+class WebhookPayloadDocHandler
   def call(env)
     req = Rack::Request.new(env)
     res = Rack::Response.new(["Not found"], 404)

--- a/_plugins/webhoook_payload_doc_handler.rb
+++ b/_plugins/webhoook_payload_doc_handler.rb
@@ -1,42 +1,100 @@
-require 'net/http'
+require 'faraday'
 require 'base64'
 require 'openssl'
 
 class WebhookPayloadDocHandler
+  DEFAULT_API_HOST = 'https://api.travis-ci.org'
+  API_HOST = ENV.fetch('API_HOST', DEFAULT_API_HOST)
+
   def call(env)
     req = Rack::Request.new(env)
+    gist_token = ENV['TRAVISBOT_GIST_TOKEN']
+    payload_gist_id = ENV['WEBHOOK_PAYLOAD_GIST_ID']
 
-    unless req.post?
-      return Rack::Response.new(
-        [{"result" => "error", "message" => "Invalid request"}.to_json],
-        400,
-        {"Content-Type" => "application/json"}
-      )
+    unless req.post? && gist_token && payload_gist_id
+      return invalid_req_response
     end
 
-    payload = JSON.load(req.body.read)['payload'].to_json
+    payload = URI.decode(req.params["payload"])
     sig = Base64.decode64 env["HTTP_SIGNATURE"]
-
-    config_data = JSON.load Net::HTTP.get(URI('https://api.travis-ci.org/config'))
-    public_key = config_data["config"]["notifications"]["webhook"]["public_key"]
 
     pkey = OpenSSL::PKey::RSA.new(public_key)
 
     unless pkey.verify(OpenSSL::Digest::SHA1.new, sig, payload)
-      return Rack::Response.new(
-        [{"result" => "error", "message" => "Signature is invalid"}.to_json],
-        400,
-        {"Content-Type" => "application/json"}
-      )
+      return invalid_sig_response
     end
 
-    # do stuff
+    conn = Faraday.new(:url => "https://api.github.com") do |faraday|
+      faraday.adapter Faraday.default_adapter
+    end
+
+    response = conn.patch "/gists/#{payload_gist_id}" do |req|
+      req.headers["Content-Type"] = 'application/json'
+      req.headers["Authorization"] = "token #{gist_token}"
+      req.body = gist_update_body(payload)
+    end
+
+    if response.success?
+      return valid_sig_response
+    else
+      return gist_update_failure_response
+    end
+  rescue
+    Rack::Response.new(["Internal server error"], 500)
+  end
+
+  private
+  def public_key
+    return @public_key if @public_key
+
+    conn = Faraday.new(:url => API_HOST) do |faraday|
+      faraday.adapter Faraday.default_adapter
+    end
+    response = conn.get '/config'
+    @public_key = JSON.parse(response.body)["config"]["notifications"]["webhook"]["public_key"]
+  rescue
+    ''
+  end
+
+  def gist_update_body(payload)
+    {
+      "files" => {
+        "webhookpayload.json" => {
+          "content" => JSON.pretty_generate(JSON.load(payload))
+        }
+      }
+    }.to_json
+  end
+
+  def invalid_req_response
+    Rack::Response.new(
+      [{"result" => "error", "message" => "Invalid request"}.to_json],
+      400,
+      {"Content-Type" => "application/json"}
+    )
+  end
+
+  def invalid_sig_response
+    Rack::Response.new(
+      [{"result" => "error", "message" => "Signature is invalid"}.to_json],
+      400,
+      {"Content-Type" => "application/json"}
+    )
+  end
+
+  def valid_sig_response
     Rack::Response.new(
       [{"result" => "success", "message" => "Signature is valid"}.to_json],
       200,
       {"Content-Type" => "application/json"}
     )
-  rescue
-    Rack::Response.new(["Internal server error"], 500)
+  end
+
+  def gist_update_failure_response
+    Rack::Response.new(
+      [{"result" => "success", "message" => "Signature is valid, but gist update failed"}.to_json],
+      200,
+      {"Content-Type" => "application/json"}
+    )
   end
 end

--- a/_plugins/webhoook_payload_doc_handler.rb
+++ b/_plugins/webhoook_payload_doc_handler.rb
@@ -6,7 +6,13 @@ class WebhookPayloadDocHandler
   def call(env)
     req = Rack::Request.new(env)
 
-    return res unless req.post?
+    unless req.post?
+      return Rack::Response.new(
+        [{"result" => "error", "message" => "Invalid request"}.to_json],
+        400,
+        {"Content-Type" => "application/json"}
+      )
+    end
 
     payload = JSON.load(req.body.read)['payload'].to_json
     sig = Base64.decode64 env["HTTP_SIGNATURE"]

--- a/config.ru
+++ b/config.ru
@@ -5,8 +5,8 @@ require 'rack-ssl-enforcer'
 use Rack::SslEnforcer, :except_environments => 'development'
 
 app = Rack::Builder.app do
-  map '/update_doc_webhook_payload' do
-    run Handler.new
+  map '/update_webhook_payload_doc' do
+    run WebhookPayloadDocHandler.new
   end
 
   run Rack::Jekyll.new

--- a/config.ru
+++ b/config.ru
@@ -4,9 +4,23 @@ require 'rack-ssl-enforcer'
 
 use Rack::SslEnforcer, :except_environments => 'development'
 
+class PatchMethodOnly
+  def initialize app
+    @app = app
+  end
+
+  def call env
+    if Rack::Request.new(env).post?
+      WebhookPayloadDocHandler.new.call(env)
+    else
+      Rack::Jekyll.new.call(env)
+    end
+  end
+end
+
 app = Rack::Builder.app do
   map '/update_webhook_payload_doc' do
-    run WebhookPayloadDocHandler.new
+    use PatchMethodOnly
   end
 
   run Rack::Jekyll.new

--- a/config.ru
+++ b/config.ru
@@ -4,4 +4,12 @@ require 'rack-ssl-enforcer'
 
 use Rack::SslEnforcer, :except_environments => 'development'
 
-run Rack::Jekyll.new
+app = Rack::Builder.app do
+  map '/update_doc_webhook_payload' do
+    run Handler.new
+  end
+
+  run Rack::Jekyll.new
+end
+
+run app

--- a/user/notifications.md
+++ b/user/notifications.md
@@ -693,40 +693,6 @@ run. Its value is one of `push`, `pull_request`, `cron`, or `api`.  For pull req
 the `type` field will have the value `pull_request`, and a `pull_request_number` field
 is included too, pointing to the pull request's issue number on GitHub.
 
-Here is a simple example of a [Sinatra](http://sinatrarb.com) app to decode the request and the payload:
-
-```ruby
-require 'sinatra'
-require 'json'
-require 'digest/sha2'
-
-class TravisWebhook < Sinatra::Base
-  set :token, ENV['TRAVIS_USER_TOKEN']
-
-  post '/' do
-    if not valid_request?
-      puts "Invalid payload request for repository #{repo_slug}"
-    else
-      payload = JSON.parse(params[:payload])
-      puts "Received valid payload for repository #{repo_slug}"
-    end
-  end
-
-  def valid_request?
-    digest = Digest::SHA2.new.update("#{repo_slug}#{settings.token}")
-    digest.to_s == authorization
-  end
-
-  def authorization
-    env['HTTP_AUTHORIZATION']
-  end
-
-  def repo_slug
-    env['HTTP_TRAVIS_REPO_SLUG']
-  end
-end
-```
-
 To quickly identify the repository involved, we include a `Travis-Repo-Slug` header, with a format of `account/repository`, so for instance `travis-ci/travis-ci`.
 
 ### Verifying Webhook requests
@@ -746,11 +712,17 @@ payload.
    (e.g., <https://api.travis-ci.org/config>)
 4. Verify the signature using the public key and SHA1 digest.
 
-[WebhookSignatureVerifier](https://github.com/travis-ci/webhook-signature-verifier)
+#### Examples
+
+1. [WebhookSignatureVerifier](https://github.com/travis-ci/webhook-signature-verifier)
 is a small Sinatra app which shows you how this works.
 
-[Travis Webhook Checker](https://gist.github.com/andrewgross/8ba32af80ecccb894b82774782e7dcd4)
+1. This documentation site receives a webhook notification, verifies the request
+and updates the Gist showing the payload example above.
+See [the code](https://github.com/travis-ci/docs-travis-ci-com/tree/gh-pages/_plugins/webhoook_payload_doc_handler.rb).
+
+1. [Travis Webhook Checker](https://gist.github.com/andrewgross/8ba32af80ecccb894b82774782e7dcd4)
 is an example Django view which implements this in Python.
 
-[Travis Golang Hooks Verification](https://gist.github.com/theshapguy/7d10ea4fa39fab7db393021af959048e)
+1. [Travis Golang Hooks Verification](https://gist.github.com/theshapguy/7d10ea4fa39fab7db393021af959048e)
 is a small webapp in Go which verifies the the hook.

--- a/user/notifications.md
+++ b/user/notifications.md
@@ -670,7 +670,7 @@ Webhooks are delivered with a `application/x-www-form-urlencoded` content type u
 
 Here's an example of what you'll find in the `payload`:
 
-<script src="https://gist.github.com/roidrage/9272064.js"></script>
+<script src="https://gist.github.com/{{ site.env.WEBHOOK_PAYLOAD_GIST_ID }}.js"></script>
 
 You will see one of the following values in the `status`/`result` fields that represent the state of the build.
 

--- a/user/notifications.md
+++ b/user/notifications.md
@@ -668,7 +668,7 @@ notifications:
 
 Webhooks are delivered with a `application/x-www-form-urlencoded` content type using HTTP POST, with the body including a `payload` parameter that contains the JSON webhook payload in a URL-encoded format.
 
-Here's an example of what you'll find in the `payload`:
+Here is the payload sent to [the Travis CI documentation application](https://github.com/travis-ci/docs-travis-ci-com):
 
 <script src="https://gist.github.com/{{ site.env.WEBHOOK_PAYLOAD_GIST_ID }}.js"></script>
 


### PR DESCRIPTION
This PR adds a POST endpoint, which is only valid at `/update_doc_webhook_payload`.

The idea here is that the docs app will receive the live (and hence always up-to-date) webhook payload, and update the gist (to be determined later) with that payload when we receive a POST request on the new endpoint.

This resolves https://github.com/travis-ci/docs-travis-ci-com/issues/1199.