### PR TITLE
Add fast_finish to recommended Rust configuration

### DIFF
--- a/user/languages/rust.md
+++ b/user/languages/rust.md
@@ -65,6 +65,7 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+  fast_finish: true
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
This allows tests to be run against nightly rust without slowing down the overall build.