### PR TITLE
Update to match permissions behaviour

### DIFF
--- a/user/travis-pro.md
+++ b/user/travis-pro.md
@@ -29,8 +29,8 @@ accompanying the launch of pull requests for Travis CI.
 Access rights on Travis CI is based on the access rights on GitHub:
 
 - Users that can access a repository on GitHub can see the build status and logs on Travis CI.
-- Users that can push to a repository on GitHub can trigger, cancel and restart builds.
-- Users that have admin access to a repository on GitHub can enable/disable it on Travis CI and change its settings.
+- Users that can push to a repository on GitHub can trigger, cancel and restart builds, and change its settings.
+- Users that have admin access to a repository on GitHub can enable/disable it on Travis CI.
 
 To keep the access rights up to date, we sync every user account approximately once every 24 hours with GitHub. You can use the "Sync account" button on [the profile page](https://travis-ci.com/profile) or `travis sync --pro` in the CLI to force a sync.
 


### PR DESCRIPTION
Moving forward, I believe we could use a table so that this is clearer, kind of what GitHub is doing at https://help.github.com/articles/repository-permission-levels-for-an-organization/