### PR TITLE
Code styles readability

### DIFF
--- a/assets/stylesheets/_base.sass
+++ b/assets/stylesheets/_base.sass
@@ -11,8 +11,6 @@ p
   @include linkStyle
 
 %code-styles
-  border: 1px solid $cement-grey
-  border-radius: 4px
   font-family: monaco, monospace
   font-size: $font-size-xs
   color: #000
@@ -25,12 +23,12 @@ address
 code
   @extend %code-styles
   display: inline-block
-  margin: 0 0 0 .3em
   padding: 0em 0.4em
   line-height: 1.7
 
 pre
   @extend %code-styles
+  border-radius: 3px
   margin-top: 1em
   padding: 1em 1.5em
   line-height: 1.5em
@@ -55,7 +53,7 @@ blockquote
   code
     color: $oxide-blue
     border-color: $oxide-blue
-    background-color: $white
+    background-color: transparent
 
 ol
   padding: 0 0 0 1.3em

--- a/assets/stylesheets/prism.scss
+++ b/assets/stylesheets/prism.scss
@@ -182,7 +182,6 @@ pre.code-toolbar > .toolbar span {
 	padding: 0 .5em;
 	background: #f5f2f0;
 	background: rgba(224, 224, 224, 0.2);
-	box-shadow: 0 2px 0 0 rgba(0,0,0,0.2);
 	border-radius: .5em;
 }
 


### PR DESCRIPTION
The current `code` styles make text rather hard to read, especially when used a lot in a single sentence or lists. E.g.:

![image](https://user-images.githubusercontent.com/2208/41234934-d63e94f8-6d8d-11e8-89a5-74babd15956d.png)

This PR is meant to dial this down a little. I generally feel a more "flat" style feels a little more clean and modern, too:

![image](https://user-images.githubusercontent.com/2208/41235091-397cfc9e-6d8e-11e8-8411-31b89d51f3ae.png)

It also removes the odd curved underline from the format tag on the right side:

![image](https://user-images.githubusercontent.com/2208/41235012-16666d80-6d8e-11e8-9585-55347a348945.png)

Now:

![image](https://user-images.githubusercontent.com/2208/41235052-2a1a22f4-6d8e-11e8-8db7-3c82905669d9.png)

It also removes the border and white background color from code tags in `blockquote` tags (which have a blue background). This looks especially hardcore when there are lots of code tags inside a blockquote. E.g.:

![image](https://user-images.githubusercontent.com/2208/41235372-fa83a460-6d8e-11e8-8f8f-8b0a3f7041e5.png)

Actual example from current production:

![image](https://user-images.githubusercontent.com/2208/41235275-c047df46-6d8e-11e8-9865-1ee76ab8f6af.png)


Now:

![image](https://user-images.githubusercontent.com/2208/41235252-afe1e692-6d8e-11e8-9528-6832ed846621.png)
