### PR TITLE
Fixed indentation issue in gcc on Linux section of c11-cpp11-and-beyond-and-toolchains.md

### DIFF
--- a/_includes/c11-cpp11-and-beyond-and-toolchains.md
+++ b/_includes/c11-cpp11-and-beyond-and-toolchains.md
@@ -55,7 +55,7 @@ matrix:
           packages:
             - g++-7
       env:
-- MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
 before_install:
     - eval "${MATRIX_EVAL}"


### PR DESCRIPTION
there was an indentation issue in the gcc on Linux section. One line was not indented at all, which when used as it is, travis would fail to parse the yml.