### PR TITLE
improve readbility of rust.md

### DIFF
--- a/user/languages/rust.md
+++ b/user/languages/rust.md
@@ -95,7 +95,7 @@ Travis CI uses Cargo to run your build, the default commands are:
 cargo test --verbose
 ```
 
-You always can always configure different comands if you need to. For example,
+You can always configure different comands if you need to. For example,
 if your project is a
 [workspace](http://doc.crates.io/manifest.html#the-workspace-section), you
 should pass `--all` to the build commands to build and test all of the member


### PR DESCRIPTION
Hi Travis CI! Thanks for all your work in open source 👏 

It seems to me that if we remove an extra 'always' from Default Build Scripts section of rust.md , it will improve the flow of that section. Of course I am open to making additional changes or just leaving as is, let me know 😄 