### PR TITLE
Fix Trusty Q4 roll-out date

### DIFF
--- a/user/build-environment-updates/2017-12-12.md
+++ b/user/build-environment-updates/2017-12-12.md
@@ -1,12 +1,12 @@
 ---
 title: Build Environment Update History
 layout: en
-permalink: /user/build-environment-updates/2017-12-11/
+permalink: /user/build-environment-updates/2017-12-12/
 category: linux_build_env_updates
 date: 2017-12-11
 ---
 
-## 2017-12-11
+## 2017-12-12
 
 This update applies to Ubuntu Trusty stacks on both sudo-enabled and
 container-based execution environments.


### PR DESCRIPTION
We didn't release yesterday, as planned, so the docs should be consistent with the rest of our announcements around the updates.