### PR TITLE
Minor fixes for repeated words and subordinate that

### DIFF
--- a/user/deployment/atlas.md
+++ b/user/deployment/atlas.md
@@ -11,7 +11,7 @@ Travis CI can automatically deploy your application to [Atlas](https://atlas.has
 To deploy your application to Atlas:
 
 1. Sign in to your Atlas account.
-2. [Generate](https://atlas.hashicorp.com/settings/tokens) an Atlas API token for for Travis CI.
+2. [Generate](https://atlas.hashicorp.com/settings/tokens) an Atlas API token for Travis CI.
 3. Add the following minimum configuration to your `.travis.yml`
 
    ```yaml

--- a/user/deployment/testfairy.md
+++ b/user/deployment/testfairy.md
@@ -43,7 +43,7 @@ Always [encrypt](http://docs.travis-ci.com/user/encrypting-files/) your keystore
 
 ## Symbols file
 
-Attach your symbols mapping file so TestFairy can de-obfuscate and symbolicate crash reports automatically. Set the `symbols-file` key to to your `proguard_mapping.txt` file or to a zipped `.dSYM` file.
+Attach your symbols mapping file so TestFairy can de-obfuscate and symbolicate crash reports automatically. Set the `symbols-file` key to your `proguard_mapping.txt` file or to a zipped `.dSYM` file.
 
 ```yaml
 deploy:

--- a/user/notifications.md
+++ b/user/notifications.md
@@ -750,7 +750,7 @@ See [the code](https://github.com/travis-ci/docs-travis-ci-com/tree/master/_plug
 is an example Django view which implements this in Python.
 
 1. [Travis Golang Hooks Verification](https://gist.github.com/theshapguy/7d10ea4fa39fab7db393021af959048e)
-is a small webapp in Go which verifies the the hook.
+is a small webapp in Go which verifies the hook.
 
 1. [travis-webhook-verification-nodejs](https://github.com/Brodan/travis-webhook-verification-nodejs)
 contains two examples for verifying webhooks in Node.js using [express](https://github.com/Brodan/travis-webhook-verification-nodejs/blob/master/express.js)

--- a/user/private-dependencies.md
+++ b/user/private-dependencies.md
@@ -30,7 +30,7 @@ to your situation.
 
 You can use a [dedicated CI user account](#Dedicated-User-Account) for all but
 the deploy key approach. This allows you to limit access to a well defined list
-of repositories, and make sure that that access is read only.
+of repositories, and make sure that access is read only.
 
 ## Deploy Key
 
@@ -150,7 +150,7 @@ updating ssh key for myorg/main with key from myorg_key
 Current SSH key: CI dependencies
 ```
 
-Starting with the 1.7.0 release of the `travis` command line tool, you are able to combine it with the `repos` command to set up the key not only for for "main" and "main2", but all repositories under the "myorg" organization.
+Starting with the 1.7.0 release of the `travis` command line tool, you are able to combine it with the `repos` command to set up the key not only for "main" and "main2", but all repositories under the "myorg" organization.
 
 ```bash
 $ travis repos --active --owner myorg --pro | xargs -I % travis sshkey --upload myorg_key -r % --description "CI dependencies"

--- a/user/ssh-known-hosts.md
+++ b/user/ssh-known-hosts.md
@@ -64,7 +64,7 @@ Say your build instance connects to the SSH server *ssh.example.com*:
     - If you have previously connected to *ssh.example.com* from a trusted local computer, run `ssh-keygen -F ssh.example.com` to display its public key.
 
     - If you have not yet connected to *ssh.example.com*, run `ssh-keyscan ssh.example.com` to retrieve it and `ssh-keygen -F ssh.example.com` to display it.
-    Ideally, you would double-check with the owner of *ssh.example.com* that that is indeed the server's public key and not the key of a spoofed instance of *ssh.example.com*.
+    Ideally, you would double-check with the owner of *ssh.example.com* that it is indeed the server's public key and not the key of a spoofed instance of *ssh.example.com*.
 
 3. Configure Travis CI to use the public key of the SSH server:
 Add the key server's public key *KEY* to the SSH `known_hosts` file, e.g., with the following addition to the installation phase:


### PR DESCRIPTION
In `user/ssh-known-hosts.md`, the repeated that is grammatically correct but should be rephrased to avoid confusion.