### PR TITLE
Restore leading content

### DIFF
--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -24,10 +24,13 @@
             </div>
           {% endunless%}
 
+          {{ content }}
+<!--
           {% include anchor_headings.html html=content anchorClass="toc-anchor" anchorBody="#" %}
 
         </main>
-      </div><!-- /#content -->
+      </div> -->
+      <!-- /#content -->
 
       {% include footer.html %}
     </div><!-- /.wrapper -->


### PR DESCRIPTION
Looks like there is a bug in allejo/jekyll-anchor-headings/issues/3 that does not show content before the first heading. Introduced in #1909

This PR restores that pending a fix. 

FAO @cotsog -- thanks!