### PR TITLE
Recommend deploy.if over deploy.on

### DIFF
--- a/user/build-stages/deploy-github-releases.md
+++ b/user/build-stages/deploy-github-releases.md
@@ -22,7 +22,7 @@ jobs:
         provider: releases
         api_key: $GITHUB_OAUTH_TOKEN
         skip_cleanup: true
-        on:
+        if:
           tags: true
 ```
 

--- a/user/build-stages/deploy-npm.md
+++ b/user/build-stages/deploy-npm.md
@@ -29,7 +29,7 @@ jobs:
       deploy:
         provider: npm
         api_key: $NPM_API_KEY
-        on: deploy-npm-release
+        if: deploy-npm-release
 ```
 
 This is how the build matrix might look:

--- a/user/build-stages/deploy-rubygems.md
+++ b/user/build-stages/deploy-rubygems.md
@@ -27,7 +27,7 @@ jobs:
         provider: rubygems
         gem: travis-build-stages-demo
         api_key: $RUBYGEMS_API_KEY
-        on: deploy-gem-release
+        if: deploy-gem-release
 ```
 This is how the build matrix would look like:
 

--- a/user/deployment.md
+++ b/user/deployment.md
@@ -40,9 +40,9 @@ deploy:
     api_key: "YOUR HEROKU API KEY"
 ```
 
-### Conditional Releases with `on:`
+### Conditional Releases with `if:`
 
-Deployment can be controlled by setting the `on:` for each deployment provider.
+Deployment can be controlled by setting the `if:` for each deployment provider.
 
 ```yaml
 deploy:
@@ -51,12 +51,12 @@ deploy:
   secret_access_key: "YOUR AWS SECRET KEY"
   bucket: "S3 Bucket"
   skip_cleanup: true
-  on:
+  if:
     branch: release
     condition: $MY_ENV = super_awesome
 ```
 
-When all conditions specified in the `on:` section are met, deployment for this
+When all conditions specified in the `if:` section are met, deployment for this
 provider will be performed.
 
 Common options are:
@@ -76,7 +76,7 @@ Common options are:
 
 5. **`tags`**: When set to `true`, the application is deployed when a tag is applied to the commit. This causes the `branch` condition to be ignored.
 
-#### Examples of Conditional Releases using `on:`
+#### Examples of Conditional Releases using `if:`
 
 This example deploys to Appfog only from the `staging` branch when the test has run on Node.js version 0.11.
 
@@ -85,7 +85,7 @@ deploy:
   provider: appfog
   user: ...
   api_key: ...
-  on:
+  if:
     branch: staging
     node: '0.11' # this should be quoted; otherwise, 0.10 would not work
 ```
@@ -99,7 +99,7 @@ deploy:
   secret_access_key: "YOUR AWS SECRET KEY"
   skip_cleanup: true
   bucket: "S3 Bucket"
-  on:
+  if:
     condition: "$CC = gcc"
 ```
 
@@ -111,7 +111,7 @@ deploy:
   api_key: "GITHUB OAUTH TOKEN"
   file: "FILE TO UPLOAD"
   skip_cleanup: true
-  on:
+  if:
     tags: true
     rvm: 2.0.0
 ```

--- a/user/deployment/anynines.md
+++ b/user/deployment/anynines.md
@@ -45,4 +45,4 @@ travis encrypt --add deploy.password
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).

--- a/user/deployment/appfog.md
+++ b/user/deployment/appfog.md
@@ -83,7 +83,7 @@ deploy:
   provider: appfog
   email: ...
   password: ...
-  on: production
+  if: production
 ```
 
 Alternatively, you can also configure it to deploy from all branches:
@@ -93,7 +93,7 @@ deploy:
   provider: appfog
   email: ...
   password: ...
-  on:
+  if:
     all_branches: true
 ```
 
@@ -116,7 +116,7 @@ deploy:
 ### Conditional Deploys
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### Running commands before and after deploy
 

--- a/user/deployment/azure-web-apps.md
+++ b/user/deployment/azure-web-apps.md
@@ -45,7 +45,7 @@ You can explicitly specify the branch to deploy from with the **on** option:
 ```
 deploy:
   provider: azure_web_apps
-  on: production
+  if: production
 ```
 
 Alternatively, you can also configure it to deploy from all branches:
@@ -53,7 +53,7 @@ Alternatively, you can also configure it to deploy from all branches:
 ```
 deploy:
   provider: azure_web_apps
