### PR TITLE
Update build virtualization environments

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -79,7 +79,6 @@
       <li><a href="/user/reference/osx/">OS X CI Environment Reference</a></li>
       <li><a href="/user/multi-os/">Building on Multiple Operating Systems</a></li>
       <li><a href="/user/environment-variables/">Environment Variables</a></li>
-      <li><a href="/user/migrating-from-legacy/">Migrating to Container-Based Infrastructure</a></li>
       <li><a href="/user/precise-to-trusty-migration-guide/">Precise to Trusty Migration Guide</a></li>
       <li><a href="/user/build-environment-updates/">Build Environment Updates</a></li>
       </ul>

--- a/user/reference/overview.md
+++ b/user/reference/overview.md
@@ -8,7 +8,7 @@ redirect_from:
 
 ### What This Guide Covers
 
-This guide provides an overview on the various different environments in which
+This guide provides an overview on the different environments in which
 Travis CI can run your builds, and why you might want to pick one over another.
 
 <div id="toc"></div>
@@ -25,15 +25,15 @@ Each Linux environment runs either [Ubuntu Precise 12.04](/user/reference/precis
 
 The following table summarizes the differences between the virtual environments:
 
-|                  | Ubuntu Precise                     | Ubuntu Precise                        | Ubuntu Trusty                     | Ubuntu Trusty                        | [OS X](/user/reference/osx/) |
-|:-----------------|:-----------------------------------|:--------------------------------------|:----------------------------------|:-------------------------------------|:-----------------------------|
-| Name             | Container-based                    | Sudo-enabled VM                       | Container-based                   | Sudo-enabled VM                      | OS X                         |
-| Status           | Retired as of September 2017       | Current                               | Default as of August 2017         | Current                              | Current                      |
-| Infrastructure   | Container                          | Virtual machine on GCE                | Container                         | Virtual machine on GCE               | Virtual machine              |
-| `.travis.yml`    | `sudo: false` <br> `dist: precise` | `sudo: required` <br> `dist: precise` | `sudo: false` <br> `dist: trusty` | `sudo: required` <br> `dist: trusty` | `os: osx`                    |
-| Allows `sudo`    | No                                 | Yes                                   | No                                | Yes                                  | Yes                          |
-| Approx boot time | 1-6s                               | 20-50s                                | 1-6s                              | 20-50s                               | 60-90s                       |
-| File system      | AUFS                               | EXT4                                  | AUFS                              | EXT4                                 | HFS+                         |
-| Operating system | Ubuntu 12.04                       | Ubuntu 12.04                          | Ubuntu 14.04                      | Ubuntu 14.04                         | OS X                         |
-| Memory           | 4 GB max                           | 7.5 GB                                | 4 GB max                          | 7.5 GB                               | 4 GB                         |
-| Cores            | 2                                  | ~2, bursted                           | 2                                 | ~2, bursted                          | 2                            |
+|                  | Ubuntu Precise                        | Ubuntu Trusty                     | Ubuntu Trusty                        | [OS X](/user/reference/osx/) |
+|:-----------------|:--------------------------------------|:----------------------------------|:-------------------------------------|:-----------------------------|
+| Name             | Sudo-enabled VM                       | Container-based                   | Sudo-enabled VM                      | OS X                         |
+| Status           | Current                               | Default as of August 2017         | Current                              | Current                      |
+| Infrastructure   | Virtual machine on GCE                | Container                         | Virtual machine on GCE               | Virtual machine              |
+| `.travis.yml`    | `sudo: required` <br> `dist: precise` | `sudo: false` <br> `dist: trusty` | `sudo: required` <br> `dist: trusty` | `os: osx`                    |
+| Allows `sudo`    | Yes                                   | No                                | Yes                                  | Yes                          |
+| Approx boot time | 20-50s                                | 1-6s                              | 20-50s                               | 60-90s                       |
+| File system      | EXT4                                  | AUFS                              | EXT4                                 | HFS+                         |
+| Operating system | Ubuntu 12.04                          | Ubuntu 14.04                      | Ubuntu 14.04                         | OS X                         |
+| Memory           | 7.5 GB                                | 4 GB max                          | 7.5 GB                               | 4 GB                         |
+| Cores            | ~2, bursted                           | 2                                 | ~2, bursted                          | 2                            |

--- a/user/reference/overview.md
+++ b/user/reference/overview.md
@@ -18,11 +18,9 @@ Travis CI can run your builds, and why you might want to pick one over another.
 
 Each build runs in one of the following virtual environments:
 
-- Sudo-enabled: a sudo enabled, full virtual machine per build
-- Container-based: Fast boot time environment in which `sudo` commands are not available
+- Sudo-enabled: a sudo enabled, full virtual machine per build. Running either Linux [Ubuntu Precise 12.04](/user/reference/precise/) or [Ubuntu Trusty 14.04](/user/reference/trusty/)
+- Container-based: Fast boot time environment in which `sudo` commands are not available. Running Linux [Ubuntu Trusty 14.04](/user/reference/trusty/)
 - [OS X](/user/reference/osx/): for Objective-C and other OS X specific projects
-
-Linux environments run in either [Ubuntu Precise 12.04](/user/reference/precise/) or [Ubuntu Trusty 14.04](/user/reference/trusty/).
 
 The following table summarizes the differences between the virtual environments:
 
@@ -42,7 +40,7 @@ The following table summarizes the differences between the virtual environments:
 
 ## Deprecated Virtualization Environments
 
-Historically, Travis CI has provided the following virtualization environments. You can find below a reference guide of the environments are no longer available.
+Historically, Travis CI has provided the following virtualization environments.
 
-- **Precise Container-based environment**: available since the announcement in [December, 2014](https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) and until [September, 2017](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status).
+- **Precise Container-based environment**: available from the announcement in [December, 2014](https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) to [September, 2017](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status).
 - **Legacy environment**: available until [December, 2015](https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future).

--- a/user/reference/overview.md
+++ b/user/reference/overview.md
@@ -21,7 +21,7 @@ Each build runs in one of the following virtual environments:
 - Container-based: Fast boot time environment in which `sudo` commands are not available
 - [OS X](/user/reference/osx/): for Objective-C and other OS X specific projects
 
-Each Linux environment runs either [Ubuntu Precise 12.04](/user/reference/precise/) or [Ubuntu Trusty 14.04](/user/reference/trusty/).
+Linux environments run in either [Ubuntu Precise 12.04](/user/reference/precise/) or [Ubuntu Trusty 14.04](/user/reference/trusty/).
 
 The following table summarizes the differences between the virtual environments:
 

--- a/user/reference/overview.md
+++ b/user/reference/overview.md
@@ -38,3 +38,11 @@ The following table summarizes the differences between the virtual environments:
 | Operating system | Ubuntu 12.04                          | Ubuntu 14.04                      | Ubuntu 14.04                         | OS X                         |
 | Memory           | 7.5 GB                                | 4 GB max                          | 7.5 GB                               | 4 GB                         |
 | Cores            | ~2, bursted                           | 2                                 | ~2, bursted                          | 2                            |
+
+
+## Deprecated Virtualization Environments
+
+Historically, Travis CI has provided the following virtualization environments. You can find below a reference guide of the environments are no longer available.
+
+- **Precise Container-based environment**: available since the announcement in [December, 2014](https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) and until [September, 2017](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status).
+- **Legacy environment**: available until [December, 2015](https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future).

--- a/user/reference/overview.md
+++ b/user/reference/overview.md
@@ -4,6 +4,7 @@ layout: en
 permalink: /user/reference/overview/
 redirect_from:
   - /user/ci-environment/
+  - /user/migrating-from-legacy/
 ---
 
 ### What This Guide Covers


### PR DESCRIPTION
- Updates virtualization environments overview
the long-term Ubuntu Precise 12.04 environment is available in fully virtualized infrastructure, per https://blog.travis-ci.com/2017-08-31-trusty-as-default-status

- Removes 2015 migration guide from legacy to container-based infra and redirects to overview page

- Adds a reference to deprecated virtualization environments, linking to the corresponding announcement blog posts



