### PR TITLE
[FIX] AWS Lambda Deploy Policy

### DIFF
--- a/user/deployment/lambda.md
+++ b/user/deployment/lambda.md
@@ -70,7 +70,7 @@ The AWS user that Travis deploys as must have the following IAM permissions in o
             "Sid": "DeployCode",
             "Effect": "Allow",
             "Action": [
-                "lambda:UploadFunction",
+                "lambda:GetFunction",
                 "lambda:UpdateFunctionCode",
                 "lambda:UpdateFunctionConfiguration"
             ],


### PR DESCRIPTION
## Expected behaviour
When following the travis-ci documentation, you should be able to sucessfully deploy your application to AWS Lambda without any errors

## Actual behaviour
The user recieves an error stating that they do not have permission to execute 'lambda:GetFunction'.

## PR Contents
This pull request adresses the following issues:
* When deploying to AWS Lambda - lambda:UploadFunction is no longer used by AWS
* lambda:GetFunction permissions are now explicitely required.

## Reasoning
When following the travis-ci documentation you should have confidence that the proposed solution will work. Adding lambda:GetFunction allows this to be the case.

Also, travis-ci documentation should not include any depreciated permissions as a matter of course. Removing lambda:UploadFunction mades this the case.