### PR TITLE
Correct typo of Travis .com in "Travis CI for Private Projects" page

### DIFF
--- a/user/travis-pro.md
+++ b/user/travis-pro.md
@@ -98,7 +98,7 @@ settings on GitHub, and resync your Travis CI account:
 GitHub](https://help.github.com/articles/making-a-public-repository-private/) on
 how to make a repository private.
 
-2. On [Travis CI .org](https://travis-ci.org) go to *Accounts*, click *Sync
+2. On [Travis CI .com](https://travis-ci.com) go to *Accounts*, click *Sync
    Account*, then toggle the repository to *ON*.
 
 5. If you're using the Travis CI [commmand line client](https://github.com/travis-ci/travis.rb#readme)


### PR DESCRIPTION
I just corrected a typo  in the ["How can I make a public repository private?" section](https://docs.travis-ci.com/user/travis-pro/#How-can-I-make-a-public-repository-private%3F).