### PR TITLE
Correct filename in database setup documentation

### DIFF
--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -76,7 +76,7 @@ test:
   username: travis
   encoding: utf8
 ```
-{: data-file=".travis.yml"}
+{: data-file="config/database.yml"}
 
 You might have to create the `myapp_test` database first, for example in
 the `before_install` step in `.travis.yml`:


### PR DESCRIPTION
The database setup documentation provides an example `config/database.yml` file for using MySQL with ActiveRecord, but it's mislabeled as `.travis.yml`. This corrects this label.

![screen shot 2018-02-08 at 6 07 59 pm](https://user-images.githubusercontent.com/7942714/36008309-97de2194-0cfb-11e8-9d4b-9951fce759aa.png)
