### PR TITLE
Add TOC to for-beginners

### DIFF
--- a/user/for-beginners.md
+++ b/user/for-beginners.md
@@ -4,6 +4,8 @@ layout: en
 
 ---
 
+<div id="toc"></div>
+
 Welcome to Travis CI! This page provides some contexts and terminologies used
 throughout the platform and documentation, which might be helpful if you are new
 here or new to Continuous Integration (CI).


### PR DESCRIPTION
Noticed that there's no TOC exist in this section during scraping the index, this patch attempts to add one according to other sections' practices.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>