### PR TITLE
New IPs for travis-ci.com containers

### DIFF
--- a/user/ip-addresses.md
+++ b/user/ip-addresses.md
@@ -11,7 +11,7 @@ on the infrastructure your builds are running on:
 
 | Infrastructure                  | IP ranges                                                                                                                        |
 | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------|
-| Container-based (travis-ci.com) | `workers-nat-com-shared-2.aws-us-east-1.travisci.net` (`52.45.220.64/32` `52.54.40.118/32` `54.89.89.104/32` `54.82.137.203/32`) |
+| Container-based (travis-ci.com) | `workers-nat-com-shared-2.aws-us-east-1.travisci.net` (`52.45.220.64/32` `52.54.40.118/32` `54.89.89.104/32` `54.82.137.203/32` `34.234.4.53/32` `54.208.31.17/32`) |
 | Container-based (travis-ci.org) | `workers-nat-org-shared-2.aws-us-east-1.travisci.net` (`52.45.185.117/32` `52.54.31.11/32` `54.87.185.35/32` `54.87.141.246/32`) |
 | OS X                            | `208.78.110.192/27`                                                                                                              |
 | Sudo-enabled Linux              |  See notes below. <br><br>{{site.data.gce_ip_range}}                                                                            |


### PR DESCRIPTION
Deploys started failing intermittently and we noticed the introduction of 2 new IPs for travis-ci.com worker containers. A curl request revealed he first IP and an `nslookup` of `workers-nat-com-shared-2.aws-us-east-1.travisci.net` revealed a second. After adding these two IPs to our AWS EC2 security group, the issue appears to be resolved.

```
Run individual commands; or execute configured build phases
with `travis_run_*` functions (e.g., `travis_run_before_install`).

For more information, consult https://docs.travis-ci.com/user/running-build-in-debug-mode/, or email support@travis-ci.com.
travis@travis-job-************************:~/build/******/******.com$ curl httpbin.org/ip
{
  "origin": "54.208.31.17"
}
travis@travis-job-************************:~/build/******/******.com$ 
```

```
16:51 $ nslookup workers-nat-com-shared-2.aws-us-east-1.travisci.net
Server:		10.203.128.69
Address:	10.203.128.69#53

Non-authoritative answer:
Name:	workers-nat-com-shared-2.aws-us-east-1.travisci.net
Address: 52.45.220.64
Name:	workers-nat-com-shared-2.aws-us-east-1.travisci.net
Address: 52.54.40.118
Name:	workers-nat-com-shared-2.aws-us-east-1.travisci.net
Address: 34.234.4.53
Name:	workers-nat-com-shared-2.aws-us-east-1.travisci.net
Address: 54.208.31.17
```