### PR TITLE
Make assets:precompile depend on build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,6 @@ task :serve => [:gen_trusty_image_data] do
 end
 
 namespace :assets do
-  task :precompile do
-    sh "bundle exec jekyll build"
+  task :precompile => [:build] do
   end
 end


### PR DESCRIPTION
This would indirectly invoke gen_trusty_image_data,
to ensure that we fetch the docker image data on deployment.

This resolves #1317.