### PR TITLE
Add `-L` flag to `curl` command

### DIFF
--- a/user/languages/php.md
+++ b/user/languages/php.md
@@ -93,7 +93,7 @@ Please note that if you want to run PHPUnit on HHVM, you have to explicitly inst
 
 ```yaml
 before_script:
-  - curl -sSf -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
+  - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
The URL to download `phpunit` is returning a 302 status code and the `curl` command was failing to download the file. Added the `-L` flag to tell `curl` to follow to the new location.