### PR TITLE
Add env variables for AWS credentials in S3 deployment

### DIFF
--- a/user/deployment/s3.md
+++ b/user/deployment/s3.md
@@ -11,8 +11,8 @@ For a minimal configuration, add the following to your `.travis.yml`:
 ```yaml
 deploy:
   provider: s3
-  access_key_id: "YOUR AWS ACCESS KEY"
-  secret_access_key: "YOUR AWS SECRET KEY"
+  access_key_id: $AWS_ACCESS_KEY # Set in travis-ci.org dashboard
+  secret_access_key: $AWS_SECRET_KEY # Set in travis-ci.org dashboard
   bucket: "S3 Bucket"
 ```
 
@@ -27,8 +27,8 @@ The previous example is almost certainly not ideal, as you probably want to uplo
 ```yaml
 deploy:
   provider: s3
-  access_key_id: "YOUR AWS ACCESS KEY"
-  secret_access_key: "YOUR AWS SECRET KEY"
+  access_key_id: $AWS_ACCESS_KEY # Set in travis-ci.org dashboard
+  secret_access_key: $AWS_SECRET_KEY # Set in travis-ci.org dashboard
   bucket: "S3 Bucket"
   skip_cleanup: true
 ```
@@ -50,8 +50,8 @@ You can set the acl of your uploaded files via the `acl` option like this:
 ```yaml
 deploy:
   provider: s3
-  access_key_id: "YOUR AWS ACCESS KEY"
-  secret_access_key: "YOUR AWS SECRET KEY"
+  access_key_id: $AWS_ACCESS_KEY # Set in travis-ci.org dashboard
+  secret_access_key: $AWS_SECRET_KEY # Set in travis-ci.org dashboard
   bucket: "S3 Bucket"
   skip_cleanup: true
   acl: public_read
@@ -123,8 +123,8 @@ This can be resolved by specifying your bucket's region using the `region` confi
 ```yaml
 deploy:
   provider: s3
-  access_key_id: "YOUR AWS ACCESS KEY"
-  secret_access_key: "YOUR AWS SECRET KEY"
+  access_key_id: $AWS_ACCESS_KEY # Set in travis-ci.org dashboard
+  secret_access_key: $AWS_SECRET_KEY # Set in travis-ci.org dashboard
   bucket: "S3 Bucket"
   skip_cleanup: true
   region: eu-west-1
@@ -137,8 +137,8 @@ Often, you don't want to upload your entire project to S3. You can tell Travis C
 ```yaml
 deploy:
   provider: s3
-  access_key_id: "YOUR AWS ACCESS KEY"
-  secret_access_key: "YOUR AWS SECRET KEY"
+  access_key_id: $AWS_ACCESS_KEY # Set in travis-ci.org dashboard
+  secret_access_key: $AWS_SECRET_KEY # Set in travis-ci.org dashboard
   bucket: "S3 Bucket"
   skip_cleanup: true
   local_dir: build
@@ -151,8 +151,8 @@ Often, you want to upload only to a specific S3 Folder. You can use the `upload-
 ```yaml
 deploy:
   provider: s3
-  access_key_id: "YOUR AWS ACCESS KEY"
-  secret_access_key: "YOUR AWS SECRET KEY"
+  access_key_id: $AWS_ACCESS_KEY # Set in travis-ci.org dashboard
+  secret_access_key: $AWS_SECRET_KEY # Set in travis-ci.org dashboard
   bucket: "S3 Bucket"
   skip_cleanup: true
   upload-dir: travis-builds
@@ -165,8 +165,8 @@ To upload to a S3 hosted website, to use this template to upload to your website
 ```yaml
 deploy:
   provider: s3
-  access_key_id: "YOUR AWS ACCESS KEY"
-  secret_access_key: "YOUR AWS SECRET KEY"
+  access_key_id: $AWS_ACCESS_KEY # Set in travis-ci.org dashboard
+  secret_access_key: $AWS_SECRET_KEY # Set in travis-ci.org dashboard
   bucket: "S3 Bucket"
   skip_cleanup: true
   region: "Bucket region"
@@ -181,13 +181,13 @@ If you want to upload to multiple buckets, you can do this:
 ```yaml
 deploy:
   - provider: s3
-    access_key_id: "YOUR AWS ACCESS KEY"
-    secret_access_key: "YOUR AWS SECRET KEY"
+  access_key_id: $AWS_ACCESS_KEY # Set in travis-ci.org dashboard
+  secret_access_key: $AWS_SECRET_KEY # Set in travis-ci.org dashboard
     bucket: "S3 Bucket"
     skip_cleanup: true
   - provider: s3
-    access_key_id: "YOUR AWS ACCESS KEY"
-    secret_access_key: "YOUR AWS SECRET KEY"
+  access_key_id: $AWS_ACCESS_KEY # Set in travis-ci.org dashboard
+  secret_access_key: $AWS_SECRET_KEY # Set in travis-ci.org dashboard
     bucket: "Second S3 Bucket"
     skip_cleanup: true
 ```


### PR DESCRIPTION
Putting AWS credentials directly in `.travis.yml` file is not a great idea because then anyone can use the same. This PR adds basic security step of putting AWS credentials in env variables in travis-ci dashboard and later using it in `.travis.yml` file.