### PR TITLE
Fix mentions of various JDK versions

### DIFF
--- a/user/languages/groovy.md
+++ b/user/languages/groovy.md
@@ -134,22 +134,22 @@ install: ant deps
 ## Testing Against Multiple JDKs
 
 To test against multiple JDKs, use the `:jdk` key in `.travis.yml`. For example,
-to test against Oracle JDK 7 (which is newer than OpenJDK 7 on Travis CI) and
-OpenJDK 6:
+to test against Oracle JDK 8 and
+OpenJDK 7:
 
 ```yaml
 jdk:
-  - oraclejdk7
-  - openjdk6
+  - oraclejdk8
+  - openjdk7
 ```
 {: data-file=".travis.yml"}
 
-To test against OpenJDK 7 and Oracle JDK 7:
+To test against OpenJDK 7 and Oracle JDK 8:
 
 ```yaml
 jdk:
   - openjdk7
-  - oraclejdk7
+  - oraclejdk8
 ```
 {: data-file=".travis.yml"}
 

--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -12,7 +12,7 @@ This guide covers build environment and configuration topics specific to Java pr
 
 ## Overview
 
-The Travis CI environment provides Oracle JDK 8 (default), Oracle JDK 9, OpenJDK 6, OpenJDK 7, Gradle 2.0, Maven 3.2 and Ant 1.8, and has sensible defaults for projects that use Gradle, Maven or Ant.
+The Travis CI environment provides recent versions of Oracle JDK 8 (default), Oracle JDK 9, OpenJDK 7, Gradle 2.0, Maven 3.2 and Ant 1.8, and has sensible defaults for projects that use Gradle, Maven or Ant.
 
 To use the Java environment add the following to your `.travis.yml`:
 
@@ -20,6 +20,8 @@ To use the Java environment add the following to your `.travis.yml`:
 language: java
 ```
 {: data-file=".travis.yml"}
+
+Older OpenJDK and Oracle JDK versions may be available on [Precise](/user/reference/precise#JDK).
 
 ## Projects Using Maven
 
@@ -130,23 +132,26 @@ install: ant deps
 
 ## Testing Against Multiple JDKs
 
-To test against multiple JDKs, use the `jdk:` key in `.travis.yml`. For example, to test against Oracle JDK 7 and 8 and OpenJDK 6:
+To test against multiple JDKs, use the `jdk:` key in `.travis.yml`. For example, to test against Oracle JDKs 8 and 9, as well as OpenJDK 7:
 
 ```yaml
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk6
+  - oraclejdk9
+  - openjdk7
 ```
 {: data-file=".travis.yml"}
 
 > Note that testing against multiple Java versions is not supported on OS X. See the [OS X Build Environment](/user/reference/osx/#JDK-and-OS-X) for more details.
 
-Travis CI provides OpenJDK 6, OpenJDK 7, Oracle JDK 7, and Oracle JDK 8. Sun JDK 6 is not provided, because it is EOL as of November 2012. OpenJDK 8 is available on our Trusty images, specify `dist: trusty` to make use of it.
+Travis CI provides OpenJDK 7, Oracle JDK 8, and Oracle JDK 9.
 
-JDK 7 is backwards compatible, we think it's time for all projects to start testing against JDK 7 first and JDK 6 if resources permit.
+### Updating Oracle JDK to a recent release
 
-Of note: OracleJDK 8 and JavaFX  projects may need to update to the latest available version from a repository. This can be accomplished by adding the following lines from [this issue comment](https://github.com/travis-ci/travis-ci/issues/3259#issuecomment-130860338) to your .travis.yml:
+Your repository may require a newer release of Oracle JDK than the pre-installed version.
+(You can consult [the list](https://launchpad.net/~webupd8team/+archive/ubuntu/java).)
+
+The following example will use the latest Oracle JDK 8:
 
 ```yaml
 sudo: false
@@ -170,7 +175,7 @@ If your build needs to switch JDKs during a job, you can do so with `jdk_switche
 script:
   - jdk_switcher use oraclejdk8
   - # do stuff with Java 8
-  - jdk_switcher use oraclejdk7
+  - jdk_switcher use openjdk7
   - # do stuff with Java 7
 ```
 {: data-file=".travis.yml"}


### PR DESCRIPTION
Oracle JDK 7 and OpenJDK 6 are unavailable on Trusty.
Do mention that Precise image has older versions.

This documents the behavior reported in https://github.com/travis-ci/travis-ci/issues/7884 and closes it as a WONTFIX.