### PR TITLE
Add missing token scope to documentation

### DIFF
--- a/user/deployment/pages.md
+++ b/user/deployment/pages.md
@@ -34,7 +34,7 @@ deploy:
 
 You'll need to generate a [personal access
 token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/)
-with the `public_repo` or `repo` scope (`repo` is required for private
+with the `user` as well as the `public_repo` or `repo` scope (`repo` is required for private
 repositories). Since the token should be private,
 you'll want to pass it to Travis securely in your [repository
 settings](/user/environment-variables#defining-variables-in-repository-settings)


### PR DESCRIPTION
I've had my build reported as failed for a week due to a, seemingly, failed gh-pages deploy. However, my branch was successfully updated on each build, but the build still showed up as errored. After some digging, I found out that the personal token also requires `user` scope. After creating a new token with both `user` and `repo` scope, my build is reported as succesful. 