### PR TITLE
fix syntax highlighting for a code block in the rust doc

### DIFF
--- a/user/languages/rust.md
+++ b/user/languages/rust.md
@@ -82,7 +82,7 @@ cargo build --verbose
 You can cache your dependencies so they are only recompiled if they or the
 compiler were upgraded:
 
-```yanl
+```yaml
 cache: cargo
 ```
 {: data-file=".travis.yml"}


### PR DESCRIPTION
You can see the broken code block here: https://docs.travis-ci.com/user/languages/rust/#Dependency-Management