### PR TITLE
Add example for smalltalk_vm option

### DIFF
--- a/user/languages/smalltalk.md
+++ b/user/languages/smalltalk.md
@@ -30,6 +30,11 @@ os:
   - linux
   - osx
 
+# Select virtual machine(s)
+smalltalk_vm:
+  - Squeak-5.0
+  - Pharo-5.0
+
 # Select compatible Smalltalk image(s)
 smalltalk:
   - Squeak-trunk


### PR DESCRIPTION
With the merge of https://github.com/travis-ci/travis-gatekeeper/pull/207 Smalltalk users now have the option of selecting a `smalltalk_vm`