### PR TITLE
Add PSTravis to tools list

### DIFF
--- a/user/apps.md
+++ b/user/apps.md
@@ -232,6 +232,12 @@ Feature complete command line client
 
 - [website](https://github.com/travis-ci/travis#readme)
 
+### PSTravis
+
+Command line client for PowerShell
+
+- [website](https://github.com/felixfbecker/PSTravis#readme)
+
 ## Build Monitoring
 
 ### Bickle
@@ -468,6 +474,10 @@ By Eduardo Antonio Lundgren Melo and Zeno Rocha Bueno Netto
 ## Python
 
 - [TravisPy](http://travispy.readthedocs.org/en/latest/) by Fabio Menegazzo
+
+## PowerShell
+
+- [PSTravis](https://github.com/felixfbecker/PSTravis) by Felix Becker
 
 ## Elixir
 


### PR DESCRIPTION
Coded together this client for PowerShell which PowerShell users might find useful: https://github.com/felixfbecker/PSTravis

I added it to both the CLI section and to libraries, because PowerShell is both a shell and an advanced object-oriented programming language, so I felt like it belonged to both and people might look for one under both categories.