### PR TITLE
Generate table for on-demand Python runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tmp/
 node_modules
 generated-language-mapping.json
 _data/trusty_mapping_data.yml
+_data/language_archives.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 branches:
   only:
   - master
+  - staging
 env:
   global:
     - PATH=$HOME/.local/user/bin:$PATH
@@ -16,14 +17,22 @@ cache:
     - vendor/bundle
     - node_modules
 deploy:
-  provider: heroku
-  api_key:
-    secure: "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
-  app: docs-travis-ci-com
-  skip_cleanup: true
-  on:
-    branch:
-    - master
+  - provider: heroku
+    api_key:
+      secure: "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
+    app: docs-travis-ci-com
+    skip_cleanup: true
+    on:
+      branch:
+      - master
+  - provider: heroku
+    api_key:
+      secure: "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
+    app: docs-staging-travis-ci-com
+    skip_cleanup: true
+    on:
+      branch:
+      - staging
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,13 @@ deploy:
   - provider: heroku
     api_key:
       secure: "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
-    app: docs-travis-ci-com
+    app:
+      master: docs-travis-ci-com
+      staging: docs-staging-travis-ci-com
     skip_cleanup: true
     on:
       branch:
       - master
-  - provider: heroku
-    api_key:
-      secure: "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
-    app: docs-staging-travis-ci-com
-    skip_cleanup: true
-    on:
-      branch:
       - staging
 notifications:
   slack:

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'rack-ssl-enforcer'
 gem 'puma'
 
 gem 'faraday'
+gem 'aws-sdk'
 
 gem 'rake'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,14 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
+    aws-sdk (2.9.7)
+      aws-sdk-resources (= 2.9.7)
+    aws-sdk-core (2.9.7)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.9.7)
+      aws-sdk-core (= 2.9.7)
+    aws-sigv4 (1.0.0)
     colorator (1.1.0)
     colored (1.2)
     concurrent-ruby (1.0.5)
@@ -45,6 +53,7 @@ GEM
       sass (~> 3.4)
     jekyll-watch (1.5.0)
       listen (~> 3.0, < 3.1)
+    jmespath (1.3.1)
     kramdown (1.13.2)
     liquid (3.0.6)
     listen (3.0.8)
@@ -86,6 +95,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk
   faraday
   html-proofer (~> 3.0)
   jekyll (>= 3.1.6)

--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -152,11 +152,16 @@ a recent development version of [CPython](https://bitbucket.org/mirror/cpython) 
 
 It also has the [packages above](#Pre-installed-packages) pre-installed.
 
-## On-demand installations
+## How Python Version is Chosen
 
-For a limited number of Python development releases, on-demand installation is available.
+When you specify Python versions, your job will first look for the runtime
+pre-installed on the image.
+If that version is not available, the job will fetch a pre-compiled
+archive that matches the version for the image the job is running on,
+and installed on demand.
 
-Currently, these are: `3.5-dev` (built nightly), `3.5`/`3.5.0`.
+For the complete list of Python runtimes available for on-demand installation,
+see [the table below](#python-runtime-list).
 
 ## Build Matrix
 
@@ -171,3 +176,55 @@ to construct a build matrix.
 - [dstufft/slumber](https://github.com/dstufft/slumber/blob/master/.travis.yml)
 - [dreid/cotools](https://github.com/dreid/cotools/blob/master/.travis.yml)
 - [twisted/klein](https://github.com/twisted/klein/blob/master/.travis.yml)
+
+## Python Versions Available for On-Demand Installation
+
+These Python runtimes are available for on-demand installation.
+
+<table id="python-runtime-list">
+  <tr>
+    <th>Python</th>
+    <th>Distribution</th>
+    <th>Versions</th>
+  </tr>
+  <tr>
+    <th rowspan="{{ site.data.language_archives.python.precise | size }}" text-align="top">Python</th>
+    <th rowspan="{{ site.data.language_archives.python.precise | size }}" text-align="top">Precise</th>
+    <td>{{ site.data.language_archives.python.precise[0] }}</td>
+  </tr>
+  {% for x in site.data.language_archives.python.precise offset:1 %}
+  <tr>
+    <td>{{ x }}</td>
+  </tr>
+  {% endfor %}
+  <tr>
+    <th rowspan="{{ site.data.language_archives.python.trusty | size }}" text-align="top">Python</th>
+    <th rowspan="{{ site.data.language_archives.python.trusty | size }}" text-align="top">Trusty</th>
+    <td>{{ site.data.language_archives.python.trusty[0] }}</td>
+  </tr>
+  {% for x in site.data.language_archives.python.trusty offset:1 %}
+  <tr>
+    <td>{{ x }}</td>
+  </tr>
+  {% endfor %}
+  <tr>
+    <th rowspan="{{ site.data.language_archives.pypy.precise | size }}" text-align="top">PyPy</th>
+    <th rowspan="{{ site.data.language_archives.pypy.precise | size }}" text-align="top">Precise</th>
+    <td>{{ site.data.language_archives.pypy.precise[0] }}</td>
+  </tr>
+  {% for x in site.data.language_archives.pypy.precise offset:1 %}
+  <tr>
+    <td>{{ x }}</td>
+  </tr>
+  {% endfor %}
+  <tr>
+    <th rowspan="{{ site.data.language_archives.pypy.trusty | size }}" text-align="top">PyPy</th>
+    <th rowspan="{{ site.data.language_archives.pypy.trusty | size }}" text-align="top">Trusty</th>
+    <td>{{ site.data.language_archives.pypy.trusty[0] }}</td>
+  </tr>
+  {% for x in site.data.language_archives.pypy.trusty offset:1 %}
+  <tr>
+    <td>{{ x }}</td>
+  </tr>
+  {% endfor %}
+</table>


### PR DESCRIPTION
This PR dynamically generates the list of Python archives available for on-demand installation.

It does so by fetching the list of archives available on S3, dumping the list into a YAML file, and reading it to generate the table. The table looks a little ugly as a source; I could not figure out a cleaner way to do that with `rowspan`.