### PR TITLE
Add stages section to very first code sample

### DIFF
--- a/user/build-stages.md
+++ b/user/build-stages.md
@@ -56,6 +56,9 @@ Here’s how you’d set up the build configuration for this in your .travis.yml
 file:
 
 ```yaml
+stages:
+  - test
+  - deploy
 jobs:
   include:
     - stage: test


### PR DESCRIPTION
The stages feature doesn't seem to work without an explicit `stages:` section. This PR adds that section to the very first code sample in the Build Stages section of the Travis docs.

See [build 313007058](https://travis-ci.org/edestecd/puppet-software/builds/313007058) (without) and [build 313013400](https://travis-ci.org/edestecd/puppet-software/builds/313013400) (with stages section) for comparison.