### PR TITLE
OS X gcc is actually an alias for clang

### DIFF
--- a/_includes/c11-cpp11-and-beyond-and-toolchains.md
+++ b/_includes/c11-cpp11-and-beyond-and-toolchains.md
@@ -64,7 +64,8 @@ before_install:
 
 ### GCC on OS X
 
-On OS X, `gcc` is an alias for `clang`. So you must set CC to a specific `gcc` version:
+On OS X, `gcc` is an alias for `clang`, and `g++` is an alias for `clang++`.
+So you must set CC and CXX to specific `gcc`/`g++` versions:
 
 ```yaml
 matrix:

--- a/_includes/c11-cpp11-and-beyond-and-toolchains.md
+++ b/_includes/c11-cpp11-and-beyond-and-toolchains.md
@@ -64,6 +64,8 @@ before_install:
 
 ### GCC on OS X
 
+On OS X, `gcc` is an alias for `clang`. So you must set CC to a specific `gcc` version:
+
 ```yaml
 matrix:
   include:

--- a/user/languages/c.md
+++ b/user/languages/c.md
@@ -110,6 +110,8 @@ Testing against two compilers will create (at least) 2 rows in your build
 matrix. For each row, Travis CI C builder will export the `CC` env variable to
 point to either `gcc` or `clang`.
 
+On OS X, `gcc` is an alias for `clang`. Set a specific [GCC version](#gcc-on-os-x) to use GCC on OS X.
+
 ## Build Matrix
 
 For C projects, `env` and `compiler` can be given as arrays

--- a/user/languages/cpp.md
+++ b/user/languages/cpp.md
@@ -108,6 +108,9 @@ matrix. For each row, the Travis CI C++ builder will export the `CXX` env
 variable to point to either `g++` or `clang++` and `CC` to either `gcc` or
 `clang`.
 
+On OS X, `gcc` is an alias for `clang`, and `g++` is an alias for `clang++`.
+Set a specific [GCC version](#gcc-on-os-x) to use GCC on OS X.
+
 ## Build Matrix
 
 For C++ projects, `env` and `compiler` can be given as arrays


### PR DESCRIPTION
OS X developers who use `compiler: gcc` are actually getting clang.

In the toolchain include and C reference, warn developers that they need to set a specific gcc version, and link to the details in the toolchain section.