### PR TITLE
Fix flipped go get flags in Dependency Management section

### DIFF
--- a/user/languages/go.md
+++ b/user/languages/go.md
@@ -78,13 +78,13 @@ The default install step depends on the version of go:
 * if go version is greater than or equal to `1.2`
 
   ```
-  go get ./...
+  go get -t ./...
   ```
 
 * if go version is older than `1.2`
 
   ```
-  go get -t ./...
+  go get ./...
   ```
 
 *  or if any of the following files are present, the default install step is `true`:


### PR DESCRIPTION
-t was introduced in Go 1.2.  The behavior of Travis (rightfully) is flipped from what the docs say.