### PR TITLE
Update PostgreSQL docs to reflect current reality

### DIFF
--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -170,7 +170,10 @@ before_script:
 
 ### Using a different PostgreSQL Version
 
-The Travis CI build environments use version 9.1 by default, but other versions from the official [PostgreSQL APT repository](http://apt.postgresql.org) are also available. To use a version other than the default, specify only the **major.minor** version in your `.travis.yml`:
+The Travis CI build environments use version 9.1 by default, but other versions
+from the official [PostgreSQL APT repository](http://apt.postgresql.org) are
+also available. To use a version other than the default, specify only the
+**major.minor** version in your `.travis.yml`:
 
 ```yaml
 addons:
@@ -178,26 +181,23 @@ addons:
 ```
 {: data-file=".travis.yml"}
 
-The following versions are available on Linux builds:
+Many PostgreSQL versions have been preinstalled in our build environments, and
+others may be installed may be added and activated at build time by using a
+combination of the `postgresql` and `apt` addons along with a global env var
+override for `PGPORT`:
 
-| PostgreSQL | sudo enabled precise | sudo enabled trusty | container precise | container trusty |
-|:----------:|:--------------------:|:-------------------:|:-----------------:|:----------------:|
-|    9.1     |         yes          |                     |        yes        |                  |
-|    9.2     |         yes          |         yes         |        yes        |       yes        |
-|    9.3     |         yes          |         yes         |        yes        |       yes        |
-|    9.4     |         yes          |         yes         |        yes        |       yes        |
-|    9.5     |         yes          |         yes         |                   |       yes        |
-|    9.6     |                      |         yes         |                   |       yes        |
-
-On OS X, the following versions are installed:
-
-|     image     | version |
-|:-------------:|:-------:|
-|    xcode61    |   9.3   |
-| beta-xcode6.1 |   9.3   |
-|   xcode6.4    |   9.4   |
-|   xcode7.3    |   9.5   |
-|    xcode8     |   9.5   |
+``` yaml
+addons:
+  postgresql: "10"
+  apt:
+    packages:
+    - postgresql-10
+    - postgresql-client-10
+env:
+  global:
+  - PGPORT=5433
+```
+{: data-file=".travis.yml"}
 
 ### Using PostGIS
 

--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -182,9 +182,8 @@ addons:
 {: data-file=".travis.yml"}
 
 Many PostgreSQL versions have been preinstalled in our build environments, and
-others may be installed may be added and activated at build time by using a
-combination of the `postgresql` and `apt` addons along with a global env var
-override for `PGPORT`:
+others may be added and activated at build time by using a combination of the
+`postgresql` and `apt` addons along with a global env var override for `PGPORT`:
 
 ``` yaml
 addons:


### PR DESCRIPTION
by removing the outdated and doomed-to-be-outdated table of which versions are available where, and adding a section about combining `apt` and `postgresql` addons to install and enable arbitrary versions on both container-based and sudo-enabled Linux.