### PR TITLE
Remove whitespace around list items

### DIFF
--- a/user/osx-ci-environment.md
+++ b/user/osx-ci-environment.md
@@ -192,12 +192,10 @@ Xcode {{ image.xcode_full_version }} is available by adding `osx_image: {{ image
 Our Xcode {{ image.xcode_full_version }} images have the following SDKs preinstalled:
 
 {% for sdk in image.sdks %}
-- {{ sdk }}
-{% endfor %}
+- {{ sdk }}{% endfor %}
 
 The Xcode {{ image.xcode_full_version }} image also comes with the following simulators:
 {% for simulator in image.simulators %}
-- {{ simulator }}
-{% endfor %}
+- {{ simulator }}{% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
Firefox was showing the text of each line item beneath
its bullet. See here:
https://travisci.slack.com/archives/teal/p1462462487001036

This unsightly template formation seems required to prevent
the generated whitespace being interpreted as paragraphs
in Markdown. See this discussion:
https://github.com/Shopify/liquid/issues/216