### PR TITLE
Add mention on JavaScript docs for Node 9 support

### DIFF
--- a/user/languages/javascript-with-nodejs.md
+++ b/user/languages/javascript-with-nodejs.md
@@ -44,6 +44,7 @@ releases in your `.travis.yml`:
 - `node` latest stable Node.js release
 - `iojs` latest stable io.js release
 - `lts/*` latest LTS Node.js release
+- `9` latest 9.x release
 - `8` latest 8.x release
 - `7` latest 7.x release
 - `6` latest 6.x release


### PR DESCRIPTION
The JavaScript docs currently only mention support up to Node 8, and but Node 9 is the current version. I tried using `"9"` in my `.travis.yml` and `nvm` downloaded `v9.8.0`. This would update the docs to mention that support 😄 