-  on:
+  if:
     all_branches: true
 ```
 
@@ -91,5 +91,5 @@ deploy:
   slot: myapp-staging
 - provider: azure_web_apps
   slot: myapp-develop
-  on: develop
+  if: develop
 ```

--- a/user/deployment/bintray.md
+++ b/user/deployment/bintray.md
@@ -35,7 +35,7 @@ You can explicitly specify the branch to deploy from with the **on** option:
 ```yaml
 deploy:
   ..
-  on: production
+  if: production
 ```
 
 Alternatively, you can also configure it to deploy from all branches:
@@ -43,7 +43,7 @@ Alternatively, you can also configure it to deploy from all branches:
 ```yaml
 deploy:
   ..
-  on:
+  if:
     all_branches: true
 ```
 
@@ -52,7 +52,7 @@ Builds triggered from Pull Requests will never trigger a deploy.
 ### Conditional Deploys
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### Running commands before and after deploy
 

--- a/user/deployment/bluemixcloudfoundry.md
+++ b/user/deployment/bluemixcloudfoundry.md
@@ -46,4 +46,4 @@ If your password includes symbols (such as braces, parentheses, backslashes, and
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).

--- a/user/deployment/cloud66.md
+++ b/user/deployment/cloud66.md
@@ -33,7 +33,7 @@ You can explicitly specify the branch to deploy from with the **on** option:
 deploy:
   provider: cloud66
   redeployment_hook: "YOUR REDEPLOYMENT HOOK URL"
-  on: production
+  if: production
 ```
 
 Alternatively, you can also configure it to deploy from all branches:
@@ -42,7 +42,7 @@ Alternatively, you can also configure it to deploy from all branches:
 deploy:
   provider: cloud66
   redeployment_hook: "YOUR REDEPLOYMENT HOOK URL"
-  on:
+  if:
     all_branches: true
 ```
 
@@ -51,7 +51,7 @@ Builds triggered from Pull Requests will never trigger a deploy.
 ### Conditional Deploys
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### Running commands before and after deploy
 

--- a/user/deployment/cloudfiles.md
+++ b/user/deployment/cloudfiles.md
@@ -60,7 +60,7 @@ deploy:
   region: "CLOUDFILE REGION"
   container: "CLOUDFILES CONTAINER NAME"
   skip_cleanup: true
-  on:
+  if:
     tags: true
 ```
 
@@ -111,7 +111,7 @@ deploy:
   region: "CLOUDFILE REGION"
   container: "CLOUDFILES CONTAINER NAME"
   skip_cleanup: true
-  on:
+  if:
     branch: production
 ```
 
@@ -125,7 +125,7 @@ deploy:
   region: "CLOUDFILE REGION"
   container: "CLOUDFILES CONTAINER NAME"
   skip_cleanup: true
-  on:
+  if:
     all_branches: true
 ```
 
@@ -134,7 +134,7 @@ Builds triggered from Pull Requests will never trigger a release.
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### Running commands before and after release
 

--- a/user/deployment/cloudfoundry.md
+++ b/user/deployment/cloudfoundry.md
@@ -41,4 +41,4 @@ If your password includes symbols (such as braces, parentheses, backslashes, and
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).

--- a/user/deployment/codedeploy.md
+++ b/user/deployment/codedeploy.md
@@ -21,7 +21,7 @@ For a minimal configuration with S3, add the following to your `.travis.yml`:
         deployment_group: MyDeploymentGroup
 ```
 
