### PR TITLE
clarify GitHub Releases uploading directory

### DIFF
--- a/user/deployment/releases.md
+++ b/user/deployment/releases.md
@@ -4,7 +4,7 @@ layout: en
 
 ---
 
-Travis CI can automatically upload assets from your [`$TRAVIS_BUILD_DIR`](/user/environment-variables/#Default-Environment-Variables) to git tags on your GitHub repository.
+Travis CI can automatically upload assets to git tags on your GitHub repository.
 
 For a minimal configuration, add the following to your `.travis.yml`:
 
@@ -157,6 +157,8 @@ deploy:
     tags: true
 ```
 {: data-file=".travis.yml"}
+
+Please note that all paths in `file` are relative to the current working directory, not to [`$TRAVIS_BUILD_DIR`](/user/environment-variables/#Default-Environment-Variables).
 
 ### Conditional releases
 


### PR DESCRIPTION
Refer to https://github.com/travis-ci/travis-ci/issues/6172#issuecomment-226825661 .

The current documentation states that all paths in `file` field are relative to `$TRAVIS_BUILD_DIR`, but it's not true. For instance, I've spent two hours to understand why Travis creates new Release and it's empty. The thing was I changed the current directory in at `before_deploy` stage.

Also, Appveyor's artifacts path is **always** relative to the building directory, so many users may expect the same behavior from Travis.