### PR TITLE
Script deployment: run custom scripts with bash

### DIFF
--- a/user/deployment/script.md
+++ b/user/deployment/script.md
@@ -12,7 +12,7 @@ The following example runs `scripts/deploy.sh` on the `develop` branch of your r
 ```yaml
 deploy:
   provider: script
-  script: scripts/deploy.sh
+  script: bash scripts/deploy.sh
   on:
     branch: develop
 ```
@@ -31,12 +31,12 @@ It is possible to pass arguments to a script deployment.
 deploy:
   # deploy develop to the staging environment
   - provider: script
-    script: scripts/deploy.sh staging
+    script: bash scripts/deploy.sh staging
     on:
       branch: develop
   # deploy master to production
   - provider: script
-    script: scripts/deploy.sh production
+    script: bash scripts/deploy.sh production
     on:
       branch: master
 ```
@@ -47,7 +47,7 @@ The script has access to all the usual [environment variables](/user/environment
 ```yaml
 deploy:
   provider: script
-  script: scripts/deploy.sh production $TRAVIS_TAG
+  script: bash scripts/deploy.sh production $TRAVIS_TAG
   on:
     tags: true
     all_branches: true


### PR DESCRIPTION
I believe that the current examples assume that the script files are executable and running the example as it is in Travis CI will error with a "command not found (exit code 127)" error.

We've also had several questions about this in Support, so I suggest changing the examples to use `bash` to run the scripts.

