### PR TITLE
Reorganize ssh-known-hosts page

### DIFF
--- a/user/ssh-known-hosts.md
+++ b/user/ssh-known-hosts.md
@@ -12,8 +12,60 @@ your git repository, which is necessary if there are git submodules
 from domains other than `github.com`, `gist.github.com`, or
 `ssh.github.com`.
 
-Both hostnames and IP addresses are supported, as the keys are
-added via `ssh-keyscan`.  A single host may be specified like so:
+Each entry in the configuration is one of the following:
+
+1. a hash with `host`, `type`, `key`
+1. a hostname
+1. a numeric IP address
+
+In the first case, we write key directly to `~/.ssh/known_hosts`.
+
+In the last two cases, we run `ssh-keyscan` to add the host key.
+See [Security Implications](#Security-Implications) below to understand what this means.
+
+## Examples
+
+Hosts may be given in various ways.
+
+### A single hash with `host`, `type`, `key`
+
+In the case where a host is defined with `host`, `type`, and `key`,
+
+```yaml
+addons:
+  ssh_known_hosts:
+    host: ssh.example.com
+    type: ssh-ed25519
+    key: AAAAC3NzaC1lZDI1NTE5AAAAIOd6AtszfjD3nI7WvvnN+B39XsrjPzAMCByYO1hwUGf9
+```
+{: data-file=".travis.yml" }
+
+a line of the form
+
+    HOST TYPE KEY
+
+is added to `$HOME/.ssh/known_hosts`.
+
+Each of `host`, `type`, and `key` is required. If any is missing, the entry is ignored.
+
+### Multiple hashes
+
+Multiple hashes can also be specified in an array (alongside other means of specifying SSH hosts):
+
+```yaml
+addons:
+  ssh_known_hosts:
+    - host: ssh.example.com
+      type: ssh-ed25519
+      key: AAAAC3NzaC1lZDI1NTE5AAAAIOd6AtszfjD3nI7WvvnN+B39XsrjPzAMCByYO1hwUGf9
+    - host: ssh2.example.com
+      type: ssh-ed25519
+      key: AAAAC3NzaC1lZDI1NTE5AAAAIOd6AtszfjD3nI7WvvnN+B39XsrjPzAMCByYO1hwUGf0
+    - ssh3.example.com
+```
+{: data-file=".travis.yml" }
+
+### A single hostname
 
 ```yaml
 addons:
@@ -21,7 +73,8 @@ addons:
 ```
 {: data-file=".travis.yml"}
 
-Multiple hosts or IPs may be added as a list:
+
+### Multiple hosts or IPs in a list
 
 ```yaml
 addons:
@@ -31,7 +84,9 @@ addons:
 ```
 {: data-file=".travis.yml"}
 
-Hosts with ports can also be specified:
+### Nonstandard SSH port
+
+If the host is listening on a nonstandard port, it may be specified as follows:
 
 ```yaml
 addons:
@@ -42,37 +97,8 @@ addons:
 ## Security Implications
 
 Note that the `ssh_known_hosts` option may introduce a risk of man-in-the-middle attacks for your builds.
-(Also see the _Security_ section of the [ssh-keyscan man page](https://linux.die.net/man/1/ssh-keyscan "man page for ssh-keyscan").)
+(Also see the _Security_ section of the [ssh-keyscan man page](http://man7.org/linux/man-pages/man1/ssh.1.html "man page for ssh-keyscan").)
 For example, it may prevent a build from detecting that an illegitimate 3rd party attempts to inject a modified git repository or submodule into the build.
 This possibility might be of particular relevance where Travis CI build outputs are used for release packages or production deployments.
 
-### Mitigations and Workarounds
-
-Currently, Travis CI only detects the above attacks out-of-the-box for repositories on `github.com`, `gist.github.com`, or `ssh.github.com`.
-If you host your code on other domains, there is currently no straightforward alternative to using the `ssh_known_hosts` option and its security implications.
-
-However, you can protect other SSH connections that occur after the cloning phase in your build, e.g., when deploying build outputs.
-To make your builds reject spoofed SSH servers for such connections, you configure them with known good SSH keys.
-Say your build instance connects to the SSH server *ssh.example.com*:
-
-1. Remove the `ssh_known_hosts` option for *ssh.example.com*.
-
-2. Obtain the public key of the SSH server at *ssh.example.com*:
-
-    - Ideally (but rarely), the owner of *ssh.example.com* can provide you with the server's public SSH key through e-mail or some other trusted channel.
-
-    - If you have previously connected to *ssh.example.com* from a trusted local computer, run `ssh-keygen -F ssh.example.com` to display its public key.
-
-    - If you have not yet connected to *ssh.example.com*, run `ssh-keyscan ssh.example.com` to retrieve it and `ssh-keygen -F ssh.example.com` to display it.
-    Ideally, you would double-check with the owner of *ssh.example.com* that that is indeed the server's public key and not the key of a spoofed instance of *ssh.example.com*.
-
-3. Configure Travis CI to use the public key of the SSH server:
-Add the key server's public key *KEY* to the SSH `known_hosts` file, e.g., with the following addition to the installation phase:
-
-```yaml
-install:
-  - echo 'KEY' >> $HOME/.ssh/known_hosts
-```
-{: data-file=".travis.yml"}
-
-Make sure to replace *KEY* with the complete line of text containing the public key of the SSH server as obtained in the previous step.
+We recommend using the first form.

--- a/user/ssh-known-hosts.md
+++ b/user/ssh-known-hosts.md
@@ -18,14 +18,14 @@ Each entry in the configuration is one of the following:
 1. a hostname
 1. a numeric IP address
 
-In the first case, we write key directly to `~/.ssh/known_hosts`.
+In the first case, we write the key directly to `~/.ssh/known_hosts`.
 
 In the last two cases, we run `ssh-keyscan` to add the host key.
 See [Security Implications](#Security-Implications) below to understand what this means.
 
 ## Examples
 
-Hosts may be given in various ways.
+Here are some examples of the different ways to add hosts.
 
 ### A single hash with `host`, `type`, `key`
 
@@ -101,4 +101,4 @@ Note that the `ssh_known_hosts` option may introduce a risk of man-in-the-middle
 For example, it may prevent a build from detecting that an illegitimate 3rd party attempts to inject a modified git repository or submodule into the build.
 This possibility might be of particular relevance where Travis CI build outputs are used for release packages or production deployments.
 
-We recommend using the first form.
+We recommend adding hosts using the hash with `host`, `type`, `key`.

--- a/user/ssh-known-hosts.md
+++ b/user/ssh-known-hosts.md
@@ -97,7 +97,7 @@ addons:
 ## Security Implications
 
 Note that the `ssh_known_hosts` option may introduce a risk of man-in-the-middle attacks for your builds.
-(Also see the _Security_ section of the [ssh-keyscan man page](http://man7.org/linux/man-pages/man1/ssh.1.html "man page for ssh-keyscan").)
+(Also see the the [SECURITY section of the `ssh-keyscan` man page](http://man7.org/linux/man-pages/man1/ssh-keyscan.1.html#SECURITY "man page for ssh-keyscan").)
 For example, it may prevent a build from detecting that an illegitimate 3rd party attempts to inject a modified git repository or submodule into the build.
 This possibility might be of particular relevance where Travis CI build outputs are used for release packages or production deployments.
 


### PR DESCRIPTION
Explain the new means of adding previously-known SSH host keys

An additional minor change is eschewing die.net, which tends to be
outdated.

To correspond to https://github.com/travis-ci/travis-build/pull/1304.

Also, see #1649.