### PR TITLE
caching: Travis CI fetches the cache of the default branch

### DIFF
--- a/user/caching.md
+++ b/user/caching.md
@@ -13,7 +13,7 @@ Travis CI can cache content that does not often change, to speed up your build p
 *ON*.
 
 * Travis CI fetches the cache for every build, including branches and pull requests.
-* If a branch does not have its own cache, Travis CI fetches the master branch cache.
+* If a branch does not have its own cache, Travis CI fetches the cache of the repository's default branch.
 * There is one cache per branch and language version/ compiler version/ JDK version/  Gemfile location/ etc.
 * Only modifications made to the cached directories from normal pushes are stored.
 


### PR DESCRIPTION
The documentation states that "If a branch does not have its own
cache, Travis CI fetches the master branch cache".  However, this is
not quite true: it fetches the cache of the repository's default
branch, whatever it is called.  While the default branch is indeed
called 'master' in most repositories, that's not always the case.