### PR TITLE
Fix "ccache on OS X example"

### DIFF
--- a/user/caching.md
+++ b/user/caching.md
@@ -157,7 +157,7 @@ ccache is not installed on OS X environments but you can install it by adding
 ```yaml
 install:
   - brew install ccache
-  - PATH=/usr/local/opt/ccache/libexec:$PATH
+  - export PATH="/usr/local/opt/ccache/libexec:$PATH"
 ```
 
 > Note that this creates wrappers around your default gcc and g++ compilers.


### PR DESCRIPTION
In order to make ccache available as the default compiler for the following commands, the modified PATH must be exported to the environment.