### PR TITLE
Fix a typo in a config key for GitHub Releases

### DIFF
--- a/user/deployment/releases.md
+++ b/user/deployment/releases.md
@@ -125,7 +125,7 @@ includes all files in a given directory.
 ```yaml
 deploy:
   provider: releases
-  api-key: "GITHUB OAUTH TOKEN"
+  api_key: "GITHUB OAUTH TOKEN"
   file_glob: true
   file: directory/*
   skip_cleanup: true


### PR DESCRIPTION
`api-key` -> `api_key`