### PR TITLE
MongoDB 'addUser' no longer works

### DIFF
--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -308,7 +308,7 @@ Add the following `before_script` to your `.travis.yml` to wait before connectin
 ```yaml
 before_script:
   - sleep 15
-  - mongo mydb_test --eval 'db.createUser("travis", "test");'
+  - mongo mydb_test --eval 'db.createUser({user:"travis",pwd:"test",roles:["readWrite"]});'
 ```
 {: data-file=".travis.yml"}
 

--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -308,7 +308,7 @@ Add the following `before_script` to your `.travis.yml` to wait before connectin
 ```yaml
 before_script:
   - sleep 15
-  - mongo mydb_test --eval 'db.addUser("travis", "test");'
+  - mongo mydb_test --eval 'db.createUser("travis", "test");'
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
MongoDB's 'addUser' was deprecated since v2.6 and no longer works on v3.4 and up.