### PR TITLE
Change docker.md header levels to make TOC appear

### DIFF
--- a/user/docker.md
+++ b/user/docker.md
@@ -27,7 +27,7 @@ examples.
 
 > For information on how to use Docker on Travis CI Enterprise check out [Enabling Docker Builds](https://docs.travis-ci.com/user/enterprise/build-images/#Enabling-Docker-Builds).
 
-### Using a Docker Image from a Repository in a Build
+## Using a Docker Image from a Repository in a Build
 
 This [example repository](https://github.com/travis-ci/docker-sinatra) runs two
 Docker containers built from the same image:
@@ -90,7 +90,7 @@ Finished in 0.022952763 seconds.
 43.57 tests/s, 43.57 assertions/s
 ```
 
-### Building a Docker Image from a Dockerfile
+## Building a Docker Image from a Dockerfile
 
 Instead of downloading the Docker image from
 [carlad/sinatra](https://registry.hub.docker.com/u/carlad/sinatra/) you can
@@ -125,7 +125,7 @@ script:
 ```
 {: data-file=".travis.yml"}
 
-### Pushing a Docker Image to a Registry
+## Pushing a Docker Image to a Registry
 
 In order to push an image to a registry, one must first authenticate via `docker
 login`.  The email, username, and password used for login should be stored in
@@ -147,7 +147,7 @@ Within your `.travis.yml` prior to attempting a `docker push` or perhaps before
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 ```
 
-#### Branch Based Registry Pushes
+### Branch Based Registry Pushes
 
 To push a particular branch of your repository to a remote registry,
 use the custom deploy section of your `.travis.yml`:
@@ -171,7 +171,7 @@ docker push USER/REPO
 {: data-file="docker_push"}
 
 
-#### Private Registry Login
+### Private Registry Login
 
 When pushing to a private registry, be sure to specify the hostname in the
 `docker login` command, e.g.:
@@ -180,7 +180,7 @@ When pushing to a private registry, be sure to specify the hostname in the
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin registry.example.com
 ```
 
-### Using Docker Compose
+## Using Docker Compose
 
 The [Docker Compose](https://docs.docker.com/compose/) tool is also [installed in the Docker enabled environment](/user/reference/trusty/#Docker).
 
@@ -199,7 +199,7 @@ before_install:
 ```
 {: data-file=".travis.yml"}
 
-### Installing a newer Docker version
+## Installing a newer Docker version
 
 You can upgrade to the latest version and use any new Docker features by manually
 updating it in the `before_install` step of your `.travis.yml`:
@@ -225,7 +225,7 @@ addons:
 
 > Check what version of Docker you're running with `docker --version`
 
-#### Examples
+## Examples
 
 - [heroku/logplex](https://github.com/heroku/logplex/blob/master/.travis.yml) (Heroku log router)
 - [kartorza/docker-pg-backup](https://github.com/kartoza/docker-pg-backup/blob/master/.travis.yml) (A cron job that will back up databases running in a docker PostgreSQL container)


### PR DESCRIPTION
This makes it consistent with other documents in "Getting started".

Also changed header level for "Examples" section to also appear in the TOC, to make it consistent with build-stages.md.