### PR TITLE
Update docs for installing dependencies for Homebrew addon

### DIFF
--- a/user/installing-dependencies.md
+++ b/user/installing-dependencies.md
@@ -275,9 +275,9 @@ addons:
 ```
 {: data-file=".travis.yml"}
 
-### Taps and Casks
+### Installing Casks
 
-The Homebrew addon supports more than just packages. It also supports installing [casks][homebrew-cask]: GUI apps and other things that need to run installers rather than being built from source code. Many casks are not very useful for automated building and testing, but there may be some that you need for your builds. You can add them to the `casks` key in the Homebrew addon configuration to install them:
+The Homebrew addon also supports installing [casks][homebrew-cask]. You can add them to the `casks` key in the Homebrew addon configuration to install them:
 
 [homebrew-cask]: https://github.com/Homebrew/homebrew-cask
 
@@ -289,12 +289,17 @@ addons:
 ```
 {: data-file=".travis.yml"}
 
-Homebrew also supports installing casks and packages from third-party repositories called [taps][homebrew-tap]. You can add these with the Homebrew addon. For instance, Homebrew maintains a tap of older versions of certain casks at [`homebrew/cask-versions`][cask-versions]. If you wanted to install Java 8 on an image with Java 10 installed, you can add that tap and then install the `java8` cask:
+### Installing From Taps
+
+Homebrew supports installing casks and packages from third-party repositories called [taps][homebrew-tap], and you can use these with the Homebrew addon.
+
+For instance, Homebrew maintains a tap of older versions of certain casks at [`homebrew/cask-versions`][cask-versions]. If you wanted to install Java 8 on an image with Java 10 installed, you can add that tap and then install the `java8` cask:
 
 [homebrew-tap]: https://docs.brew.sh/Taps
 [cask-versions]: https://github.com/Homebrew/homebrew-cask-versions
 
 ```yaml
+osx_image: xcode10
 addons:
   homebrew:
     taps: homebrew/cask-versions
@@ -313,8 +318,16 @@ addons:
   homebrew:
     brewfile: true
 ```
+{: data-file=".travis.yml"}
 
-You can also provide a path if your Brewfile is in a different location. For example: `brewfile: Brewfile.travis`.
+You can also provide a path if your Brewfile is in a different location.
+
+```yaml
+addons:
+  homebrew:
+    brewfile: Brewfile.travis
+```
+{: data-file=".travis.yml"}
 
 ## Installing Dependencies on Multiple Operating Systems
 

--- a/user/installing-dependencies.md
+++ b/user/installing-dependencies.md
@@ -254,20 +254,82 @@ addons:
 
 ## Installing Packages on OS X
 
-To install packages that are not included in the [default OS X environment](/user/reference/osx/#Compilers-and-Build-toolchain) use [Homebrew](http://brew.sh) in your `.travis.yml`. For example, to install beanstalk:
+To install packages that are not included in the [default OS X environment](/user/reference/osx/#Compilers-and-Build-toolchain) use [Homebrew](http://brew.sh) and our Homebrew addon in your `.travis.yml`. For example, to install beanstalk:
 
 ```yaml
-before_install:
-  - brew update # see note below
-  - brew install beanstalk
+addons:
+  homebrew:
+    packages:
+    - beanstalk
 ```
 {: data-file=".travis.yml"}
 
-> To speed up your build, try installing your packages *without* running `brew update` first, to see if the Homebrew database on the build image already has what you need.
+By default, the Homebrew addon will not run `brew update` before installing packages. `brew update` can take a long time and slow down your builds. If you need more up-to-date versions of packages than the snapshot on the build VM has, you can add `update: true` to the addon configuration:
+
+```yaml
+addons:
+  homebrew:
+    packages:
+    - beanstalk
+    update: true
+```
+{: data-file=".travis.yml"}
+
+### Taps and Casks
+
+The Homebrew addon supports more than just packages. It also supports installing [casks][homebrew-cask]: GUI apps and other things that need to run installers rather than being built from source code. Many casks are not very useful for automated building and testing, but there may be some that you need for your builds. You can add them to the `casks` key in the Homebrew addon configuration to install them:
+
+[homebrew-cask]: https://github.com/Homebrew/homebrew-cask
+
+```yaml
+addons:
+  homebrew:
+    casks:
+    - dotnet-sdk
+```
+{: data-file=".travis.yml"}
+
+Homebrew also supports installing casks and packages from third-party repositories called [taps][homebrew-tap]. You can add these with the Homebrew addon. For instance, Homebrew maintains a tap of older versions of certain casks at [`homebrew/cask-versions`][cask-versions]. If you wanted to install Java 8 on an image with Java 10 installed, you can add that tap and then install the `java8` cask:
+
+[homebrew-tap]: https://docs.brew.sh/Taps
+[cask-versions]: https://github.com/Homebrew/homebrew-cask-versions
+
+```yaml
+addons:
+  homebrew:
+    taps: homebrew/cask-versions
+    casks: java8
+```
+{: data-file=".travis.yml"}
+
+### Using a Brewfile
+
+Under the hood, the Homebrew addon works by creating a `~/.Brewfile` and running `brew bundle --global`. You can also use the addon to install dependencies from your own [Brewfile][] that is checked in to your project. By passing `brewfile: true`, the addon will look for a `Brewfile` in the root directory of your project:
+
+[brewfile]: https://github.com/Homebrew/homebrew-bundle
+
+```yaml
+addons:
+  homebrew:
+    brewfile: true
+```
+
+You can also provide a path if your Brewfile is in a different location. For example: `brewfile: Brewfile.travis`.
 
 ## Installing Dependencies on Multiple Operating Systems
 
-If you're testing on both Linux and OS X, use the `$TRAVIS_OS_NAME` variable to install dependencies separately:
+If you're testing on both Linux and OS X, you can use both the APT addon and the Homebrew addon together. Each addon will only run on the appropriate platform:
+
+```yaml
+addons:
+  apt:
+    packages: foo
+  homebrew:
+    packages: bar
+```
+{: data-file=".travis.yml"}
+
+If you're installing packages manually, use the `$TRAVIS_OS_NAME` variable to install dependencies separately for each OS:
 
 ```yaml
 install:


### PR DESCRIPTION
Expand the macOS section of Installing Dependencies with instructions on using the new Homebrew addon instead of running manual `brew` commands.

Also update the section on supporting macOS and Linux in the same .yml to show how to use both addons in tandem.