### PR TITLE
Common Build Problems: Uses the new name of Capybara.default_wait_time

### DIFF
--- a/user/common-build-problems.md
+++ b/user/common-build-problems.md
@@ -105,7 +105,7 @@ Capybara has a timeout setting which you can increase to a minimum of 15
 seconds:
 
 ```js
-Capybara.default_wait_time = 15
+Capybara.default_max_wait_time = 15
 ```
 
 Poltergeist has its own setting for timeouts:


### PR DESCRIPTION
`Capybara.default_wait_time` is now `Capybara.default_max_wait_time`:

https://github.com/teamcapybara/capybara#using-capybara-with-rspec