### PR TITLE
ports can be used with known_hosts, update docs

### DIFF
--- a/user/ssh-known-hosts.md
+++ b/user/ssh-known-hosts.md
@@ -30,3 +30,11 @@ addons:
   - 111.22.33.44
 ```
 {: data-file=".travis.yml"}
+
+Hosts with ports can also be specified:
+
+```yaml
+addons:
+  ssh_known_hosts: git.example.com:1234
+```
+{: data-file=".travis.yml"}


### PR DESCRIPTION
As seen in the addon functionality here: https://github.com/travis-ci/travis-build/blob/a3395b694b00225118582b47432aed9c64614b3d/lib/travis/build/addons/ssh_known_hosts.rb#L48-L51, one can specify the port as well. This just updates the documentation to reflect the existing functionality.