### PR TITLE
Fix some links on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,9 +46,9 @@ short_title: true
     <section>
       <h2>Common Questions</h2>
       <ul>
-        <li><a href="/user/customizing-the-build/#What-repository-providers-or-version-control-systems-can-I-use">What repository providers can I use?</a></li>
+        <li><a href="/user/customizing-the-build/#what-repository-providers-or-version-control-systems-can-i-use">What repository providers can I use?</a></li>
         <li><a href="/user/trusty-ci-environment/">Can I use Ubuntu Trusty for my builds?</a><li>
-        <li><a href="/user/notifications/#Changing-the-email-address-for-build-notifications">How do I change the notification email address?</a><li>
+        <li><a href="/user/notifications/#changing-the-email-address-for-build-notifications">How do I change the notification email address?</a><li>
         <li><a href="/user/ip-addresses/">What IP addresses do the builds use?</a></li>
       </ul>
     </section>


### PR DESCRIPTION
I found these two links not working properly:

![image](https://user-images.githubusercontent.com/4066489/46523924-edc83680-c88f-11e8-9b44-1aad8a4d63c8.png)