### PR TITLE
python.md: Replace broken pypy2.7 with pypy

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -86,19 +86,17 @@ virtualenv:
 
 Travis CI supports PyPy and PyPy3.
 
-To test your project against PyPy, add "pypy" or "pypy3" to the list of Pythons
+To test your project against PyPy, add "pypy3.5" to the list of Pythons
 in your `.travis.yml`:
 
 ```yaml
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
   # PyPy versions
-  - "pypy2.7"
   - "pypy3.5"
 # command to install dependencies
 install:


### PR DESCRIPTION
pypy2.7 is broken.

Related to https://github.com/travis-ci/travis-ci/issues/9452

It was introduced to the docs in https://github.com/travis-ci/docs-travis-ci-com/pull/1704