### PR TITLE
Clarify that deploy steps are skipped on build failure

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -141,6 +141,7 @@ However, if one of these stages times out, the build is marked as a failure.
 An optional phase in the build lifecycle is deployment. This step can't be
 overridden, but is defined by using one of our continuous deployment providers
 to deploy code to Heroku, Engine Yard, or a different supported platform.
+The deploy steps are skipped if the build is broken.
 
 When deploying files to a provider, prevent Travis CI from resetting your
 working directory and deleting all changes made during the build ( `git stash


### PR DESCRIPTION
I was trying to figure out how to upload test logs and screenshots from successful and failed builds. It's unclear whether the deploy-related steps run on build failures.  From @BanzaiMan's [answer on StackOverflow](https://stackoverflow.com/a/39056573), they are not.

