### PR TITLE
doc: travis-ci piwik project deprecated

### DIFF
--- a/user/apps.md
+++ b/user/apps.md
@@ -71,7 +71,6 @@ By Frederik Dietz
 Travis CI dashboard<br>
 By Piwik.
 
-- [website](https://ci-status.com/)
 - [source code](https://github.com/piwik/ci-status)
 
 ### node-build-monitor


### PR DESCRIPTION
The Travis-CI Piwik dashboard project is deprecated. The site is no longer
in operation. The source code is still hosted on GitHub.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>