### PR TITLE
Remove link to docs.basho.com

### DIFF
--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -341,7 +341,7 @@ services:
   - riak
 ```
 
-Riak uses the default configuration apart from the storage backend, which is [LevelDB](http://docs.basho.com/riak/kv/2.1.4/setup/planning/backend/leveldb/).
+Riak uses the default configuration apart from the storage backend, which is LevelDB.
 
 Riak Search is enabled.
 


### PR DESCRIPTION
It is yielding 403 now.

Given the state of Basho, it is highly unlikely to come back.
We'll simply remove the link.