### PR TITLE
Corrected order of install steps in example

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -106,8 +106,8 @@ python:
   - "pypy3.5"
 # command to install dependencies
 install:
-  - pip install .
   - pip install -r requirements.txt
+  - pip install .
 # command to run tests
 script: pytest
 ```


### PR DESCRIPTION
You should first `pip install -r requirements.txt` and then `pip install .` and not the other way round. The reason is, that the `requrements.txt` carries the dependencies with pinned versions and the `setup.py` only the dependencies (and conflicting version dependencies if necessary).