### PR TITLE
adds permalink to T&Cs survey 2018

### DIFF
--- a/legal/survey-terms-conditions.md
+++ b/legal/survey-terms-conditions.md
@@ -1,6 +1,7 @@
 ---
 title: Terms & Conditions - 2018 Travis CI Community Survey
 layout: en
+permalink: /legal/2018-survey-terms-conditions/
 no_toc: true
 ---
 


### PR DESCRIPTION
This will make the page appear at: https://docs.travis-ci.com/legal/2018-survey-terms-conditions/