### PR TITLE
Explain how setup worker behind a proxy

### DIFF
--- a/user/enterprise/upgrading.md
+++ b/user/enterprise/upgrading.md
@@ -12,7 +12,7 @@ and `/var/travis`.
 One good way to do this is to run
 ```
   sudo tar -cvzf travis-backup-$(date +%s).tar.gz /var/travis /etc/travis/
-```   
+```
 See [restoring from backups](#Restoring-from-Backups) if you have any questions about the steps or want to do a restore.
 
 ## Updating your Travis CI Enterprise Platform
@@ -44,10 +44,28 @@ whether you are behind a web proxy you'll want to run one of these:
 
 ## Updating your Travis CI Enterprise Worker
 
+### Ubuntu 16.04+
+
+On Ubuntu 16.04 and later travis-worker ships inside a Docker container. So, in order to update travis-worker on the machine, the first step is to configure a new image. For that, please open `/etc/systemd/system/travis-worker.service.d/env.conf` and replace the Docker tag with a new version, so it looks similar to:
+
+```
+[Service]
+Environment="TRAVIS_WORKER_SELF_IMAGE=travisci/worker:v4.6.1"
+```
+
+After that, please run the following commands to reload the configuration and then also to restart the service:
+
+```
+$ sudo systemctl daemon-reload
+$ sudo systemctl restart travis-worker
+```
+
+### Ubuntu 14.04
+
 In order to update the Worker, you can run the following on each worker
 host:
 
-```         
+```
   sudo apt-get update
   sudo apt-get install travis-worker
 ```

--- a/user/enterprise/upgrading.md
+++ b/user/enterprise/upgrading.md
@@ -65,8 +65,8 @@ In order to update the Worker, you can run the following on each worker
 host:
 
 ```
-  sudo apt-get update
-  sudo apt-get install travis-worker
+$ sudo apt-get update
+$ sudo apt-get install travis-worker
 ```
 
 ## Restoring from Backups

--- a/user/enterprise/upgrading.md
+++ b/user/enterprise/upgrading.md
@@ -44,23 +44,22 @@ whether you are behind a web proxy you'll want to run one of these:
 
 ## Updating your Travis CI Enterprise Worker
 
-### Ubuntu 16.04+
+### On Ubuntu 16.04 and later
 
-On Ubuntu 16.04 and later travis-worker ships inside a Docker container. So, in order to update travis-worker on the machine, the first step is to configure a new image. For that, please open `/etc/systemd/system/travis-worker.service.d/env.conf` and replace the Docker tag with a new version, so it looks similar to:
+On Ubuntu 16.04 and later, travis-worker ships inside a Docker container. To update travis-worker, please follow the steps below.
 
-```
-[Service]
-Environment="TRAVIS_WORKER_SELF_IMAGE=travisci/worker:v4.6.1"
-```
+  1. Configure the new image by editing the Docker tag in `/etc/systemd/system/travis-worker.service.d/env.conf`:
+  ```
+  [Service]
+  Environment="TRAVIS_WORKER_SELF_IMAGE=travisci/worker:v4.6.1"
+  ```
+  1. Reload the configuration and restart the service:
+  ```
+  $ sudo systemctl daemon-reload
+  $ sudo systemctl restart travis-worker
+  ```
 
-After that, please run the following commands to reload the configuration and then also to restart the service:
-
-```
-$ sudo systemctl daemon-reload
-$ sudo systemctl restart travis-worker
-```
-
-### Ubuntu 14.04
+### On Ubuntu 14.04
 
 In order to update the Worker, you can run the following on each worker
 host:

