### PR TITLE
[Enterprise] Docker in Docker for Trusty build images

### DIFF
--- a/user/enterprise/build-images.md
+++ b/user/enterprise/build-images.md
@@ -79,7 +79,7 @@ With Trusty build images a few additional steps are required. Since `docker-ce` 
 
 On Amazon EC2 each machine has a private IP address by default. That address will be used to connect to the Docker daemon.
 
-To get the address, please run `ifconfig` in your terminal. For EC2 Virtual Machines, usually `eth0` interface is what we're looking for.
+To get the address, please run `ifconfig` in your terminal. For EC2 Virtual Machines, usually `eth0` interface is correct.
 
 Now the Docker daemon needs to listen to that address. Please open `/etc/default/docker`. In this file, you'll find the `DOCKER_OPTS` variable. This is read by Docker during service startup. In there please configure the additional host like this:
 

--- a/user/enterprise/build-images.md
+++ b/user/enterprise/build-images.md
@@ -81,7 +81,7 @@ On Amazon EC2 each machine has a private IP address by default. That address wil
 
 To get the address, please run `ifconfig` in your terminal. For EC2 Virtual Machines, usually `eth0` interface is correct.
 
-Now the Docker daemon needs to listen to that address. Please open `/etc/default/docker`. In this file, you'll find the `DOCKER_OPTS` variable. This is read by Docker during service startup. In there please configure the additional host like this:
+Now the Docker daemon needs to listen to that address. Please open `/etc/default/docker`. In this file, you'll find the `DOCKER_OPTS` variable. This is read by Docker during service startup. In there please configure the additional host like this (We're using `172.31.7.199` as example here):
 
 ```
 DOCKER_OPTS="-H tcp://172.31.7.199:4243 -H tcp://127.0.0.1:4243 -H unix:///var/run/docker.sock ..."

--- a/user/enterprise/build-images.md
+++ b/user/enterprise/build-images.md
@@ -73,7 +73,7 @@ In order to build other docker images, the Worker needs to be setup to support D
 
 #### Configuration for Docker Builds in Trusty Build Environments
 
-With Trusty build images a few additional steps are required. Since Docker-ce can't run on its own inside another Docker container, it'll connect to the Host's Docker daemon to execute the respective commands.
+With Trusty build images a few additional steps are required. Since `docker-ce` can't run on its own inside another Docker container, it'll connect to the Host's Docker daemon to execute the respective commands.
 
 > For non-AWS deployments, please make sure that the worker machine has a private IP address configured on one of its interfaces.
 

--- a/user/enterprise/build-images.md
+++ b/user/enterprise/build-images.md
@@ -69,7 +69,7 @@ In order to build other docker images, the Worker needs to be setup to support D
     export TRAVIS_WORKER_DOCKER_PRIVILEGED="true"
 ```
 
-You will then need to restart each Worker, you can find more information on this here: https://docs.travis-ci.com/user/enterprise/worker-cli-commands/#Stopping-and-Starting-the-Worker.
+You will then need to restart each Worker, you can find more information on this here: [https://docs.travis-ci.com/user/enterprise/worker-cli-commands/#Stopping-and-Starting-the-Worker](https://docs.travis-ci.com/user/enterprise/worker-cli-commands/#Stopping-and-Starting-the-Worker).
 
 ### Updates to your .travis.yml files
 

--- a/user/enterprise/build-images.md
+++ b/user/enterprise/build-images.md
@@ -71,7 +71,7 @@ In order to build other docker images, the Worker needs to be setup to support D
     export TRAVIS_WORKER_DOCKER_PRIVILEGED="true"
 ```
 
-#### Additional configuration for Trusty build images
+#### Configuration for Docker Builds in Trusty Build Environments
 
 With Trusty build images a few additional steps are required. Since Docker-ce can't run on its own inside another Docker container, it'll connect to the Host's Docker daemon to execute the respective commands.
 


### PR DESCRIPTION
This PR updates the Docker in Docker section for Trusty build images. Because these days Docker-Engine is no more and has been replaced with Docker-CE, the old approach we've done with Precise doesn't work anymore. There we had Docker actually running in Docker. 
The approach for Trusty build images looks a bit different though. Here we're using the Host's Docker daemon to execute the commands. The disadvantage is: the user has to clean up after they're done building, the advantage though: fast interaction with Docker ✨ 
