### PR TITLE
Use encrypted AWS Access Key ID

### DIFF
--- a/user/deployment/elasticbeanstalk.md
+++ b/user/deployment/elasticbeanstalk.md
@@ -12,7 +12,7 @@ successful build.
 
 To deploy to AWS Elastic Beastalk add the following to your `.travis.yml`:
 
-* `access-key-id`: AWS Access Key ID, obtained from your [AWS Console](https://console.aws.amazon.com/iam/home?#security_credential).
+* `access-key-id`: [Encrypted](/user/encryption-keys#Usage) AWS Access Key ID, obtained from your [AWS Console](https://console.aws.amazon.com/iam/home?#security_credential).
 * `secret-access-key`: [Encrypted](/user/encryption-keys#Usage) AWS Secret Key, obtained from your [AWS Console](https://console.aws.amazon.com/iam/home?#security_credential).
 * `region`: **must** be the region the Elastic Beanstalk application is running on, for example `us-east-1`.
 * `app`: Application name.
@@ -22,7 +22,7 @@ To deploy to AWS Elastic Beastalk add the following to your `.travis.yml`:
 ```yaml
 deploy:
   provider: elasticbeanstalk
-  access_key_id: <access-key-id>
+  access_key_id: "Encrypted <access-key-id>="
   secret_access_key:
     secure: "Encypted <secret-access-key>="
   region: "us-east-1"  


### PR DESCRIPTION
According to "[Understanding and Getting Your Security Credentials > Access Keys (Access Key ID and Secret Access Key) ](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)"

> Do not provide your access keys to a third party, even to help find your canonical user ID. By doing this, you might give someone full access to your account. 

So I think we should encrypt **AWS Access Key ID** same as AWS Secret Access Key. What do you think?