### PR TITLE
Fixed small grammatical error in the running builds in debug mode guide.

### DIFF
--- a/user/running-build-in-debug-mode.md
+++ b/user/running-build-in-debug-mode.md
@@ -17,7 +17,7 @@ to get shell access to the virtual machine or container.
 > the feature is enabled.
 > To have the feature enabled for a public repository, please email us at
 > [support@travis-ci.com](mailto:support@travis-ci.com) indicating which ones.
-> The push access to the repository is also required.
+> Push access to the repository is also required.
 
 For private repositories, the "Debug build" or "Debug job" button is available on the upper right corner of
 the build/job page.


### PR DESCRIPTION
This guide [here](https://docs.travis-ci.com/user/running-build-in-debug-mode/) contains a small grammatical error- it says "The push access permission is required", when just "Push access is required" is correct.