### PR TITLE
Fix apt-get command for updating Docker

### DIFF
--- a/user/docker.md
+++ b/user/docker.md
@@ -188,7 +188,7 @@ updating it in the `before_install` step of your `.travis.yml`:
 ```yaml
 before_install:
   - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 ```
 
 **Updating from download.docker.com**


### PR DESCRIPTION
Using "docker-engine" caused a missing package error. Changing it to "docker-ce" fixed it.