### PR TITLE
Update OpenSSL warning to reflect Python 3.7

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -126,8 +126,8 @@ You can specify these in your builds with `3.5-dev`, `3.6-dev`,
 `3.7-dev` or `3.8-dev`.
 
 {: .warning}
-> Recent Python development branches [require OpenSSL 1.0.2+](https://github.com/travis-ci/travis-ci/issues/9069).
-> As this library is not available for Trusty, `3.7-dev`, `3.8-dev`, and `nightly`
+> Recent Python branches [require OpenSSL 1.0.2+](https://github.com/travis-ci/travis-ci/issues/9069).
+> As this library is not available for Trusty,  `3.7`, `3.7-dev`, `3.8-dev`, and `nightly`
 > do not work (or use outdated archive).
 
 ## Default Build Script


### PR DESCRIPTION
Now that [Python 3.7 has shipped](https://docs.python.org/3/whatsnew/3.7.html), this warning not only covers development branches but also production branches of CPython.