### PR TITLE
Prepare changelist for the Trusty Q4 updates

### DIFF
--- a/user/build-environment-updates/2017-12-11.md
+++ b/user/build-environment-updates/2017-12-11.md
@@ -15,7 +15,7 @@ container-based execution environments.
 
 - installation of the `dbus-x11` package for better xserver support
 
- ### Changed
+### Changed
 
  - pre-installed Python versions `2.7.14` and `3.6.3`
  - pre-installed PHP versions `5.6.32`, `7.0.25` and `7.1.11`

--- a/user/build-environment-updates/2017-12-11.md
+++ b/user/build-environment-updates/2017-12-11.md
@@ -1,0 +1,47 @@
+---
+title: Build Environment Update History
+layout: en
+permalink: /user/build-environment-updates/2017-12-11/
+category: linux_build_env_updates
+date: 2017-12-11
+---
+
+## 2017-12-11
+
+This update applies to Ubuntu Trusty stacks on both sudo-enabled and
+container-based execution environments.
+
+### Added
+
+- installation of the `dbus-x11` package for better xserver support
+
+ ### Changed
+
+ - pre-installed Python versions `2.7.14` and `3.6.3`
+ - pre-installed PHP versions `5.6.32`, `7.0.25` and `7.1.11`
+ - pre-installed nodejs versions `6.12.0` and `8.9.1`
+ - clang `5.0.0`
+ - cmake `3.9.2`
+ - docker `17.09.0-ce`
+ - docker-compose `1.17.1`
+ - firefox `56.0.2` (now supports [headless mode](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-the-Firefox-addon-in-headless-mode))
+ - google-chrome `62.0.3202`
+ - google-cloud-sdk `176.0.0`
+ - maven `3.5.2`
+ - mongodb `3.4.10`
+ - neo4j `3.2.7`
+ - phantomjs `2.1.1`
+ - rabbitmq-server `3.6.14`
+ - shfmt `2.0.0`
+ - pre-installed tools that are typically updated at job execution time:
+    - nvm `0.33.6`
+    - yarn `1.3.2`
+
+### Removed
+
+- the `-Xcext.enabled=false` option from `JRUBY_OPTS`
+
+### Details
+
+- [travis-cookbooks diff](https://github.com/travis-ci/travis-cookbooks/compare/4642454...7c2c6a6)
+- [packer-templates diff](https://github.com/travis-ci/packer-templates/compare/f33ae65...986baf0)

--- a/user/build-environment-updates/2017-12-11.md
+++ b/user/build-environment-updates/2017-12-11.md
@@ -25,8 +25,10 @@ container-based execution environments.
  - docker `17.09.0-ce`
  - docker-compose `1.17.1`
  - firefox `56.0.2` (now supports [headless mode](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-the-Firefox-addon-in-headless-mode))
+ - git `2.15.1`
  - google-chrome `62.0.3202`
  - google-cloud-sdk `176.0.0`
+ - leiningen `2.8.1`
  - maven `3.5.2`
  - mongodb `3.4.10`
  - neo4j `3.2.7`


### PR DESCRIPTION
Reference: https://github.com/travis-pro/team-jade/issues/762

Add a page for the 2017-12-11 update. 
This initial list of changes is based on the git logs. We still need to cross-check it with the image metadata diffs.
