### PR TITLE
Add build env update about old beta xcode 6.x deprecation

### DIFF
--- a/user/build-environment-updates/2017-08-17.md
+++ b/user/build-environment-updates/2017-08-17.md
@@ -1,0 +1,27 @@
+---
+title: Build Environment Update History
+layout: en
+permalink: /user/build-environment-updates/2017-08-17/
+category: build_env_updates
+date: 2017-08-17
+---
+
+## 2017-08-17
+
+### Schedule
+
+[2017-08-21 18:00 UTC](http://everytimezone.com/#2017-8-21,360,c8l)
+
+### Updated
+
+- As previously communicated, Xcode beta versions 6.1, 6.2, and 6.3 are being deprecated. 
+Projects configured with values of `beta-xcode6.1`, `beta-xcode6.2`, or `beta-xcode6.3` 
+for the `osx_image` tag will now be run on our [default OS X image](https://docs.travis-ci.com/user/reference/osx/#OS-X-Version).
+
+- Users will be able to run on Xcode 6.4 by specifying `osx_image: xcode-6.4` in
+their project configuration.
+
+### Details
+
+- More information about the differences between the new Xcode 7.3 default image and
+the previous Xcode 6.1 image can be found [here](https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/).


### PR DESCRIPTION
These images have been deprecated since December/January, this lets people know that they are actually being run on 7.3, not 6.4 (unless they specify 6.4).