### PR TITLE
Update Rakudo default branch name after branch rename

### DIFF
--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -57,7 +57,7 @@ backend.  Future support for the
 ## Default Perl 6 Version
 
 If you leave the `perl6` key out of your `.travis.yml`, Travis CI will build
-Rakudo Perl 6 from the latest commit from the project's `nom` branch.
+Rakudo Perl 6 from the latest commit from the project's `master` branch.
 
 ## Default Test Script
 


### PR DESCRIPTION
This should fix [GitHub issue 8825](https://github.com/travis-ci/travis-ci/issues/8825).