-Note that in this example, Travis CI will attempt to deploy to an existing CodeDeploy Application called MyApp in AWS Region `us-east-1`.  
+Note that in this example, Travis CI will attempt to deploy to an existing CodeDeploy Application called MyApp in AWS Region `us-east-1`.
 
 A complete example can be found [here](https://github.com/travis-ci/cat-party/blob/master/.travis.yml).
 
@@ -60,7 +60,7 @@ You can explicitly specify the branch to deploy from with the **on** option:
       key: latest/MyApp.zip
       application: MyApp
       deployment_group: MyDeploymentGroup
-      on:
+      if:
         branch: production
 ```
 
@@ -75,7 +75,7 @@ Alternatively, you can also configure Travis CI to deploy from all branches:
       key: latest/MyApp.zip
       application: MyApp
       deployment_group: MyDeploymentGroup
-      on:
+      if:
         all_branches: true
 ```
 
@@ -112,7 +112,7 @@ Travis CI will wait for the deploy to complete, and log whether it succeeded.
 ### Conditional deployments
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### Note on `.gitignore`
 

--- a/user/deployment/deis.md
+++ b/user/deployment/deis.md
@@ -38,7 +38,7 @@ Keep in mind that the above command has to run in your project directory, so it 
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### Note on `.gitignore`
 

--- a/user/deployment/engineyard.md
+++ b/user/deployment/engineyard.md
@@ -71,7 +71,7 @@ You can also explicitly specify the branch to deploy from with the **on** option
 deploy:
   provider: engineyard
   api_key: ...
-  on: production
+  if: production
 ```
 
 Alternatively, you can also configure it to deploy from all branches:
@@ -80,7 +80,7 @@ Alternatively, you can also configure it to deploy from all branches:
 deploy:
   provider: engineyard
   api_key: ...
-  on:
+  if:
     all_branches: true
 ```
 
@@ -100,4 +100,4 @@ deploy:
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).

