### PR TITLE
Remove TRAVIS_PULL_REQUEST=false

### DIFF
--- a/user/environment-variables.md
+++ b/user/environment-variables.md
@@ -204,7 +204,7 @@ to tag the build, or to run post-build deployments.
 - `TRAVIS_OS_NAME`: On multi-OS builds, this value indicates the platform the job is running on.
   Values are `linux` and `osx` currently, to be extended in the future.
 - `TRAVIS_PULL_REQUEST`: The pull request number if the current job is a pull
-  request, "false" if it's not a pull request.
+  request
 - `TRAVIS_PULL_REQUEST_BRANCH`:
   +  if the current job is a pull request, the name of the branch from which the PR originated.
   + if the current job is a push build, this variable is empty (`""`).


### PR DESCRIPTION
I noticed $TRAVIS_PULL_REQUEST is not present at all in non PR builds. These docs state it should have a value of false. The $TRAVIS_PULL_REQUEST_BRANCH behaviour is correct so can be used instead anyway.