### PR TITLE
Move Middleman config to root dir because Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-#ruby '2.4.3'
+ruby '2.4.3'
 
 gem 'faraday'
 gem 'html-proofer', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,5 +248,8 @@ DEPENDENCIES
   ruby18_source_location
   therubyracer
 
+RUBY VERSION
+   ruby 2.4.3p205
+
 BUNDLED WITH
    1.16.1

--- a/Rakefile
+++ b/Rakefile
@@ -208,9 +208,5 @@ end
 
 desc 'make API docs'
 task :make_api do
-  Dir.chdir('slate') do
-    sh 'bundle exec middleman build --clean'
-    FileUtils.mkdir_p '../api'
-    sh 'cp -r build/* ../api/'
-  end
+  sh 'bundle exec middleman build --clean'
 end

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: "Travis CI Documentation"
 email: "support@travis-ci.com"
 url: "https://docs.travis-ci.com"
 docs_github: "https://github.com/travis-ci/docs-travis-ci-com/"
-exclude: [bin, CNAME, Gemfile, Gemfile.lock, README.md, slate, vendor, '*.erb']
+exclude: [bin, CNAME, Gemfile, Gemfile.lock, README.md, slate, vendor, '*.erb', 'config.rb']
 markdown: kramdown
 permalink: :/title/
 syntax-highlighting:

--- a/config.rb
+++ b/config.rb
@@ -6,6 +6,10 @@ set :images_dir, 'images'
 
 set :fonts_dir, 'fonts'
 
+set :source, 'slate/source'
+
+set :build_dir, 'api'
+
 set :markdown_engine, :redcarpet
 
 set :markdown, :fenced_code_blocks => true, :smartypants => true, :disable_indented_code_blocks => true, :prettify => true, :tables => true, :with_toc_data => true, :no_intra_emphasis => true


### PR DESCRIPTION
Apparently 

> Heroku apps expect the app directory structure at the root of the repository. If your app is inside a subdirectory in your repository, it won’t run when pushed to Heroku.

And when we switched to generating the Slate on the fly we started cding into `slate` and running Ruby, which was causing the weird version issues.

:-( :-( 