### PR TITLE
Clarify that the `tags` option applies to npm

### DIFF
--- a/user/deployment/npm.md
+++ b/user/deployment/npm.md
@@ -108,7 +108,7 @@ We recommend deploying from only one job with
 
 ## Tagging releases
 
-You can automatically tag releases with the `tag` option:
+You can automatically add [npm distribution tags](https://docs.npmjs.com/getting-started/using-tags) with the `tag` option:
 
 ```yaml
 deploy:


### PR DESCRIPTION
I initially got confused that thought these were git tags.  Hopefully this clarification will point future users in the right direction.