### PR TITLE
MariaDB uses root as user not travis

### DIFF
--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -224,7 +224,7 @@ addons:
   mariadb: '10.0'
 ```
 
-The version number is exported as the `TRAVIS_MARIADB_VERSION` environment variable.
+The version number is exported as the `TRAVIS_MARIADB_VERSION` environment variable. The dafult user is root.
 
 ## SQLite3
 


### PR DESCRIPTION
It is really nowhere to find what the user should be. If you are upgrading from mysql, or read the docs athe the begining you asume the user is travis