### PR TITLE
Fix typo "CCX_FOR_BUILD" -> "CXX_FOR_BUILD"

### DIFF
--- a/user/languages/cpp.md
+++ b/user/languages/cpp.md
@@ -102,7 +102,7 @@ compiler:
 
 Testing against two compilers will create (at least) 2 rows in your build
 matrix. For each row, the Travis CI C++ builder will export the `CXX` and
-`CCX_FOR_BUILD` env variables to point to either `g++` or `clang++`, and
+`CXX_FOR_BUILD` env variables to point to either `g++` or `clang++`, and
 correspondingly export the `CC` and `CC_FOR_BUILD` env variables to point
 to either `gcc` or `clang`.
 


### PR DESCRIPTION
Trivial typo in [Building a C++ Project](https://docs.travis-ci.com/user/languages/cpp/). 