### PR TITLE
Removed 'master' from the first line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-master# About this repository [![Build Status](https://travis-ci.org/travis-ci/docs-travis-ci-com.svg?branch=master)](https://travis-ci.org/travis-ci/docs-travis-ci-com)
+# About this repository [![Build Status](https://travis-ci.org/travis-ci/docs-travis-ci-com.svg?branch=master)](https://travis-ci.org/travis-ci/docs-travis-ci-com)
 
 This is the documentation site for Travis CI! (<http://docs.travis-ci.com/>)
 


### PR DESCRIPTION
There seems to be the word `master` at the very beggining of your readme for no obvious reason. It is also stoping the `h1` on that line being parsed correctly.

![image](https://cloud.githubusercontent.com/assets/18352787/26766118/cc1c6ce6-4982-11e7-9260-490b20a79f72.png)

This PR simpily removes the word, which should fix the broken rendering too.



