### PR TITLE
[Enterprise] Remove devicemapper installer from docs

### DIFF
--- a/user/enterprise/trusty.md
+++ b/user/enterprise/trusty.md
@@ -34,8 +34,6 @@ Next, run the following to complete the install:
 
 This installer uses Docker's `aufs` storage driver. If this default doesn't work out for you, please [get in touch with us](mailto: enterprise@travis-ci.com?subject=Trusty%20Workers) to discuss alternatives.
 
-There are two differences with the non-AWS installer. First, it uses AUFS instead of DeviceMapper and, second doesn't have strict storage device layout requirements which would otherwise be required for setting up the DeviceMapper volumes.
-
 ## Running builds on Trusty
 
 To run builds on a worker with Trusty images, please add `dist: trusty` to your `.travis.yml`. If that key is not present in your project's `.travis.yml`, the build will routed to the Precise build environments instead.

--- a/user/enterprise/trusty.md
+++ b/user/enterprise/trusty.md
@@ -9,7 +9,7 @@ layout: en_enterprise
 
 ## System Setup
 
-**Platform Requirements**: To use the Trusty build containers, the Travis CI installation must be at 2.1.9 or higher. Please be sure to [upgrade](/user/enterprise/upgrading/), if needed, before getting started with this feature. 
+**Platform Requirements**: To use the Trusty build containers, the Travis CI installation must be at 2.1.9 or higher. Please be sure to [upgrade](/user/enterprise/upgrading/), if needed, before getting started with this feature.
 
 **Worker Requirements**: While workers with the older Precise (Ubuntu 12.04) containers can co-exist with Trusty workers in an installation configuration, _Precise build containers and Trusty build containers must be on different instances_. To run both Precise and Trusty builds, at least two worker instances are required.
 
@@ -22,16 +22,7 @@ layout: en_enterprise
 5. Disconnect from the Travis Enterprise platform machine
 
 
-## Installation on AWS
-Spin up at least one additional AWS worker machine. Please note: DeviceMapper installer only supports the recommended c3.2xlarge machines due to the storage layout. Once this are ready, run:
-
-`curl -sSL -o /tmp/installer.sh https://enterprise.travis-ci.com/install/worker/trusty-devicemapper`
-
-Next, run the following to complete the install:
-
-`sudo bash /tmp/installer.sh --travis_enterprise_host="[travis.yourhost.com]" --travis_enterprise_security_token="[RabbitMQ Password/Enterprise Security Token]" --aws=true`
-
-## Installation on Non-AWS
+## Installation
 
 Start at least one additional worker machine and run:
 
@@ -41,8 +32,10 @@ Next, run the following to complete the install:
 
 `sudo bash /tmp/installer.sh --travis_enterprise_host="[travis.yourhost.com]" --travis_enterprise_security_token="[RabbitMQ Password/Enterprise Security Token]"`
 
+This installer uses Docker's `aufs` storage driver. If this default doesn't work out for you, please [get in touch with us](mailto: enterprise@travis-ci.com?subject=Trusty%20Workers) to discuss alternatives.
+
 There are two differences with the non-AWS installer. First, it uses AUFS instead of DeviceMapper and, second doesn't have strict storage device layout requirements which would otherwise be required for setting up the DeviceMapper volumes.
 
 ## Running builds on Trusty
 
-To run builds on a worker with Trusty images, please add `dist: trusty` to your `.travis.yml`. If that key is not present in your project's `.travis.yml`, the build will routed to the Precise build environments instead. 
+To run builds on a worker with Trusty images, please add `dist: trusty` to your `.travis.yml`. If that key is not present in your project's `.travis.yml`, the build will routed to the Precise build environments instead.

--- a/user/enterprise/trusty.md
+++ b/user/enterprise/trusty.md
@@ -36,4 +36,4 @@ This installer uses Docker's `aufs` storage driver. If you have any questions or
 
 ## Running builds on Trusty
 
-To run builds on a worker with Trusty images, please add `dist: trusty` to your `.travis.yml`. If that key is not present in your project's `.travis.yml`, the build will routed to the Precise build environments instead.
+To run builds on a worker with Trusty images, please add `dist: trusty` to your `.travis.yml`. If that key is not present in your project's `.travis.yml`, the build will routed to the default (Precise) build environments instead.

--- a/user/enterprise/trusty.md
+++ b/user/enterprise/trusty.md
@@ -32,7 +32,7 @@ Next, run the following to complete the install:
 
 `sudo bash /tmp/installer.sh --travis_enterprise_host="[travis.yourhost.com]" --travis_enterprise_security_token="[RabbitMQ Password/Enterprise Security Token]"`
 
-This installer uses Docker's `aufs` storage driver. If this default doesn't work out for you, please [get in touch with us](mailto: enterprise@travis-ci.com?subject=Trusty%20Workers) to discuss alternatives.
+This installer uses Docker's `aufs` storage driver. If you have any questions or concerns, please [get in touch with us](mailto: enterprise@travis-ci.com?subject=Trusty%20Workers) to discuss alternatives.
 
 ## Running builds on Trusty
 


### PR DESCRIPTION
This PR removes explanations and instructions for the DeviceMapper installer, because it requires people to use `c3.2xlarge` instances on Amazon EC2 which are now deprecated.  The non-DeviceMapper installer works out as good for now.

Also the wording has been changed from AWS/Non-AWS Installation to just Installation to avoid confusion.