### PR TITLE
Update saucelabs links

### DIFF
--- a/user/sauce-connect.md
+++ b/user/sauce-connect.md
@@ -35,11 +35,11 @@ addons:
 ```
 {: data-file=".travis.yml"}
 
-[sauce-sign-up]: https://saucelabs.com/signup/plan/free
+[sauce-sign-up]: https://signup.saucelabs.com/signup/trial
 
 [sauce-account]: https://saucelabs.com/account
 
-[open-sauce]: https://saucelabs.com/signup/plan/OSS
+[open-sauce]: https://saucelabs.com/open-source
 
 If you don't want your access key publicly available in your repository, you
 can encrypt it with `travis encrypt "your-access-key"` (see [Encryption Keys][encryption-keys]


### PR DESCRIPTION
Builds are currently failing due to broken saucelabs links: https://travis-ci.org/travis-ci/docs-travis-ci-com/builds/303492412?utm_source=github_status&utm_medium=notification
I tried to update them to match the current sign-up process.