### PR TITLE
Minimal clarification of .com/org

### DIFF
--- a/user/best-practices-security.md
+++ b/user/best-practices-security.md
@@ -41,6 +41,8 @@ If you discover a leak in one of your build logs it’s essential that you revok
 
 Instead of deleting build logs manually, you can do so using the [Travis CI CLI](https://github.com/travis-ci/travis.rb#logs) or the  [API](https://developer.travis-ci.com/resource/log#delete).
 
+> Note that if you're still using [http://www.travis-ci.org](travis-ci.org) you need to use the [open source API](https://developer.travis-ci.org/resource/log#delete) instead.
+
 ## Rotate tokens and secrets periodically
 Rotate your tokens and secrets regularly. GitHub OAuth tokens can be found in your [Developer Settings](https://github.com/settings/developers) on the GitHub site. Please regularly rotate credentials for other third-party services as well.
 

--- a/user/caching.md
+++ b/user/caching.md
@@ -306,6 +306,8 @@ Use one of the following ways to access your cache and delete it if necessary:
 
 - The [API](https://api.travis-ci.com/#/repos/:owner_name/:name/caches)
 
+> Note that if you're still using [http://www.travis-ci.org](travis-ci.org) you need to use the .org url to reach your settings page and in the API request.
+
 ## Configuration
 
 ### Enabling multiple caching features

--- a/user/notifications.md
+++ b/user/notifications.md
@@ -4,7 +4,7 @@ layout: en
 
 ---
 
-
+> Note that if you're still using [http://www.travis-ci.org](travis-ci.org) you need to use `--org` instead of `--com` in all of the commands shown on this page.
 
 Travis CI can notify you about your build results through email, IRC, chat or custom webhooks.
 

--- a/user/private-dependencies.md
+++ b/user/private-dependencies.md
@@ -153,7 +153,7 @@ Current SSH key: CI dependencies
 Starting with the 1.7.0 release of the `travis` command line tool, you are able to combine it with the `repos` command to set up the key not only for "main" and "main2", but all repositories under the "myorg" organization.
 
 ```bash
-$ travis repos --active --owner myorg | xargs -I % travis sshkey --upload myorg_key -r % --description "CI dependencies"
+$ travis repos --active --owner myorg --com | xargs -I % travis sshkey --upload myorg_key -r % --description "CI dependencies"
 updating ssh key for myorg/main with key from myorg_key
 Current SSH key: CI dependencies
 updating ssh key for myorg/main2 with key from myorg_key
@@ -163,6 +163,8 @@ Current SSH key: CI dependencies
 updating ssh key for myorg/lib2 with key from myorg_key
 Current SSH key: CI dependencies
 ```
+
+> Note that if you're still using [http://www.travis-ci.org](travis-ci.org) you need to use `--org` instead of `--com`.
 
 ## Password
 

--- a/user/running-build-in-debug-mode.md
+++ b/user/running-build-in-debug-mode.md
@@ -22,7 +22,7 @@ support@travis-ci.com and let us know which repositories you want activated.
 ## Restarting a job in debug mode
 
 The "Debug build" or "Debug job" button is available on the upper right corner of
-the build and job pages for private repositories. For open source repositories, 
+the build and job pages for private repositories. For open source repositories,
 this button is not available and you will need to use an API call instead.
 
 ![Screenshot of debug build/job buttons](/images/debug_buttons.png)
@@ -48,6 +48,9 @@ $ curl -s -X POST \
 
 As public repositories do not show the Debug button, this is the only way to restart builds
 in the debug mode for public repositories.
+
+> Note that if you're still using [http://www.travis-ci.org](travis-ci.org) you need to use `https://api.travis-ci.org/job/${id}/debug` in the previous command.
+
 
 #### Legacy repositories
 

--- a/user/triggering-builds.md
+++ b/user/triggering-builds.md
@@ -4,19 +4,18 @@ title: Triggering builds with API V3
 layout: en
 ---
 
-
+> Note that if you're still using [http://www.travis-ci.org](travis-ci.org) you need to use `--org` instead of `--com` in all of the commands shown on this page, and make requests to https://api.travis-ci.org.
 
 Trigger Travis CI builds using the API V3 by sending a POST request to `/repo/{slug|id}/requests`:
 
-1. Get an API token from your Travis CI [Profile page](https://travis-ci.com/profile). You'll need the token to authenticate most of these
-   API requests.
+1. Get an API token from your Travis CI [Profile page](https://travis-ci.com/profile). You'll need the token to authenticate most of these API requests.
 
    You can also use the Travis CI [command line client](https://github.com/travis-ci/travis.rb#readme)
    to get your API token:
 
    ```
-   travis login --pro
-   travis token --pro
+   travis login --com
+   travis token --com
    ```
 
 2. Send a request to the API. This example shell script sends a POST request to


### PR DESCRIPTION
* [x] user/best-practices-security.md
* [x] user/caching.md
* [ ] user/getting-started.md
* [x] user/notifications.md
* [x] user/private-dependencies.md
* [x] user/running-build-in-debug-mode.md
* [x] user/triggering-builds.md


Use this text in all notices to make it easier to find and revert (eventually). 

```
> Note that if you're still using [http://www.travis-ci.org](travis-ci.org) you need to use 
```