--- a/user/deployment/gcs.md
+++ b/user/deployment/gcs.md
@@ -81,7 +81,7 @@ If the `directory-name` is generated during build process, it will be deleted (c
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### Setting `Content-Encoding` header
 

--- a/user/deployment/google-app-engine.md
+++ b/user/deployment/google-app-engine.md
@@ -7,7 +7,7 @@ layout: en
 Travis CI can automatically deploy your [Google App Engine](https://cloud.google.com/appengine/docs) or [Managed VMs](https://cloud.google.com/appengine/docs/managed-vms/) application after a successful build.
 
 For a minimal configuration, add the following to your `.travis.yml`:
-  
+
 ```yaml
 deploy:
   provider: gae
@@ -62,7 +62,7 @@ deploy:
   provider: gae
   keyfile: ...
   project: ...
-  on: production
+  if: production
 ```
 
 Alternatively, you can also configure it to deploy from all branches:
@@ -72,7 +72,7 @@ deploy:
   provider: gae
   keyfile: ...
   project: ...
-  on:
+  if:
     all_branches: true
 ```
 

--- a/user/deployment/hackage.md
+++ b/user/deployment/hackage.md
@@ -35,4 +35,4 @@ Keep in mind that the above command has to run in your project directory, so it 
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).

--- a/user/deployment/heroku.md
+++ b/user/deployment/heroku.md
@@ -72,7 +72,7 @@ You can also explicitly specify the branch to deploy from with the **on** option
 deploy:
   provider: heroku
   api_key: ...
-  on: production
+  if: production
 ```
 
 Alternatively, you can also configure it to deploy from all branches:
@@ -81,7 +81,7 @@ Alternatively, you can also configure it to deploy from all branches:
 deploy:
   provider: heroku
   api_key: ...
-  on:
+  if:
     all_branches: true
 ```
 

--- a/user/deployment/lambda.md
+++ b/user/deployment/lambda.md
@@ -37,7 +37,7 @@ configuration parameters
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### AWS permissions
 

--- a/user/deployment/modulus.md
+++ b/user/deployment/modulus.md
@@ -43,7 +43,7 @@ deploy:
   provider: modulus
   api_key: ...
   project_name: ...
-  on: production
+  if: production
 ```
 
 Alternatively, you can also configure it to deploy from all branches:
@@ -53,7 +53,7 @@ deploy:
   provider: modulus
   api_key: ...
   project_name: ...
-  on:
+  if:
     all_branches: true
 ```
 
@@ -76,7 +76,7 @@ deploy:
 ## Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ## Running commands before and after deploy
 

--- a/user/deployment/npm.md
+++ b/user/deployment/npm.md
@@ -54,7 +54,7 @@ commits, like so:
 ```yaml
 deploy:
   ...
-  on:
+  if:
     tags: true
 ```
 
@@ -66,7 +66,7 @@ You can explicitly specify the branch to release from with the **on** option:
 ```yaml
 deploy:
   ...
-  on:
+  if:
     branch: production
 ```
 
@@ -75,7 +75,7 @@ Alternatively, you can also configure Travis CI to release from all branches:
 ```yaml
 deploy:
   ...
-  on:
+  if:
     all_branches: true
 ```
 
@@ -98,7 +98,7 @@ deploy:
 [A deployment issue](https://github.com/travis-ci/travis-ci/issues/4738) is
 reported when multiple attempts are made.
 We recommend deploying from only one job with
-[Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+[Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ## Tagging releases
 

--- a/user/deployment/openshift.md
+++ b/user/deployment/openshift.md
@@ -76,7 +76,7 @@ You can also explicitly specify the branch to deploy from with the **on** option
 deploy:
   provider: openshift
   ...
-  on: production
+  if: production
 ```
 
 Alternatively, you can also configure it to deploy from all branches:
@@ -85,7 +85,7 @@ Alternatively, you can also configure it to deploy from all branches:
 deploy:
   provider: openshift
   ...
-  on:
+  if:
     all_branches: true
 ```
 
@@ -107,7 +107,7 @@ deploy:
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### Note on `.gitignore`
 

--- a/user/deployment/opsworks.md
+++ b/user/deployment/opsworks.md
@@ -55,7 +55,7 @@ deploy:
   access-key-id: ACCESS-KEY-ID
   secret-access-key: SECRET-ACCESS-KEY
   app-id: APP-ID
-  on: production
+  if: production
 ```
 
 Alternatively, you can also configure it to deploy from all branches:
@@ -66,7 +66,7 @@ deploy:
   access-key-id: ACCESS-KEY-ID
   secret-access-key: SECRET-ACCESS-KEY
   app-id: APP-ID
-  on:
+  if:
     all_branches: true
 ```
 
@@ -108,7 +108,7 @@ whether it succeeded.
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### Running commands before and after deploy
 

--- a/user/deployment/packagecloud.md
+++ b/user/deployment/packagecloud.md
@@ -47,7 +47,7 @@ deploy:
   provider: packagecloud
   username: ...
   token: ...
-  on:
+  if:
     branch: production
 ```
 
@@ -58,7 +58,7 @@ deploy:
   provider: packagecloud
   username: ...
   token: ...
-  on:
+  if:
     all_branches: true
 ```
 
@@ -111,7 +111,7 @@ the `local-dir` directory. Ensure the source package and it's contents are outpu
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### Running commands before and after release
 

--- a/user/deployment/pages.md
+++ b/user/deployment/pages.md
@@ -4,7 +4,7 @@ layout: en
 
 ---
 
-> Deploying to GitHub Pages uses `git push --force` to overwrite the history on the *target* branch, so make sure you only deploy to a branch used for that specific purpose, such as `gh-pages`. 
+> Deploying to GitHub Pages uses `git push --force` to overwrite the history on the *target* branch, so make sure you only deploy to a branch used for that specific purpose, such as `gh-pages`.
 
 Travis CI can deploy your static files to [GitHub
 Pages](https://pages.github.com/) after a successful build.
@@ -20,7 +20,7 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
-  on:
+  if:
     branch: master
 ```
 

--- a/user/deployment/pypi.md
+++ b/user/deployment/pypi.md
@@ -45,7 +45,7 @@ deploy:
   provider: pypi
   user: ...
   password: ...
-  on:
+  if:
     tags: true
 ```
 
@@ -60,7 +60,7 @@ deploy:
   provider: pypi
   user: ...
   password: ...
-  on:
+  if:
     branch: production
 ```
 
@@ -70,7 +70,7 @@ Alternatively, you can also configure Travis CI to release from all branches:
 deploy:
   provider: pypi
   api_key: ...
-  on:
+  if:
     all_branches: true
 ```
 
@@ -122,7 +122,7 @@ deploy:
 ## Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ## Running commands before and after release
 

--- a/user/deployment/releases.md
+++ b/user/deployment/releases.md
@@ -16,13 +16,13 @@ deploy:
   api_key: "GITHUB OAUTH TOKEN"
   file: "FILE TO UPLOAD"
   skip_cleanup: true
-  on:
+  if:
     tags: true
 ```
 
 > Make sure you have `skip_cleanup` set to `true`, otherwise Travis CI will delete all the files created during the build, which will probably delete what you are trying to upload.
 
-The `on: tags: true` section at the end of the `.travis.yml` above is required to make sure that your tags get deployed.
+The `if: tags: true` section at the end of the `.travis.yml` above is required to make sure that your tags get deployed.
 
 If you need to overwrite existing files, add `overwrite: true` to the `deploy` section of your `.travis.yml`.
 
@@ -51,7 +51,7 @@ deploy:
     secure: YOUR_API_KEY_ENCRYPTED
   file: "FILE TO UPLOAD"
   skip_cleanup: true
-  on:
+  if:
     tags: true
 ```
 
@@ -66,7 +66,7 @@ deploy:
   password: "GITHUB PASSWORD"
   file: "FILE TO UPLOAD"
   skip_cleanup: true
-  on:
+  if:
     tags: true
 ```
 
@@ -99,7 +99,7 @@ deploy:
     - "FILE 1"
     - "FILE 2"
   skip_cleanup: true
-  on:
+  if:
     tags: true
 ```
 
@@ -113,14 +113,14 @@ deploy:
   file_glob: true
   file: directory/*
   skip_cleanup: true
-  on:
+  if:
     tags: true
 ```
 
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ## Running commands before or after release
 

--- a/user/deployment/rubygems.md
+++ b/user/deployment/rubygems.md
@@ -22,7 +22,7 @@ tagged commits, like so:
 deploy:
   provider: rubygems
   api_key: "YOUR API KEY"
-  on:
+  if:
     tags: true
 ```
 
@@ -117,7 +117,7 @@ You can also explicitly specify the branch to release from with the **on** optio
 deploy:
   provider: rubygems
   api_key: ...
-  on:
+  if:
     branch: production
 ```
 
@@ -127,7 +127,7 @@ Alternatively, you can also configure it to release from all branches:
 deploy:
   provider: rubygems
   api_key: ...
-  on:
+  if:
     all_branches: true
 ```
 
@@ -149,7 +149,7 @@ deploy:
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### Running commands before and after release
 

--- a/user/deployment/s3.md
+++ b/user/deployment/s3.md
@@ -194,7 +194,7 @@ deploy:
 ### Conditional releases
 
 You can deploy only when certain conditions are met.
-See [Conditional Releases with `on:`](/user/deployment#Conditional-Releases-with-on%3A).
+See [Conditional Releases with `if:`](/user/deployment#Conditional-Releases-with-on%3A).
 
 ### Running commands before and after release
 

--- a/user/deployment/script.md
+++ b/user/deployment/script.md
@@ -13,7 +13,7 @@ The following example runs `scripts/deploy.sh` on the `develop` branch of your r
 deploy:
   provider: script
   script: scripts/deploy.sh
-  on:
+  if:
     branch: develop
 ```
 
@@ -31,12 +31,12 @@ deploy:
   # deploy develop to the staging environment
   - provider: script
     script: scripts/deploy.sh staging
-    on:
+    if:
       branch: develop
   # deploy master to production
   - provider: script
     script: scripts/deploy.sh production
-    on:
+    if:
       branch: master
 ```
 
@@ -46,7 +46,7 @@ The script has access to all the usual [environment variables](/user/environment
 deploy:
   provider: script
   script: scripts/deploy.sh production $TRAVIS_TAG
-  on:
+  if:
     tags: true
     all_branches: true
 ```

--- a/user/deployment/surge.md
+++ b/user/deployment/surge.md
@@ -27,7 +27,7 @@ Example:
 deploy:
   provider: surge
   project: ./static/
-  domain: example.surge.sh  
+  domain: example.surge.sh
 ```
 
 ### Generated content
@@ -52,7 +52,7 @@ By default, Travis CI will only deploy from your `master` branch. You can specif
 ```yaml
 deploy:
   ...
-  on: myProductionBranch
+  if: myProductionBranch
 ```
 
 To deploy from all branches set the deploy->on option `all_branches` to `true`
@@ -60,6 +60,6 @@ To deploy from all branches set the deploy->on option `all_branches` to `true`
 ```yaml
 deploy:
   ...
-  on:
+  if:
     all_branches: true
 ```

--- a/user/languages/go.md
+++ b/user/languages/go.md
@@ -202,7 +202,7 @@ deploy section could look like this:
 ```yaml
 deploy:
   ...
-  on:
+  if:
     condition: $TRAVIS_GO_VERSION =~ ^1\.7\.[0-9]+$
 ```
 


### PR DESCRIPTION
This is to accompany https://github.com/travis-ci/travis-build/pull/1151, which came out of our work on conditional builds, stages, and jobs.

I am wondering when to best merge this docs change though with Enterprise in mind. Enterprise has, and will continue to have support for `on`, while getting support for `if` will take a while. So we could:

* Just not merge this for a couple months
* Merge it, but also add a note about Enterprise only supporting `on` in alll the places?

I have searched for these using:

```
$ ack '`on:'
$ ack ' on:'
common-build-problems.md
213:Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
224:Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

ip-addresses.md
10:on the infrastructure your builds are running on:
```
