### PR TITLE
Change “in OS X” to “on OS X”

### DIFF
--- a/user/multi-os.md
+++ b/user/multi-os.md
@@ -108,7 +108,7 @@ matrix:
 
 ### Python example (unsupported languages)
 
-For example, this `.travis.yml` uses the `matrix.include` key to include four specific entries in the build matrix. It also takes advantage of `language: generic` to test Python in OS X. Custom requirements are installed in `./.travis/install.sh` below.
+For example, this `.travis.yml` uses the `matrix.include` key to include four specific entries in the build matrix. It also takes advantage of `language: generic` to test Python on OS X. Custom requirements are installed in `./.travis/install.sh` below.
 
 ```yaml
 language: python


### PR DESCRIPTION
The documentation [always uses “on OS X”](https://github.com/travis-ci/docs-travis-ci-com/search?q=%22on+OS+X%22&type=Code). This instance is the only exception.