### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,48 +7,63 @@ This is the documentation site for Travis CI! (<http://docs.travis-ci.com/>)
 Fork the repository, read the rest of this README file and make some changes.
 Once you're done with your changes send a pull request. Thanks!
 
-## How to edit the site
+## How to check your edit before sending PR
 
-Make sure you have Ruby and RubyGems installed. Next install
-[bundler](http://bundler.io/):
+You can inspect how your edits will be reflected by the documentation site.
 
-```bash
-gem install bundler
+### Install dependencies
+
+1. Make sure you have Ruby and RubyGems installed.
+
+1. Install [bundler](http://bundler.io/):
+
+    ```sh-session
+    $ gem install bundler
+    ```
+
+1. Install application dependencies:
+
+    ```sh-session
+    $ bundle install --binstubs
+    ```
+
+### Generate documentation
+
+Run
+
+```sh-session
+$ ./bin/jekyll build
 ```
 
-Then install dependencies:
 
-```bash
-bundle install --binstubs
-```
+### Run application server
 
-In order to run a local Web server that will serve documentation site, first generate files:
+You are now ready to start your documentation site, using Jekyll or Puma.
+For documentation edits, Jekyll is sufficient.
 
-```bash
-export LANGUAGE_FILE_JSON=https://raw.githubusercontent.com/travis-infrastructure/terraform-config/master/aws-production-2/generated-language-mapping.json
-curl -O -sfSL $LANGUAGE_FILE_JSON
-erb -r json user/common-build-problems.md.erb | tee user/common-build-problems.md
-```
+#### Starting and inspecting edits with Jekyll
 
-then run Jekyll server:
+1. Run Jekyll server:
 
-```bash
-./bin/jekyll serve
-```
+    ```sh-session
+    $ ./bin/jekyll serve
+    ```
 
-and then open [localhost:4000](http://localhost:4000/) in your browser.
+1. Open [localhost:4000](http://localhost:4000/) in your browser.
 
-To regenerate the HTML pages automatically when you make changes to Markdown source files, use
+#### Starting and inspecting edits with Puma
 
-```bash
-./bin/jekyll serve --watch
-```
+For more programmatical PRs (such as handling webhooks notification
+via POST), Puma is necessary.
 
-Note that quoted entities may be escaped or unescaped depending on the Ruby
-version (1.8 vs. 1.9) used. It is normal.
+1. Run Puma server:
+
+    ```sh-session
+    $ ./bin/puma
+    ```
+
+1. Open [localhost:9292](http://localhost:9292/) in your browser.
 
 ## License
 
 Distributed under the [MIT license](https://opensource.org/licenses/MIT); the same as other Travis CI projects.
-
-***


### PR DESCRIPTION
* Remove bits about generating common-build-problems doc
* Explain `jekyll` and `puma` as application servers for local testing