### PR TITLE
Logo links to travis-ci.com instead of .org

### DIFF
--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,3 +1,3 @@
 <h1 id="logo" class="logo">
-  <a href="http://travis-ci.org/" title="Travis CI">Travis</a>
+  <a href="http://travis-ci.com/" title="Travis CI">Travis</a>
 </h1>


### PR DESCRIPTION
It's been bothering me whenever I click on the header when looking at the docs and I get taken to a different website than what I expect.

Let me know if linking to .org is still intentional!