### PR TITLE
Add docs for support for message in Firebase provider

### DIFF
--- a/user/deployment/firebase.md
+++ b/user/deployment/firebase.md
@@ -40,6 +40,18 @@ deploy:
   project: "myapp-staging"
 ```
 
+## Adding a message to a deployment
+
+To add a message to describe the deployment, use the `message` key in your `.travis.yml`:
+
+```yaml
+deploy:
+  provider: firebase
+  token:
+    secure: "YOUR ENCRYPTED token"
+  message: "your message"
+```
+
 ## Running commands before and after deploy
 
 Sometimes you want to run commands before or after deploying. You can use


### PR DESCRIPTION
Adds docs for support for adding optional messages when deploying with the Firebase provider.

See travis-ci/dpl#651 for main PR.

Fixes travis-ci/travis-ci#7872