### PR TITLE
Update notes around _JAVA_OPTIONS and MALLOC_ARENA_MAX changes

### DIFF
--- a/user/build-environment-updates/2017-09-06.md
+++ b/user/build-environment-updates/2017-09-06.md
@@ -22,7 +22,8 @@ on top of Ubuntu Trusty.
 - running `dpkg --add-architecture i386` at bootstrap time
 - directory at `~travis/.bash_profile.d` for sourcing user-level arbitrary
   things at shell init time
-- definition of `_JAVA_OPTIONS="-Xmx2048m -Xms512m"` and `MALLOC_ARENA_MAX=2`
+- definition of `_JAVA_OPTIONS="-Xmx2048m -Xms512m"` and `MALLOC_ARENA_MAX=2` on
+  *container-based only*.
 
 ### Changed
 


### PR DESCRIPTION
to note that they are specific to container-based, given that we now
unsed these vars on sudo-enabled.