### PR TITLE
Fix URL for Sauce connect proxy

### DIFF
--- a/user/gui-and-headless-browsers.md
+++ b/user/gui-and-headless-browsers.md
@@ -33,7 +33,7 @@ username = os.environ["SAUCE_USERNAME"]
 access_key = os.environ["SAUCE_ACCESS_KEY"]
 capabilities["tunnel-identifier"] = os.environ["TRAVIS_JOB_NUMBER"]
 hub_url = "%s:%s@localhost:4445" % (username, access_key)
-driver = webdriver.Remote(desired_capabilities=capabilities, command_executor="https://%s/wd/hub" % hub_url)
+driver = webdriver.Remote(desired_capabilities=capabilities, command_executor="http://%s/wd/hub" % hub_url)
 ```
 
 The Sauce Connect addon exports the `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables, and relays connections to the hub URL back to Sauce Labs.


### PR DESCRIPTION
The `https://` url doesn't work. At the suggestion of [this SO post](https://stackoverflow.com/questions/48236104/ssl-errors-using-sauce-labs-in-travis-ci-with-selenium-webriver-tests-django-pr), I changed it to `http://` and got a step further.