### PR TITLE
Remove deprecated Heroku deployment strategies

### DIFF
--- a/user/deployment/heroku.md
+++ b/user/deployment/heroku.md
@@ -164,8 +164,6 @@ Travis CI supports different mechanisms for deploying to Heroku:
 
 - **api:** Uses Heroku's [Build API](https://devcenter.heroku.com/articles/build-and-release-using-the-api). This is the default strategy.
 - **git:** Does a `git push` over HTTPS.
-- **git-ssh:** Does a `git push` over SSH. This will generate a new key on every deployment.
-- **git-deploy-key:** Does a `git push` over SSH. It will reuse the same key on every deployment. This is only available for private projects.
 
 It defaults to **api**, but you can change that via the **strategy** option:
 
@@ -175,10 +173,6 @@ deploy:
   api_key: ...
   strategy: git
 ```
-
-> Note that the `git-ssh` and `git-deploy-key` strategies are **deprecated**, and will be shut
-> down on June 26th, 2017.
-> Please contact us if you have issues switching away from these.
 
 #### Using `.gitignore` on `git` strategy
 


### PR DESCRIPTION
These have been deprecated on 2017-06-26.