### PR TITLE
Add a reference that completes the information

### DIFF
--- a/user/caching.md
+++ b/user/caching.md
@@ -268,7 +268,7 @@ Docker images are not cached, because we provision a brand new virtual machine f
 ## Fetching and storing caches
 
 - Travis CI fetches the cache for every build, including branches and pull requests.
-- There is one cache per branch and language version / compiler version / JDK version / Gemfile location, etc.
+- There is one cache per branch and language version / compiler version / JDK version / Gemfile location, etc. See [Caches and build matrices](#caches-and-build-matrices) for details.
 - If a branch does not have its own cache, Travis CI fetches the default branch cache.
 - Only modifications made to the cached directories from normal pushes are stored.
 


### PR DESCRIPTION
A lack of a reference creates an illusion that this is the entire info on this matter since this is reference documentation -- a section on subj is expected to contain full, authoritative info on subj.