--- a/user/enterprise/worker-configuration.md
+++ b/user/enterprise/worker-configuration.md
@@ -163,6 +163,65 @@ export TRAVIS_WORKER_DOCKER_BINDS="/tmp:/tmp:rw /var/log"
 A full list of options and mount modes is listed in the official
  [Docker documentation](https://docs.docker.com/storage/bind-mounts/).
 
+## Worker behind a HTTP(S) Proxy
+
+If you're using Travis CI Enterprise behind a HTTP(S) proxy, we've got you covered. Since travis-worker 4.6 it is possible to run builds behind a proxy.
+
+
+### How do I find out if I have the correct travis-worker version installed?
+
+#### Ubuntu 16.04+
+
+Connect to your worker machine via ssh and run:
+
+```
+$ sudo docker images | grep worker
+travisci/worker        v4.6.1                      ef7a3419050c        17 hours ago        44.7MB
+```
+
+#### Ubuntu 14.04
+
+Connect to your worker machine via ssh and run:
+
+```
+$ travis-worker -v
+travis-worker v=v4.6.0 rev=544a3e8108b430f990914e79baee8c7873c583b5 d=2018-10-30T15:01:38+0000 go=go1.11.1
+```
+
+#### Upgrade travis-worker
+
+If you need to install a newer version of travis-worker, please follow the instructions in our [Updating your Travis CI Worker docs](/user/enterprise/upgrading/#updating-your-travis-ci-enterprise-worker).
+
+### Configuration
+
+On the worker machine, please open `/etc/default/travis-worker` in your editor and add these two lines:
+
+```
+export TRAVIS_WORKER_DOCKER_HTTP_PROXY="http://localhost:8080"
+export TRAVIS_WORKER_DOCKER_API_VERSION=1.35
+```
+
+The value for `TRAVIS_WORKER_DOCKER_API_VERSION` depends on the installed Docker version. In this example we've used Docker-CE 17.12. [The Docker documentation](https://docs.docker.com/develop/sdk/#docker-ee-and-ce-api-mismatch) shows you which API version to choose if you have a different version of Docker-CE installed.
+
+Additionally to `TRAVIS_WORKER_DOCKER_HTTP_PROXY` we also have support for the following variables:
+
+- `TRAVIS_WORKER_DOCKER_HTTPS_PROXY`
+- `TRAVIS_WORKER_DOCKER_NO_PROXY`
+- `TRAVIS_WORKER_DOCKER_FTP_PROXY`
+
+
+All environment variables listed above are being made available during the build as follows:
+
+- `http_proxy`
+- `https_proxy`
+- `no_proxy`
+- `ftp_proxy`
+- `HTTP_PROXY`
+- `HTTPS_PROXY`
+- `NO_PROXY`
+- `FTP_PROXY`
+
+
 ## Contact Enterprise Support
 
 {{ site.data.snippets.contact_enterprise_support }}

--- a/user/enterprise/worker-configuration.md
+++ b/user/enterprise/worker-configuration.md
@@ -192,16 +192,16 @@ travis-worker v=v4.6.1 rev=73392421d0ca807b83d4d459ad3dd484820fd181 d=2018-10-30
 
 If you need to install a newer version of travis-worker, please follow the instructions in our [Updating your Travis CI Worker docs](/user/enterprise/upgrading/#updating-your-travis-ci-enterprise-worker).
 
-### Configuration
+### Configuring an HTTP Proxy
 
-On the worker machine, please open `/etc/default/travis-worker` in your editor and add these two lines:
+On the worker machine, please open `/etc/default/travis-worker` in your editor and add the two lines from the example below. The value for `TRAVIS_WORKER_DOCKER_API_VERSION` depends on the installed Docker version.
 
 ```
-export TRAVIS_WORKER_DOCKER_HTTP_PROXY="http://localhost:8080"
+export TRAVIS_WORKER_DOCKER_HTTP_PROXY="<YOUR PROXY URL>"
 export TRAVIS_WORKER_DOCKER_API_VERSION=1.35
 ```
 
-The value for `TRAVIS_WORKER_DOCKER_API_VERSION` depends on the installed Docker version. In this example we've used Docker-CE 17.12. [The Docker documentation](https://docs.docker.com/develop/sdk/#docker-ee-and-ce-api-mismatch) shows you which API version to choose if you have a different version of Docker-CE installed.
+In this example we've used Docker-CE 17.12. According to the [API mismatch table](https://docs.docker.com/develop/sdk/#docker-ee-and-ce-api-mismatch) we need to choose `1.35` for `TRAVIS_WORKER_DOCKER_API_VERSION`.
 
 Additionally to `TRAVIS_WORKER_DOCKER_HTTP_PROXY` we also have support for the following variables:
 

--- a/user/enterprise/worker-configuration.md
+++ b/user/enterprise/worker-configuration.md
@@ -165,8 +165,7 @@ A full list of options and mount modes is listed in the official
 
 ## Worker behind a HTTP(S) Proxy
 
-If you're using Travis CI Enterprise behind a HTTP(S) proxy, we've got you covered. Since travis-worker 4.6 it is possible to run builds behind a proxy.
-
+If you're using Travis CI Enterprise behind an HTTP(S) proxy, we've got you covered. Since travis-worker 4.6 it is possible to run builds behind a proxy.
 
 ### How do I find out if I have the correct travis-worker version installed?
 
@@ -203,24 +202,15 @@ export TRAVIS_WORKER_DOCKER_API_VERSION=1.35
 
 In this example we've used Docker-CE 17.12. According to the [API mismatch table](https://docs.docker.com/develop/sdk/#docker-ee-and-ce-api-mismatch) we need to choose `1.35` for `TRAVIS_WORKER_DOCKER_API_VERSION`.
 
-Additionally to `TRAVIS_WORKER_DOCKER_HTTP_PROXY` we also have support for the following variables:
+Below you find the full list of available environment variables and their equivalent how they're accessible during the build:
 
-- `TRAVIS_WORKER_DOCKER_HTTPS_PROXY`
-- `TRAVIS_WORKER_DOCKER_NO_PROXY`
-- `TRAVIS_WORKER_DOCKER_FTP_PROXY`
+Environment variable | Available as:
+`TRAVIS_WORKER_DOCKER_HTTP_PROXY` | `HTTP_PROXY`, `http_proxy`
+`TRAVIS_WORKER_DOCKER_HTTPS_PROXY` | `HTTPS_PROXY`, `https_proxy`
+`TRAVIS_WORKER_DOCKER_NO_PROXY` | `NO_PROXY`, `no_proxy`
+`TRAVIS_WORKER_DOCKER_FTP_PROXY` | `FTP_PROXY`, `ftp_proxy`
 
-
-All environment variables listed above are being made available during the build as follows:
-
-- `http_proxy`
-- `https_proxy`
-- `no_proxy`
-- `ftp_proxy`
-- `HTTP_PROXY`
-- `HTTPS_PROXY`
-- `NO_PROXY`
-- `FTP_PROXY`
-
+Please note, that all `apt-get` commands by default respect `TRAVIS_WORKER_DOCKER_HTTP_PROXY` and `TRAVIS_WORKER_DOCKER_HTTPS_PROXY` which means that all package installs will go via the HTTP Proxy as well. If that's not desired, please whitelist your apt package mirror by adding it to `TRAVIS_WORKER_DOCKER_NO_PROXY`.
 
 ## Contact Enterprise Support
 

--- a/user/enterprise/worker-configuration.md
+++ b/user/enterprise/worker-configuration.md
@@ -185,7 +185,7 @@ Connect to your worker machine via ssh and run:
 
 ```
 $ travis-worker -v
-travis-worker v=v4.6.0 rev=544a3e8108b430f990914e79baee8c7873c583b5 d=2018-10-30T15:01:38+0000 go=go1.11.1
+travis-worker v=v4.6.1 rev=73392421d0ca807b83d4d459ad3dd484820fd181 d=2018-10-30T16:13:39+0000 go=go1.11.1
 ```
 
 #### Upgrade travis-worker

--- a/user/enterprise/worker-configuration.md
+++ b/user/enterprise/worker-configuration.md
@@ -210,7 +210,12 @@ Environment variable | Available as:
 `TRAVIS_WORKER_DOCKER_NO_PROXY` | `NO_PROXY`, `no_proxy`
 `TRAVIS_WORKER_DOCKER_FTP_PROXY` | `FTP_PROXY`, `ftp_proxy`
 
-Please note, that all `apt-get` commands by default respect `TRAVIS_WORKER_DOCKER_HTTP_PROXY` and `TRAVIS_WORKER_DOCKER_HTTPS_PROXY` which means that all package installs will go via the HTTP Proxy as well. If that's not desired, please whitelist your apt package mirror by adding it to `TRAVIS_WORKER_DOCKER_NO_PROXY`.
+Please note, that all `apt-get` commands by default respect `TRAVIS_WORKER_DOCKER_HTTP_PROXY` and `TRAVIS_WORKER_DOCKER_HTTPS_PROXY` which means that all package installs will go via the HTTP Proxy as well. If you don't want this to happen, please whitelist your apt package mirror by adding it to TRAVIS_WORKER_DOCKER_NO_PROXY` like this:
+
+```
+export TRAVIS_WORKER_DOCKER_NO_PROXY='.ubuntu.com,packagecloud.io,.postgresql.org'
+```
+
 
 ## Contact Enterprise Support
 

--- a/user/enterprise/worker-configuration.md
+++ b/user/enterprise/worker-configuration.md
@@ -163,7 +163,7 @@ export TRAVIS_WORKER_DOCKER_BINDS="/tmp:/tmp:rw /var/log"
 A full list of options and mount modes is listed in the official
  [Docker documentation](https://docs.docker.com/storage/bind-mounts/).
 
-## Worker behind a HTTP(S) Proxy
+## Worker behind an HTTP(S) Proxy
 
 If you're using Travis CI Enterprise behind an HTTP(S) proxy, we've got you covered. Since travis-worker 4.6 it is possible to run builds behind a proxy.
 
@@ -202,7 +202,7 @@ export TRAVIS_WORKER_DOCKER_API_VERSION=1.35
 
 In this example we've used Docker-CE 17.12. According to the [API mismatch table](https://docs.docker.com/develop/sdk/#docker-ee-and-ce-api-mismatch) we need to choose `1.35` for `TRAVIS_WORKER_DOCKER_API_VERSION`.
 
-Below you find the full list of available environment variables and their equivalent how they're accessible during the build:
+Below you find the full list of available environment variables and how they're accessible during the build:
 
 Environment variable | Available as:
 `TRAVIS_WORKER_DOCKER_HTTP_PROXY` | `HTTP_PROXY`, `http_proxy`


### PR DESCRIPTION
This explains in detail how to setup worker behind a proxy, with all
required and optional environment variables for that.

Also, it updates our 'Update travis-worker' docs to show users how to update
worker on 16.04+