### PR TITLE
Docs Updates for new xcode default

### DIFF
--- a/_data/xcodes.yml
+++ b/_data/xcodes.yml
@@ -3,6 +3,7 @@ osx_images:
     xcode: "9.4"
     osx_version: "10.13"
     xcode_full_version: "9.4.1"
+    default: true
     image_publish_date: 2018-06-15
     sdks:
       - macosx10.13
@@ -232,7 +233,6 @@ osx_images:
     xcode: "8.3"
     osx_version: "10.12"
     xcode_full_version: "8.3.3"
-    default: true
     image_publish_date: 2017-06-06
     sdks:
       - macosx10.12

--- a/user/build-environment-updates/2018-07-31.md
+++ b/user/build-environment-updates/2018-07-31.md
@@ -1,0 +1,60 @@
+---
+title: Build Environment Update History
+layout: en
+permalink: /user/build-environment-updates/2018-07-31/
+category: mac_build_env_updates
+date: 2018-07-31
+---
+
+
+## 2018-06-15
+
+This update applies to the default osx image for osx builds
+The new default xcode image is running on High Sierra 10.13
+Xcode 9.4.1
+Build version 9F2000
+
+### Schedule
+
+2018-07-31 19:00 UTC
+
+### Changed
+
+**SDKs**
+- iPhoneOS11.4.sdk - iOS 11.4 (iphoneos11.4)
+- tvOS 11.4 (15L576)
+- iOS 11.3 (15E217)
+- watchOS 4.3 (15T212)
+- macOS 10.13.4 (17E189)
+
+**Swift**
+- Apple Swift version 4.1.2 (swiftlang-902.0.54 clang-902.0.39.2)
+
+**Gems**
+- cocoapods `1.5.3`
+- fastlane `2.89.0`
+- xctool version `0.3.4`
+- rake `12.3.1`
+- rdoc `6.0.3`
+- xcodeproj `1.5.7`
+
+### Deprecated
+
+N/A
+
+
+### Removed
+
+Previous default image, xcode8.3.  If you need the previous default please specify `osx_image=xcode8.3` in your .travis.yml
+
+### Fixed
+
+N/A
+
+### Security
+
+N/A
+
+### Details
+
+N/A

--- a/user/languages/objective-c.md
+++ b/user/languages/objective-c.md
@@ -20,7 +20,7 @@ Objective-C/Swift builds are not available on the Linux environments.
 
 ## Supported Xcode versions
 
-Travis CI uses OS X 10.12.6 (and Xcode 8.3.3) by default. You can use another
+Travis CI uses OS X 10.13 (and Xcode 9.4.1) by default. You can use another
 version of Xcode (and OS X) by specifying the corresponding `osx_image` key from
 the following table:
 

--- a/user/reference/osx.md
+++ b/user/reference/osx.md
@@ -39,7 +39,7 @@ os: osx
 
 ## OS X Version
 
-Travis CI uses OS X 10.12.6 (and Xcode 8.3.3) by default . You can use another version of OS X (and Xcode) by specifying the corresponding `osx_image` key from the following table:
+Travis CI uses OS X 10.13 and Xcode 9.4.1 by default . You can use another version of OS X (and Xcode) by specifying the corresponding `osx_image` key from the following table:
 
 <table>
 
@@ -244,7 +244,7 @@ Recent 1.16.2 version (usually the most recent)
 
 ## Xcode version
 
-Xcode 8.3.3 is installed with all available simulators and SDKs.
+Xcode 9.4.1 is installed with all available simulators and SDKs.
 Command Line Tools are also installed.
 
 {% for image in site.data.xcodes.osx_images %}


### PR DESCRIPTION
9️⃣ 4️⃣ 🍎 👏   DON'T MERGE ME YET - the date for switch is set for Tuesday, July 31st. 
We're moving from xcode8.3 -> to xcode9.4 as our default image.  

Meta-docs and communications checklist [here:](https://github.com/travis-pro/team-jade/issues/833) 