### PR TITLE
Fixed JDL/JVM version anchor for Trusty/Precise.

### DIFF
--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -187,8 +187,8 @@ details.
 
 The list of available JVMs for different dists are at
 
-  * [JDKs installed for **Trusty**](/user/reference/trusty/#jvm-clojure-groovy-java-scala-images)
-  * [JDKs installed for **Precise**](/user/reference/precise/#jvm-clojure-groovy-java-scala-vm-images)
+  * [JDKs installed for **Trusty**](/user/reference/trusty/#JVM-(Clojure%2C-Groovy%2C-Java%2C-Scala)-images)
+  * [JDKs installed for **Precise**](/user/reference/precise/#JVM-(Clojure%2C-Groovy%2C-Java%2C-Scala)-images)
 
 ### Switching JDKs Within One Job
 


### PR DESCRIPTION
Current anchors are broken.  Hopefully these work better.