### PR TITLE
fixed emacs editor link

### DIFF
--- a/user/apps.md
+++ b/user/apps.md
@@ -410,7 +410,7 @@ By Cas du Plessis
 
 ![emacs](/images/apps/emacs.jpg){:.app}
 
-Travis CI integration for [Emacs](http://https://www.gnu.org/software/emacs/)<br>
+Travis CI integration for [Emacs](https://www.gnu.org/software/emacs/)<br>
 By Skye Shaw
 
 - [website](https://github.com/sshaw/build-status)


### PR DESCRIPTION
The Emacs editor link had a redundant ``http://`` in the URL.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>