### PR TITLE
Remove option `local_dir` from docs about GitHub Releases Deployment

### DIFF
--- a/user/deployment/releases.md
+++ b/user/deployment/releases.md
@@ -153,11 +153,6 @@ after_deploy:
 ```
 {: data-file=".travis.yml"}
 
-## Pushing a specific directory
-
-* `local_dir`: Directory to push to GitHub Releases, defaults to the current
-    directory
-
 ## Advanced options
 
 Options from `.travis.yml` are passed through to [Octokit API](https://octokit.github.io/octokit.rb/Octokit/Client/Releases.html#create_release-instance_method), so you can use any valid Octokit option.


### PR DESCRIPTION
I'm in the process of getting to know how to properly set up Travis CI configs. GitHub Pages Deployment uses the `local_dir` option, but GitHub Releases Deployment uses `file` in addition with `file_glob` to specify the files and or folders. There is no mentioning of `local_dir` in `lib/dpl/provider/releases.rb` at all.

This had me confused and I think the section about the `local_dir` option should be removed from the docs about GitHub Releases Deployment.