### PR TITLE
Remove locale list from Postgres docs

### DIFF
--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -182,34 +182,7 @@ before_script:
 
 ### PostgreSQL and Locales
 
-The following locales are installed on Travis CI build environements:
-
-- C
-- C.UTF-8
-- en_AG
-- en_AG.utf8
-- en_AU.utf8
-- en_BW.utf8
-- en_CA.utf8
-- en_DK.utf8
-- en_GB.utf8
-- en_HK.utf8
-- en_IE.utf8
-- en_IN
-- en_IN.utf8
-- en_NG
-- en_NG.utf8
-- en_NZ.utf8
-- en_PH.utf8
-- en_SG.utf8
-- en_US.utf8
-- en_ZA.utf8
-- en_ZM
-- en_ZM.utf8
-- en_ZW.utf8
-- POSIX
-
-You can find what language packs are currently available for Ubuntu 12.04 [on the packages site.](http://packages.ubuntu.com/search?keywords=language-pack&searchon=names&suite=precise§ion=all)
+The Travis CI build environment comes with a number of pre-installed locales, but you can also install additional ones, should you require them.
 
 #### Installing Locales
 


### PR DESCRIPTION
Since the locales listed in our docs are outdated (we install a lot more, and they also depend on the image), we've discussed this as part of the [Trusty Q4 work](https://github.com/orgs/travis-pro/projects/13) decided it's better to remove them altogether.

