### PR TITLE
Remove nixpkgs broken link

### DIFF
--- a/user/languages/nix.md
+++ b/user/languages/nix.md
@@ -57,7 +57,3 @@ The above configuration will attempt to build the attribute "tarball" from the N
 ## Nix manual
 
 More information on writing Nix expressions and how each of the above tools works is available in the [Nix manual](https://nixos.org/nix/manual/).
-
-## Examples
-
-- [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/.travis.yml)


### PR DESCRIPTION
NixOS/nixpkgs have removed .travis.yml and the broken link is currently causing the build to fail: https://travis-ci.org/travis-ci/docs-travis-ci-com/builds/301462591