### PR TITLE
Fix GitHub edit link

### DIFF
--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -14,7 +14,7 @@
 
         <main id="main" class="main" data-swiftype-index='true'>
           {% unless page.no_header %}
-            <aside class="improve-page"><a href="{{ site.docs_github }}edit/gh-pages/{{ page.path }}" target="_blank" title="Edit this page on GitHub" class="button-pen" data-proofer-ignore>Improve this page on GitHub</a></aside>
+            <aside class="improve-page"><a href="{{ site.docs_github }}edit/master/{{ page.path }}" target="_blank" title="Edit this page on GitHub" class="button-pen" data-proofer-ignore>Improve this page on GitHub</a></aside>
             <h1 class="title">{{ page.title }}</h1>
           {% endunless %}
           {{ content }}


### PR DESCRIPTION
We changed the default branch name from `gh-pages` to `master`.