### PR TITLE
Overwrite ~/.netrc if token is needed

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -299,7 +299,7 @@ We recommend using a read-only GitHub OAuth token to authenticate when using git
 
 ```
 before_install:
-- echo -e "machine github.com\n  login $GITHUB_TOKEN" >> ~/.netrc
+- echo -e "machine github.com\n  login $GITHUB_TOKEN" > ~/.netrc
 - git lfs pull
 ```
 

--- a/user/private-dependencies.md
+++ b/user/private-dependencies.md
@@ -190,7 +190,7 @@ $ travis env set CI_USER_PASSWORD mypassword123 --private -r myorg/main
 
 ```bash
 before_install:
-- echo -e "machine github.com\n  login ci-user\n  password $CI_USER_PASSWORD" >> ~/.netrc
+- echo -e "machine github.com\n  login ci-user\n  password $CI_USER_PASSWORD" > ~/.netrc
 ```
 
 It is also possible to inject the credentials into URLs, for instance, in a Gemfile, it would look like this:
@@ -221,7 +221,7 @@ gem 'lib2', github: "myorg/lib2"
 >   submodules:
 >     false
 > before_install:
->   - echo -e "machine github.com\n  login ci-user\n  password $CI_USER_PASSWORD" >>~/.netrc
+>   - echo -e "machine github.com\n  login ci-user\n  password $CI_USER_PASSWORD" >~/.netrc
 >   - git submodule update --init --recursive
 > ```
 
@@ -255,7 +255,7 @@ You can then have Travis CI write to the `~/.netrc` on every build.
 
 ```yaml
 before_install:
-- echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc
+- echo -e "machine github.com\n  login $CI_USER_TOKEN" > ~/.netrc
 ```
 {: data-file=".travis.yml"}
 
@@ -287,7 +287,7 @@ gem 'lib2', github: "myorg/lib2"
 >   submodules:
 >     false
 > before_install:
->   - echo -e "\n\nmachine github.com\n  $CI_TOKEN\n" >>~/.netrc
+>   - echo -e "\n\nmachine github.com\n  $CI_TOKEN\n" >~/.netrc
 >   - git submodule update --init --recursive
 > ```
 


### PR DESCRIPTION
Otherwise the first machine.github.com will continue to take effect,
if that is still set up.