### PR TITLE
Add go-travis to 3rd party apps

### DIFF
--- a/user/apps.md
+++ b/user/apps.md
@@ -11,7 +11,7 @@ There is a wide range of tools you can use to interact with Travis CI:
 - **[Desktop](#desktop)**: [Mac OS X](#Mac-OS-X), [Linux](#Linux), [Cross Platform](#Cross-Platform)
 - **[Command Line Tools](#commandline)**: [Full Clients](#Full-Clients), [Build Monitoring](#Build-Monitoring), [Generators](#Generators)
 - **[Plugins](#plugins)**: [Google Chrome](#Google-Chrome), [Mozilla Firefox](#Mozilla-Firefox), [Opera](#Opera), [Editors](#Editors), [Other](#Other)
-- **[Libraries](#libraries)**: [Ruby](#Ruby), [JavaScript](#JavaScript), [PHP](#PHP), [Python](#Python), [Elixir](#Elixir), [R](#R)
+- **[Libraries](#libraries)**: [Ruby](#Ruby), [JavaScript](#JavaScript), [PHP](#PHP), [Python](#Python), [Elixir](#Elixir), [R](#R), [Go](#Go)
   {: .toc-list}
 
 And if you don't find anything that fits your needs, you can also interact with our [API](/api/) directly.
@@ -485,3 +485,6 @@ By Eduardo Antonio Lundgren Melo and Zeno Rocha Bueno Netto
 ## R
 
 - [travis](https://github.com/ropenscilabs/travis) by Kirill Müller
+
+## Go
+- [go-travis](https://github.com/shuheiktgw/go-travis) by Shuhei Kitagawa


### PR DESCRIPTION
Hi, I'm actively building Travis CI's Golang client library called [go-travis](https://github.com/shuheiktgw/go-travis) and it would be great if you people would add a link to the library! 

go-travis is the only Golang based library which supports Travis CI API V3. It will soon support all the endpoints of  the API V3.

Thanks! 👍 