### PR TITLE
Add link to 'conditional-...' in sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -94,6 +94,7 @@
       <h3>Beta Features</h3>
       <ul>
         <li><a href="/user/build-stages/">Build Stages</a></li>
+        <li><a href="user/conditional-builds-stages-jobs/">Conditional Builds, Stages, and Jobs</a></li>
       </ul>
 
       <h3>Integrations and Notifications</h3>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -94,7 +94,7 @@
       <h3>Beta Features</h3>
       <ul>
         <li><a href="/user/build-stages/">Build Stages</a></li>
-        <li><a href="user/conditional-builds-stages-jobs/">Conditional Builds, Stages, and Jobs</a></li>
+        <li><a href="/user/conditional-builds-stages-jobs/">Conditional Builds, Stages, and Jobs</a></li>
       </ul>
 
       <h3>Integrations and Notifications</h3>


### PR DESCRIPTION
Having documentations pages highlighting the sidebar helps find related content, or establish that there is none.