### PR TITLE
Typo fix: "ruby" => "Go"

### DIFF
--- a/user/reference/xenial.md
+++ b/user/reference/xenial.md
@@ -120,7 +120,7 @@ The following versions of Docker, version control software and compilers are pre
 
 * Pre-installed Go: `1.11.1`
 
-* Other ruby versions can be installed during build time by specifying the language versions with the `go:`-key.
+* Other Go versions can be installed during build time by specifying the language versions with the `go:`-key.
 
 ## JVM (Clojure, Groovy, Java, Scala) support
 


### PR DESCRIPTION
I was reading the docs and noticed this typo. I figured it was a copy+paste mistake.