### PR TITLE
[Enterprise] add enterprise docker version mismatch error to ops manual

### DIFF
--- a/user/enterprise/installation.md
+++ b/user/enterprise/installation.md
@@ -18,14 +18,14 @@ and information on obtaining a [license](/user/enterprise/prerequisites/#License
 
 <div id="toc"></div>
 
-## 1. Setting up the Travis CI Enterprise Platform
+## Setting up the Travis CI Enterprise Platform
 
 The Travis CI Enterprise Platform handles licensing, coordinates worker
 processes, and maintains the Enterprise user and admin dashboard. It must be
 installed on it's own machine instance, separate from that of the Travis CI
 Enterprise worker.
 
-### 1.1. Create a Security Group
+### Create a Travis CI Platform Security Group
 
 If you're setting up your AMI for the first time you need to create
 a Security Group. From the EC2 management console, create an entry for
@@ -40,7 +40,7 @@ each port in the table below:
 | 80   | HTTP            | Web application access.                                                      |
 | 22   | SSH             | SSH access.                                                                  |
 
-### 1.2. Install Travis CI Enterprise Platform on the first host
+### Install Travis CI Enterprise Platform
 
 Before running the installation script, we recommend downloading and reading it.
 When you're ready to run it on the host, run one of the following pairs of
@@ -63,13 +63,13 @@ installation's hostname, port 8800) to complete the setup.
 From here you can upload your license key, add your GitHub OAuth details, and
 optionally upload an SSL certificate and enter SMTP details.
 
-## 2. Setting up Travis CI Enterprise Worker
+## Install Travis CI Enterprise Worker
 
 The Travis CI Enterprise Worker manages build containers and reports build
 statuses back to the platform. It must be installed on a separate machine
 instance from the Platform.
 
-### 2.1. Create a Security Group
+### Create a Travis CI Worker Security Group
 
 If you're setting up your AMI for the first time you will need to create
 a Security Group. From the EC2 management console, create an entry for
@@ -79,7 +79,7 @@ each port in the table below:
 |:-----|:--------|:------------|
 | 22   | SSH     | SSH access. |
 
-## 2.1. Install Travis CI Worker on the second host
+## Install Travis CI Worker
 
 1. From the Travis CI Enterprise Platform management UI under Settings, retrieve
    the RabbitMQ password and the hostname for your Travis CI Enterprise
@@ -123,18 +123,3 @@ specified as follows:
 ```
   export http_proxy="http://proxy.mycompany.corp:8080/"
 ```
-
-## Backups
-
-<!-- TODO what about a Backups page linked to from here + upgrades -->
-
-We recommend a weekly machine snapshot and weekly backups of `/etc/travis` and
-`/var/travis`.
-
-One good way to do this is to run
-```
-  sudo tar -cvzf travis-backup-$(date +%s).tar.gz /var/travis /etc/travis/
-```
-
-Doing a machine snapshot and backing up those directories before performing an
-update is recommended as well.

--- a/user/enterprise/operations-manual.md
+++ b/user/enterprise/operations-manual.md
@@ -84,11 +84,11 @@ $ sudo restart travis-worker
 
 A source for the problem could be that the worker machine is not able to communicate with the platform machine.
 
-Here we're distinguishing between an AWS EC2 installation and an installation running on other hardware. For the former, security groups need to be configured per machine. To do so, please follow our installation instructions [here](/user/enterprise/installation/#create-a-travis-ci-enterprise-security-group). If you're not using AWS EC2, please make sure that the ports listed [in the docs](/user/enterprise/installation/#create-a-travis-ci-enterprise-security-group) are open in your firewall.
+Here we're distinguishing between an AWS EC2 installation and an installation running on other hardware. For the former, security groups need to be configured per machine. To do so, please follow our installation instructions [here](/user/enterprise/installation/#Create-a-Travis-CI-Platform-Security-Group). If you're not using AWS EC2, please make sure that the ports listed [in the docs](/user/enterprise/installation/#Create-a-Travis-CI-Platform-Security-Group) are open in your firewall.
 
 #### Docker Versions Mismatched 
 
-This issue sometimes occurs after maintenance on workers installed before November 2017 or systems running a `docker version` before `17.06.2-ce`. When this happens, the `/var/log/upstart/travis-worker.log` file contains a line: `Error response from daemon:client and server don't have same version`. For this issue, we recommend [re-installing worker from scratch](/user/enterprise/installation/install-travis-ci-enterprise-worker) on a fresh instance. Please note: the default build environment images will be pulled and you may need to apply customizations again as well.
+This issue sometimes occurs after maintenance on workers installed before November 2017 or systems running a `docker version` before `17.06.2-ce`. When this happens, the `/var/log/upstart/travis-worker.log` file contains a line: `Error response from daemon:client and server don't have same version`. For this issue, we recommend [re-installing worker from scratch](/user/enterprise/installation/#Install-Travis-CI-Enterprise-Worker) on a fresh instance. Please note: the default build environment images will be pulled and you may need to apply customizations again as well.
 
 If none of the steps above lead to results for you, please follow the steps in the [Contact Support](#Contact-support) section below to move forward.
 

--- a/user/enterprise/operations-manual.md
+++ b/user/enterprise/operations-manual.md
@@ -88,7 +88,7 @@ Here we're distinguishing between an AWS EC2 installation and an installation ru
 
 #### Docker Versions Mismatched 
 
-This issue sometimes occurs after maintenance on workers installed before November 2017 or systems running a `docker version` before `17.06.2-ce`. When this happens, the `/var/log/upstart/travis-worker.log` file contains a line: `Error response from daemon:client and server don't have same version`. For this issue, we recommend [re-installing worker from scratch](/user/enterprise/installation/#2.1.-Install-Travis-CI-Worker-on-the-second-host) on a fresh instance. Please note: the default build environment images will be pulled and you may need to apply customizations again as well.
+This issue sometimes occurs after maintenance on workers installed before November 2017 or systems running a `docker version` before `17.06.2-ce`. When this happens, the `/var/log/upstart/travis-worker.log` file contains a line: `Error response from daemon:client and server don't have same version`. For this issue, we recommend [re-installing worker from scratch](/user/enterprise/installation/install-travis-ci-enterprise-worker) on a fresh instance. Please note: the default build environment images will be pulled and you may need to apply customizations again as well.
 
 If none of the steps above lead to results for you, please follow the steps in the [Contact Support](#Contact-support) section below to move forward.
 

--- a/user/enterprise/operations-manual.md
+++ b/user/enterprise/operations-manual.md
@@ -43,11 +43,11 @@ The files are located at `/var/travis` on the platform machine. Please run `sudo
 
 ### The problem
 
-In the Travis CI Web UI you see none of the builds are starting. They're either in no state or `queued`. Cancelling and restarting them doesn't make any difference.
+In the Travis CI Web UI you see none of the builds are starting. They're either in no state or `queued`. Canceling and restarting them doesn't make any difference.
 
 ### Strategies
 
-There are a few different strategies to make your builds start. Please try each one in order.
+There are a few different potential approaches which may help get builds running again. Please try each one in order.
 
 #### Connection to RabbitMQ got lost
 
@@ -83,9 +83,14 @@ $ sudo restart travis-worker
 #### Ports are not open Security groups / firewall
 
 A source for the problem could be that the worker machine is not able to communicate with the platform machine.
+
 Here we're distinguishing between an AWS EC2 installation and an installation running on other hardware. For the former, security groups need to be configured per machine. To do so, please follow our installation instructions [here](/user/enterprise/installation/#11-Create-a-Security-Group). If you're not using AWS EC2, please make sure that the ports listed [in the docs](/user/enterprise/installation/#11-Create-a-Security-Group) are open in your firewall.
 
-If none of the steps above lead to results for you, please follow the steps in [#Contact-support](#Contact-support) to move forward.
+#### Docker Versions Mismatched 
+
+Upon inspecting the `travis-worker.log` file, you may notice an error: `Error response from daemon:client and server don't have same version`, which is especially common on workers installed before November 2017 or systems running a `docker version` before `17.06.2-ce`. For this issue, we recommend [re-installing worker from scratch](/user/enterprise/installation/#2.1.-Install-Travis-CI-Worker-on-the-second-host) on a fresh instance. Please note: the default build environment images will be pulled and you may need to apply customizations again as well.
+
+If none of the steps above lead to results for you, please follow the steps in the [Contact Support](#Contact-support) section below to move forward.
 
 ## Contact support
 

--- a/user/enterprise/operations-manual.md
+++ b/user/enterprise/operations-manual.md
@@ -84,7 +84,7 @@ $ sudo restart travis-worker
 
 A source for the problem could be that the worker machine is not able to communicate with the platform machine.
 
-Here we're distinguishing between an AWS EC2 installation and an installation running on other hardware. For the former, security groups need to be configured per machine. To do so, please follow our installation instructions [here](/user/enterprise/installation/#11-Create-a-Security-Group). If you're not using AWS EC2, please make sure that the ports listed [in the docs](/user/enterprise/installation/#11-Create-a-Security-Group) are open in your firewall.
+Here we're distinguishing between an AWS EC2 installation and an installation running on other hardware. For the former, security groups need to be configured per machine. To do so, please follow our installation instructions [here](/user/enterprise/installation/#create-a-travis-ci-enterprise-security-group). If you're not using AWS EC2, please make sure that the ports listed [in the docs](/user/enterprise/installation/#create-a-travis-ci-enterprise-security-group) are open in your firewall.
 
 #### Docker Versions Mismatched 
 

--- a/user/enterprise/operations-manual.md
+++ b/user/enterprise/operations-manual.md
@@ -88,7 +88,7 @@ Here we're distinguishing between an AWS EC2 installation and an installation ru
 
 #### Docker Versions Mismatched 
 
-Upon inspecting the `travis-worker.log` file, you may notice an error: `Error response from daemon:client and server don't have same version`, which is especially common on workers installed before November 2017 or systems running a `docker version` before `17.06.2-ce`. For this issue, we recommend [re-installing worker from scratch](/user/enterprise/installation/#2.1.-Install-Travis-CI-Worker-on-the-second-host) on a fresh instance. Please note: the default build environment images will be pulled and you may need to apply customizations again as well.
+This issue sometimes occurs after maintenance on workers installed before November 2017 or systems running a `docker version` before `17.06.2-ce`. When this happens, the `/var/log/upstart/travis-worker.log` file contains a line: `Error response from daemon:client and server don't have same version`. For this issue, we recommend [re-installing worker from scratch](/user/enterprise/installation/#2.1.-Install-Travis-CI-Worker-on-the-second-host) on a fresh instance. Please note: the default build environment images will be pulled and you may need to apply customizations again as well.
 
 If none of the steps above lead to results for you, please follow the steps in the [Contact Support](#Contact-support) section below to move forward.
 


### PR DESCRIPTION
@schultyy @plaindocs - how's this look for an addition to the ops manual re: the [docker version mismatch error](https://github.com/travis-pro/team-cyan/issues/50) on old worker installs? Assuming all's ok, I'd like to get things merged asap so we can email it with Meltdown vulnerability recommendations 