### PR TITLE
Remove misleading pytest comment in Python docs

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -58,7 +58,7 @@ install:
   - pip install -r requirements.txt
 # command to run tests
 script:
-  - pytest # or py.test for Python versions 3.5 and below
+  - pytest
 ```
 {: data-file=".travis.yml"}
 
@@ -133,7 +133,7 @@ For example, if your project uses pytest:
 
 ```yaml
 # command to run tests
-script: pytest  # or py.test for Python versions 3.5 and below
+script: pytest
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
`pytest` is the new executable name introduced by Pytest 3.0, it's nothing to do with what version of Python is in use. The old `py.test` continues to work but is deprecated.