### PR TITLE
Replace `android list sdk` with `sdkmanager --list`

### DIFF
--- a/user/languages/android.md
+++ b/user/languages/android.md
@@ -71,7 +71,7 @@ android:
 ```
 {: data-file=".travis.yml"}
 
-The exact component names must be specified (filter aliases like `add-on` or `extra` are also accepted). To get a list of available exact component names and descriptions run the command `android list sdk --no-ui --all --extended` (preferably in your local development machine).
+The exact component names must be specified (filter aliases like `add-on` or `extra` are also accepted). To get a list of available exact component names and descriptions run the command `sdkmanager --list` (preferably in your local development machine).
 
 ### Installing a newer SDK Platform Tools revision
 


### PR DESCRIPTION
According to https://github.com/travis-ci/travis-ci/issues/7331#issuecomment-316790695, `sdkmanager` should already be available. Even if the `android` command is not deprecated in Travis CI’s environment, I’d suggest updating this command since it’s usually ran on the local development machine.

Fixes #1299.