### PR TITLE
Environment variables: disambiguation

### DIFF
--- a/user/environment-variables.md
+++ b/user/environment-variables.md
@@ -40,7 +40,8 @@ env:
 
 ### Defining Multiple Variables per Item
 
-When you define multiple variables per line in the `env` array (matrix variables), one build is triggered per item.
+One build is triggered for each item in the `env` array. E.g. the configuration from the example above would trigger three builds (or more, depending on other parameters of the build matrix).
+If you need to specify several environment variables for each build, put them all on the same line:
 
 ```yaml
 rvm:

--- a/user/environment-variables.md
+++ b/user/environment-variables.md
@@ -26,7 +26,8 @@ Define variables in `.travis.yml` that:
 - differ per branch.
 - differ per job.
 
-Define environment variables in your `.travis.yml` in the `env` key, quoting special characters such as asterisks (`*`):
+Define environment variables in your `.travis.yml` in the `env` key, quoting special characters such as asterisks (`*`).
+One build will triggered for each line in the `env` array.
 
 ```yaml
 env:
@@ -40,8 +41,7 @@ env:
 
 ### Defining Multiple Variables per Item
 
-One build is triggered for each item in the `env` array. E.g. the configuration from the example above would trigger three builds (or more, depending on other parameters of the build matrix).
-If you need to specify several environment variables for each build, put them all on the same line:
+If you need to specify several environment variables for each build, put them all on the same line in the `env` array:
 
 ```yaml
 rvm:


### PR DESCRIPTION
[I was not the only one](https://stackoverflow.com/questions/40294597/how-to-properly-define-multiple-env-variables-on-travis-yml) confused by the paragraph on "multiple environment variables per build" and reading it so that if each entry in the `env` array contains exactly one variable, they will be all applied to a single build.

This PR attempts to describe the actual behavior of the build system unambiguously.