### PR TITLE
Update current OS X and Xcode versions

### DIFF
--- a/user/languages/objective-c.md
+++ b/user/languages/objective-c.md
@@ -20,7 +20,7 @@ Objective-C/Swift builds are not available on the Linux environments.
 
 ## Supported Xcode versions
 
-Travis CI uses OS X 10.11.6 (and Xcode 7.3.1) by default. You can use another
+Travis CI uses OS X 10.12.6 (and Xcode 8.3.3) by default. You can use another
 version of Xcode (and OS X) by specifying the corresponding `osx_image` key from
 the following table:
 


### PR DESCRIPTION
The Objective-C/Swift pages have text that references outdated default versions of OS X and Xcode. This change corrects that text to match the OS X Build Environment page as well as the tables on both pages.