### PR TITLE
Indicate GitHub Apps integration needs `--pro`

### DIFF
--- a/user/deployment/releases.md
+++ b/user/deployment/releases.md
@@ -48,7 +48,7 @@ You can also use the [Travis CI command line client](https://github.com/travis-c
 travis setup releases
 ```
 
-Or, if you're using a private repository:
+Or, if you're using a private repository or the GitHub Apps integration:
 
 ```bash
 travis setup releases --pro


### PR DESCRIPTION
`travis setup releases --pro` should be run when using the GitHub Apps integration

I used to use the old travis-ci.org services system for my builds. Recently I started using the new GitHub Apps integration but just could *not* get authentication to work.

It wasn't until I dug up the Travis CI blog post for the new integration that I discovered this would require using the travis-ci.com API endpoint instead. Hopefully this change will help others who also get stuck here.

Feel free to make changes to my branch so that this best fits your docs guidelines 👍 
