### PR TITLE
Add missing "toc" blocks for the docs in "Getting Started"

### DIFF
--- a/user/conditional-builds-stages-jobs.md
+++ b/user/conditional-builds-stages-jobs.md
@@ -3,6 +3,8 @@ title: Conditional Builds, Stages, and Jobs
 layout: en
 ---
 
+<div id="toc"></div>
+
 ## Conditional Builds, Stages, and Jobs
 
 You can filter out, and reject builds, stages, and jobs by specifying conditions in your build configuration (your `.travis.yml` file).

--- a/user/gui-and-headless-browsers.md
+++ b/user/gui-and-headless-browsers.md
@@ -4,6 +4,8 @@ layout: en
 
 ---
 
+<div id="toc"></div>
+
 ## What This Guide Covers
 
 This guide covers headless GUI & browser testing using tools provided by the Travis [CI environment](/user/reference/precise/). Most of the content is technology-neutral and does not cover all the details of specific testing tools (like Poltergeist or Capybara). We recommend you start with the [Getting Started](/user/getting-started/) and [Build Configuration](/user/customizing-the-build/) guides before reading this one.

--- a/user/speeding-up-the-build.md
+++ b/user/speeding-up-the-build.md
@@ -8,6 +8,8 @@ Travis CI implements a few optimizations which help to speed up your build,
 like in memory filesystem for DB's files, but there is a range of things
 that can be done to improve build times even more.
 
+<div id="toc"></div>
+
 ## Parallelizing your builds across virtual machines
 
 To speed up a test suite, you can break it up into several parts using


### PR DESCRIPTION
A bit unsure about the TOC placement, because some of the documents have a bit of text preceding the TOC (like in "Getting Started"), and some of them don't (like in "Core Concepts for Beginners").