### PR TITLE
Replace `crystal deps` with `shards install`

### DIFF
--- a/user/languages/crystal.md
+++ b/user/languages/crystal.md
@@ -31,7 +31,7 @@ language: crystal
 ```
 {: data-file=".travis.yml"}
 
-This will run `crystal deps` to install dependencies and then `crystal spec` to test your project.
+This will run `shards install` to install dependencies and then `crystal spec` to test your project.
 
 ## Configuration options
 


### PR DESCRIPTION
see travis-ci/travis-build#1325

Reason for this: https://github.com/crystal-lang/crystal/pull/5544

/cc @asterite, @jhass, @waj, and @will