### PR TITLE
Add link to encryption for env vars

### DIFF
--- a/user/docker.md
+++ b/user/docker.md
@@ -135,7 +135,7 @@ travis env set DOCKER_USERNAME myusername
 travis env set DOCKER_PASSWORD secretsecret
 ```
 
-Be sure to [encrypt environment variables](https://docs.travis-ci.com/user/environment-variables#Encrypting-environment-variables) 
+Be sure to [encrypt environment variables](/user/environment-variables#Encrypting-environment-variables) 
 using the travis gem. 
 
 Within your `.travis.yml` prior to attempting a `docker push` or perhaps before

--- a/user/docker.md
+++ b/user/docker.md
@@ -135,6 +135,9 @@ travis env set DOCKER_USERNAME myusername
 travis env set DOCKER_PASSWORD secretsecret
 ```
 
+Be sure to [encrypt environment variables](https://docs.travis-ci.com/user/environment-variables#Encrypting-environment-variables) 
+using the travis gem. 
+
 Within your `.travis.yml` prior to attempting a `docker push` or perhaps before
 `docker pull` of a private image, e.g.:
 


### PR DESCRIPTION
I was using the Docker build steps and had to go looking for encryption steps. I thought it would be useful to remind users to do so, and how.