### PR TITLE
Updating a needed scope for deployment

### DIFF
--- a/user/github-oauth-scopes.md
+++ b/user/github-oauth-scopes.md
@@ -54,6 +54,11 @@ On <https://travis-ci.org> we ask for the following permissions:
     Updating the webhook required for us to be notified from GitHub on new
     commits or pull requests requires this API scope. Additionally, your user
     needs to have admin access to the repository you want to enable.
+   
+- `public_repo`
+
+    Is needed for deployment process to access the repository when it is being
+    tagged and attached a file with the tag.
 
 Note that for open source projects, we don't have any write access to your source
 code or your profile.


### PR DESCRIPTION
Seems to be a requirement when creating an oAuth github token to use for deployment. Without this my build kept breaking with a 401 error when installing dependencies:
```GET https://api.github.com/user: 401 - Bad credentials // See: https://developer.github.com/v3 (Octokit::Unauthorized)```

I am not exactly sure on the description of why this is needed, but all I know that it was crucial for me to do.

See example log: https://travis-ci.org/augsteyer/cloud-integration-magento/builds/305297570