### PR TITLE
use .test instead of .dev

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -686,7 +686,7 @@ hostnames in `/etc/hosts` for both IPv4 and IPv6.
 ```yaml
 addons:
   hosts:
-  - travis.dev
+  - travis.test
   - joshkalderimis.com
 ```
 {: data-file=".travis.yml"}


### PR DESCRIPTION
.dev is owned by Google and has been added to HSTS preload. It should not be used for this purpose.