### PR TITLE
Standardize spelling of “macOS”

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -29,7 +29,7 @@ trusty_note: |
   >  * [Precise](/user/reference/precise/)
   >  * [Trusty](/user/reference/trusty/)
   >  * [Xenial](/user/reference/xenial/)
-  >  * [OS X](/user/reference/osx/)
+  >  * [macOS](/user/reference/osx/)
 trusty_note_no_osx: |
   > Language versions and other build-environment specific
   > information are in our reference pages:

--- a/_includes/c11-cpp11-and-beyond-and-toolchains.md
+++ b/_includes/c11-cpp11-and-beyond-and-toolchains.md
@@ -64,9 +64,9 @@ before_install:
 ```
 {: data-file=".travis.yml"}
 
-### GCC on OS X
+### GCC on macOS
 
-On OS X, `gcc` is an alias for `clang`, and `g++` is an alias for `clang++`.
+On macOS, `gcc` is an alias for `clang`, and `g++` is an alias for `clang++`.
 So you must set CC and CXX to specific `gcc`/`g++` versions:
 
 ```yaml
@@ -184,10 +184,10 @@ before_install:
 ```
 {: data-file=".travis.yml"}
 
-### Clang on OS X
+### Clang on macOS
 
-On OS X, the version of `clang` is controlled by the choice of `osx_image`.
-You can find [here](/user/reference/osx/#os-x-version) the list of available `osx_image`.
+On macOS, the version of `clang` is controlled by the choice of `osx_image`.
+You can find [here](/user/reference/osx/#macos-version) the list of available `osx_image`.
 
 ```yaml
 matrix:
@@ -221,4 +221,4 @@ addons:
 ```
 {: data-file=".travis.yml"}
 
-On OS X, the version of `cmake` is controlled by the choice of `osx_image`.
+On macOS, the version of `cmake` is controlled by the choice of `osx_image`.

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -82,7 +82,7 @@
       <li><a href="/user/reference/precise/">Precise CI Environment Reference</a></li>
       <li><a href="/user/reference/trusty/">Trusty CI Environment</a><li>
       <li><a href="/user/reference/xenial/">Xenial CI Environment</a><li>
-      <li><a href="/user/reference/osx/">OS X CI Environment Reference</a></li>
+      <li><a href="/user/reference/osx/">macOS CI Environment Reference</a></li>
       <li><a href="/user/reference/windows/">Windows CI Environment Reference</a></li>
       <li><a href="/user/multi-os/">Building on Multiple Operating Systems</a></li>
       <li><a href="/user/environment-variables/">Environment Variables</a></li>

--- a/slate/source/index.md
+++ b/slate/source/index.md
@@ -116,7 +116,7 @@ The first thing you need to know is what API URL endpoint to use:
 
 When you write your own Travis CI client, please keep the following in mind:
 
-- Always set the **User-Agent** header. This header is not required right now, but will be in the near future. Assuming your client is called "My Client", and its current version is 1.0.0, a good value would be `MyClient/1.0.0`. For our command line client running on OS X 10.9 on Ruby 2.1.1, it might look like this: `Travis/1.6.8 (Mac OS X 10.9.2 like Darwin; Ruby 2.1.1; RubyGems 2.0.14) Faraday/0.8.9 Typhoeus/0.6.7`.
+- Always set the **User-Agent** header. This header is not required right now, but will be in the near future. Assuming your client is called "My Client", and its current version is 1.0.0, a good value would be `MyClient/1.0.0`. For our command line client running on macOS 10.9 on Ruby 2.1.1, it might look like this: `Travis/1.6.8 (Mac OS X 10.9.2 like Darwin; Ruby 2.1.1; RubyGems 2.0.14) Faraday/0.8.9 Typhoeus/0.6.7`.
 - Always set the **Accept** header to `application/vnd.travis-ci.2.1+json` to make sure that you get results from the V2.1 API. See also the note about [API V2.1](#API-V2-1)
 
 Client libraries will usually set these headers automatically.

--- a/user/apps.md
+++ b/user/apps.md
@@ -8,7 +8,7 @@ There is a wide range of tools you can use to interact with Travis CI:
 
 - **[Websites](#websites)**: [Full Web Clients](#full-web-clients), [Dashboards](#dashboards), [Tools](#tools)
 - **[Mobile Applications](#mobile)**: [Android](#android), [iOS](#ios), [Windows Phone](#windows-phone)
-- **[Desktop](#desktop)**: [Mac OS X](#mac-os-x), [Linux](#linux), [Cross Platform](#cross-platform)
+- **[Desktop](#desktop)**: [macOS](#macos), [Linux](#linux), [Cross Platform](#cross-platform)
 - **[Command Line Tools](#commandline)**: [Full Clients](#full-clients), [Build Monitoring](#build-monitoring), [Generators](#generators)
 - **[Plugins](#plugins)**: [Google Chrome](#google-chrome), [Opera](#opera), [Editors](#editors), [Other](#other)
 - **[Libraries](#libraries)**: [Ruby](#ruby), [JavaScript](#javascript), [PHP](#php), [Python](#python), [Elixir](#elixir), [R](#r), [Go](#go)
@@ -158,13 +158,13 @@ By Tim Felgentreff
 
 If you are looking for **desktop notifications**, our command line client [supports them](https://github.com/travis-ci/travis.rb#monitor).
 
-## Mac OS X
+## macOS
 
 ### CCMenu
 
 ![CCMenu](/images/apps/ccmenu.jpg){:.app}
 
-OS X status bar app<br>
+macOS status bar app<br>
 By ThoughtWorks Inc.
 
 - [website](http://ccmenu.org/)

--- a/user/build-environment-updates/2017-08-17.md
+++ b/user/build-environment-updates/2017-08-17.md
@@ -16,7 +16,7 @@ date: 2017-08-17
 
 - As previously communicated, Xcode beta versions 6.1, 6.2, and 6.3 are being deprecated.
 Projects configured with values of `beta-xcode6.1`, `beta-xcode6.2`, or `beta-xcode6.3`
-for the `osx_image` tag will now be run on our [default OS X image](/user/reference/osx/#os-x-version).
+for the `osx_image` tag will now be run on our [default OS X image](/user/reference/osx/#macos-version).
 
 - Users will be able to run on Xcode 6.4 by specifying `osx_image: xcode-6.4` in
 their project configuration.

--- a/user/caching.md
+++ b/user/caching.md
@@ -191,9 +191,9 @@ cache: ccache
 
 to cache `$HOME/.ccache` and automatically add `/usr/lib/ccache` to your `$PATH`.
 
-#### ccache on OS X
+#### ccache on macOS
 
-ccache is not installed on OS X environments but you can install it by adding
+ccache is not installed on macOS environments but you can install it by adding
 
 ```yaml
 install:
@@ -417,7 +417,7 @@ These factors are:
 
 1. OS name (currently, `linux` or `osx`)
 2. OS distribution (for Linux, `xenial`, `trusty`, or `precise`)
-3. OS X image name (e.g., `xcode7.2`)
+3. macOS image name (e.g., `xcode7.2`)
 4. Names and values of visible environment variables set in `.travis.yml` or Settings panel
 5. Language runtime version (for the language specified in the `language` key) if applicable
 6. For Bundler-aware jobs, the name of the `Gemfile` used

--- a/user/cc-menu.md
+++ b/user/cc-menu.md
@@ -6,7 +6,7 @@ layout: en
 
 ![Screenshot of CC menu](/images/Backstop_Menubar_20140305_155352_20140305_155425.jpg "Screenshot of CC menu")
 
-[CCMenu](http://ccmenu.org/) is a little tool for the OS X status bar to keep track of your repositories' latest build status from the convenience of your Mac.
+[CCMenu](http://ccmenu.org/) is a little tool for the macOS status bar to keep track of your repositories' latest build status from the convenience of your Mac.
 
 [CCTray](http://sourceforge.net/projects/ccnet/files/CruiseControl.NET%20Releases/CruiseControl.NET%201.8.4/) is the equivalent tool for your Windows environment, [BuildNotify](https://bitbucket.org/Anay/buildnotify/wiki/Home) for Linux systems. The general instructions apply to all of them.
 

--- a/user/chrome.md
+++ b/user/chrome.md
@@ -4,7 +4,7 @@ layout: en
 
 ---
 
-The Google Chrome addon allows Travis CI builds to install Google Chrome at run time. To use the addon you need to be running builds on either the [Trusty build environment](/user/reference/trusty/) or the [OS X build environment](/user/reference/osx/).
+The Google Chrome addon allows Travis CI builds to install Google Chrome at run time. To use the addon you need to be running builds on either the [Trusty build environment](/user/reference/trusty/) or the [macOS build environment](/user/reference/osx/).
 
 ## Selecting a Chrome version
 

--- a/user/common-build-problems.md
+++ b/user/common-build-problems.md
@@ -167,7 +167,7 @@ RSpec.configure do |c|
 end
 ```
 
-## Mac: OS X Mavericks (10.9) Code Signing Errors
+## Mac: macOS Mavericks (10.9) Code Signing Errors
 
 With Mavericks, quite a lot has changed in terms of code signing and the keychain application.
 
@@ -192,7 +192,7 @@ security set-keychain-settings -t 3600 -u $KEY_CHAIN
 
 With the introduction of macOS Sierra (10.12) on our infrastructure, we've seen build jobs that were hanging at the codesigning step of the build process. Here's some information on how to recognize this issue and fix it.
 
-Your build is running on macOS Sierra (10.12) if the `osx_image` in your .travis.yml file is `xcode8.3` or higher. See [the OS X Build Environment documentation](https://docs.travis-ci.com/user/reference/osx/) to know which macOS version is associated with each image.
+Your build is running on macOS Sierra (10.12) if the `osx_image` in your .travis.yml file is `xcode8.3` or higher. See [the macOS Build Environment documentation](https://docs.travis-ci.com/user/reference/osx/) to know which macOS version is associated with each image.
 
 The following lines in your build log possibly indicate an occurrence of this issue:
 

--- a/user/coverity-scan.md
+++ b/user/coverity-scan.md
@@ -22,9 +22,9 @@ See more details about Coverity Scan in the [FAQ](https://scan.coverity.com/faq)
 
 It's probably overkill to run static analysis on each and every commit of your project. To increase availability of the free service to more projects, the addon is designed by default to run analysis on a per-branch basis. We recommend you create a branch named `coverity_scan`, which you can merge into whenever you would like to trigger analysis. See the [FAQ](https://scan.coverity.com/faq#frequency) for information about build submission frequency.
 
-## OS X / macOS support
+## macOS support
 
-The Coverity Scan addon doesn't work on OS X/macOS versions with the SIP feature enabled i.e. on OS X El Capitan (10.11) and higher. Specifically on Travis CI, it currently only works on our Xcode 6.4 image (i.e. with `osx_image: xcode6.4`). However, it's possible to make it work with custom scripts or commands. Please reach out to [support@travis-ci.com](mailto:support@travis-ci.com) to learn how.
+The Coverity Scan addon doesn't work on macOS versions with the SIP feature enabled i.e. on macOS El Capitan (10.11) and higher. Specifically on Travis CI, it currently only works on our Xcode 6.4 image (i.e. with `osx_image: xcode6.4`). However, it's possible to make it work with custom scripts or commands. Please reach out to [support@travis-ci.com](mailto:support@travis-ci.com) to learn how.
 
 ## Step-by-step Configuration
 

--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -130,9 +130,9 @@ Deploy keys are not currently supported by LFS, so you should use a GitHub OAuth
 
 [Git LFS](https://git-lfs.github.com/) is supported by default on our Ubuntu Trusty images.
 
-### Mac OS
+### macOS
 
-Installing git-lfs via brew is the recommended way to get Git LFS in [Mac OS](/user/reference/osx/).
+Installing git-lfs via brew is the recommended way to get Git LFS in [macOS](/user/reference/osx/).
 
 ```
 os: osx

--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -356,7 +356,7 @@ before_script:
 
 ## RabbitMQ
 
-RabbitMQ requires `setuid` flags, so you can only run RabbitMQ on OS X or Ubuntu Trusty infrastructure.
+RabbitMQ requires `setuid` flags, so you can only run RabbitMQ on macOS or Ubuntu Trusty infrastructure.
 
 Start RabbitMQ in your `.travis.yml`:
 

--- a/user/docker.md
+++ b/user/docker.md
@@ -20,7 +20,7 @@ services:
 Then you can add `- docker` commands to your build as shown in the following
 examples.
 
-> We do not currently support use of Docker on OS X.
+> We do not currently support use of Docker on macOS.
 
 > For information on how to use Docker on Travis CI Enterprise check out [Enabling Docker Builds](/user/enterprise/build-images/#enabling-docker-builds).
 

--- a/user/encrypting-files.md
+++ b/user/encrypting-files.md
@@ -89,7 +89,7 @@ before_install:
 
 ### Caveat
 
-There is a report of this function not working on a local Windows machine. Please use the WSL (Windows Subsystem for Linux) or a Linux or OS X machine.
+There is a report of this function not working on a local Windows machine. Please use the WSL (Windows Subsystem for Linux) or a Linux or macOS machine.
 
 ## Manual Encryption
 

--- a/user/firefox.md
+++ b/user/firefox.md
@@ -6,7 +6,7 @@ layout: en
 
 Our 64-bit Linux VMs include a version of Firefox.
 
-While Firefox is not pre-installed on OS X images, you can use this addon to set it up for use
+While Firefox is not pre-installed on macOS images, you can use this addon to set it up for use
 on your builds.
 
 ## Selecting a Firefox version

--- a/user/for-beginners.md
+++ b/user/for-beginners.md
@@ -73,7 +73,7 @@ Travis CI offers a few different infrastructure environments, so you can select
 the setup that suits your project best:
 
 * *Ubuntu Linux* - these Linux Ubuntu environments run inside full virtual machines, provide plenty of computational resources, and support the use of `sudo`, `setuid`, and `setgid`.
-* *OS X* - uses one of several versions of the OS X operating system. This environment is useful for building projects that require the OS X software, such as projects written in Swift. It is not a requirement to use the OS X environment if you develop on a macOS machine.
+* *macOS* - uses one of several versions of the macOS operating system. This environment is useful for building projects that require the macOS software, such as projects written in Swift. It is not a requirement to use the macOS environment if you develop on a macOS machine.
 
 More details are on our environments are available in our [CI Environment](/user/ci-environment/) documentation.
 

--- a/user/gui-and-headless-browsers.md
+++ b/user/gui-and-headless-browsers.md
@@ -56,7 +56,7 @@ For travis-web, our very own website, we use Sauce Labs to run browser tests on 
 To run tests requiring a graphical user interface on Travis CI, use `xvfb` (X
 Virtual Framebuffer) to imitate a display. If you need a browser, you can use
 Firefox (either with the pre-installed version, or the [addon](/user/firefox))
-or Google Chrome (with the [addon](/user/chrome), on Linux Trusty or OS X).
+or Google Chrome (with the [addon](/user/chrome), on Linux Trusty or macOS).
 
 ### Using the xvfb-run wrapper
 
@@ -132,10 +132,10 @@ Note that <code>sudo</code> is not available for builds that are running on the 
 
 ### Using the [Chrome addon](/user/chrome) in the headless mode
 
-Starting with version 57 for Linux Trusty and version 59 on OS X, Google Chrome can be used in "headless"
+Starting with version 57 for Linux Trusty and version 59 on macOS, Google Chrome can be used in "headless"
 mode, which is suitable for driving browser-based tests using Selenium and other tools.
 
-> As of 2017-05-02, this means `stable` or `beta` on Linux builds, and `beta` on OS X builds.
+> As of 2017-05-02, this means `stable` or `beta` on Linux builds, and `beta` on macOS builds.
 
 For example, on Linux
 
@@ -150,7 +150,7 @@ before_install:
 ```
 {: data-file=".travis.yml"}
 
-On OS X:
+On macOS:
 
 ```yaml
 language: objective-c

--- a/user/installing-dependencies.md
+++ b/user/installing-dependencies.md
@@ -181,9 +181,9 @@ script:
 ```
 {: data-file=".travis.yml"}
 
-## Installing Packages on OS X
+## Installing Packages on macOS
 
-To install packages that are not included in the [default OS X environment](/user/reference/osx/#compilers-and-build-toolchain) use [Homebrew](http://brew.sh).
+To install packages that are not included in the [default macOS environment](/user/reference/osx/#compilers-and-build-toolchain) use [Homebrew](http://brew.sh).
 
 For convenience, you can use Homebrew addon in your `.travis.yml`.
 For example, to install beanstalk:
@@ -278,7 +278,7 @@ rvm use $TRAVIS_RUBY_VERSION # optionally, switch back to the Ruby version you n
 
 ## Installing Dependencies on Multiple Operating Systems
 
-If you're testing on both Linux and OS X, you can use both the APT addon and the Homebrew addon together. Each addon will only run on the appropriate platform:
+If you're testing on both Linux and macOS, you can use both the APT addon and the Homebrew addon together. Each addon will only run on the appropriate platform:
 
 ```yaml
 addons:

--- a/user/integration/platformio.md
+++ b/user/integration/platformio.md
@@ -10,7 +10,7 @@ layout: en
 
 [PlatformIO](http://platformio.org/) is a cross-platform code-builder and library manager for embedded development with no external dependencies. Using PlatformIO you can compile your code on multiple platforms, frameworks and boards. Unit testing requires a [monthly subscription](http://platformio.org/pricing).
 
-- *Platforms* - pre-built different development platforms for the most popular host OS (Mac OS X, Windows, Linux 32/64bit, Linux ARMv6+). Each of them
+- *Platforms* - pre-built different development platforms for the most popular host OS (macOS, Windows, Linux 32/64bit, Linux ARMv6+). Each of them
   includes compiler, debugger, uploader, etc:
 
   - Atmel AVR

--- a/user/languages/android.md
+++ b/user/languages/android.md
@@ -8,7 +8,7 @@ layout: en
 
 This guide covers build environment and configuration topics specific to Android projects. Please make sure to read our [Tutorial](/user/tutorial/) and [general build configuration](/user/customizing-the-build/) guides first.
 
-Android builds are not available on the OS X environment.
+Android builds are not available on the macOS environment.
 
 
 

--- a/user/languages/c.md
+++ b/user/languages/c.md
@@ -104,7 +104,7 @@ Testing against two compilers will create (at least) 2 rows in your build
 matrix. For each row, Travis CI C builder will export the `CC` and `CC_FOR_BUILD` env variables to
 point to either `gcc` or `clang`.
 
-On OS X, `gcc` is an alias for `clang`. Set a specific [GCC version](#gcc-on-os-x) to use GCC on OS X.
+On macOS, `gcc` is an alias for `clang`. Set a specific [GCC version](#gcc-on-macos) to use GCC on macOS.
 
 ## Build Matrix
 

--- a/user/languages/clojure.md
+++ b/user/languages/clojure.md
@@ -30,7 +30,7 @@ This guide covers build environment and configuration topics specific to Clojure
 projects. Please make sure to read our [Tutorial](/user/tutorial/)
 and [general build configuration](/user/customizing-the-build/) guides first.
 
-Clojure builds are not available on the OS X environment.
+Clojure builds are not available on the macOS environment.
 
 ## CI Environment for Clojure Projects
 

--- a/user/languages/cpp.md
+++ b/user/languages/cpp.md
@@ -106,8 +106,8 @@ matrix. For each row, the Travis CI C++ builder will export the `CXX` and
 correspondingly export the `CC` and `CC_FOR_BUILD` env variables to point
 to either `gcc` or `clang`.
 
-On OS X, `gcc` is an alias for `clang`, and `g++` is an alias for `clang++`.
-Set a specific [GCC version](#gcc-on-os-x) to use GCC on OS X.
+On macOS, `gcc` is an alias for `clang`, and `g++` is an alias for `clang++`.
+Set a specific [GCC version](#gcc-on-macos) to use GCC on macOS.
 
 ## Build Matrix
 

--- a/user/languages/csharp.md
+++ b/user/languages/csharp.md
@@ -18,7 +18,7 @@ and cc [@joshua-anderson](https://github.com/joshua-anderson), [@akoeplinger](ht
 
 ### Build Environment
 
-Currently, Travis builds your C#, F#, and Visual Basic project with the either the [Mono](http://www.mono-project.com/) or the [.NET Core](https://github.com/dotnet/core) runtimes on Linux or OS X. Note that these runtimes do not implement the entire .NET framework, so Windows .NET framework programs may not be fully compatible and require porting.
+Currently, Travis builds your C#, F#, and Visual Basic project with the either the [Mono](http://www.mono-project.com/) or the [.NET Core](https://github.com/dotnet/core) runtimes on Linux or macOS. Note that these runtimes do not implement the entire .NET framework, so Windows .NET framework programs may not be fully compatible and require porting.
 
 ### Overview
 
@@ -79,13 +79,13 @@ mono:
 
 You can choose from the following Mono versions:
 
-| Version          | Installed Packages (Linux only, OS X always includes everything) |
-|:-----------------|:-----------------------------------------------------------------|
-| 3.10.0 and later | mono-complete, mono-vbnc, fsharp, nuget, referenceassemblies-pcl |
-| 3.8.0            | mono-complete, mono-vbnc, fsharp, nuget                          |
-| 3.2.8            | mono-complete, mono-vbnc, fsharp                                 |
-| 2.10.8           | mono-complete, mono-vbnc                                         |
-| none             | *disables Mono (use this if you only want .NET Core, see below)* |
+| Version          | Installed Packages (Linux only, macOS always includes everything) |
+|:-----------------|:------------------------------------------------------------------|
+| 3.10.0 and later | mono-complete, mono-vbnc, fsharp, nuget, referenceassemblies-pcl  |
+| 3.8.0            | mono-complete, mono-vbnc, fsharp, nuget                           |
+| 3.2.8            | mono-complete, mono-vbnc, fsharp                                  |
+| 2.10.8           | mono-complete, mono-vbnc                                          |
+| none             | *disables Mono (use this if you only want .NET Core, see below)*  |
 
 > *Note*: even if you specify e.g. 3.12.0 the version used by your build may actually be 3.12.1 depending on what the latest version in the 3.12.x series is (it's a limitation of the Xamarin repositories right now).
 

--- a/user/languages/dart.md
+++ b/user/languages/dart.md
@@ -75,7 +75,7 @@ Each task creates a separate Travis job. It can be used in conjunction with
 ### Available Browsers
 
 Travis comes with Firefox and Chrome installed by default on Linux, and Safari
-on OS X. However, if you want to run your tests on Dartium, you'll need to
+on macOS. However, if you want to run your tests on Dartium, you'll need to
 install it by adding `install_dartium: true` either at the top level or for a
 particular task.
 
@@ -106,7 +106,7 @@ dart_task:
 ```
 {: data-file=".travis.yml"}
 
-XVFB is never used on OS X, since it doesn't use the X windows system.
+XVFB is never used on macOS, since it doesn't use the X windows system.
 
 ## Other Tasks
 

--- a/user/languages/elixir.md
+++ b/user/languages/elixir.md
@@ -33,7 +33,7 @@ specific to Elixir projects. Please make sure to read our
 [Tutorial](/user/tutorial/) and
 [general build configuration](/user/customizing-the-build/) guides first.
 
-Elixir builds are not available on the OS X environment.
+Elixir builds are not available on the macOS environment.
 
 ## CI Environment for Elixir Projects
 

--- a/user/languages/erlang.md
+++ b/user/languages/erlang.md
@@ -34,7 +34,7 @@ specific to Erlang projects. Please make sure to read our
 [Tutorial](/user/tutorial/) and
 [general build configuration](/user/customizing-the-build/) guides first.
 
-Erlang builds are not available on the OS X environment.
+Erlang builds are not available on the macOS environment.
 
 ## Choosing OTP releases to test against
 

--- a/user/languages/groovy.md
+++ b/user/languages/groovy.md
@@ -30,7 +30,7 @@ The rest of this guide covers configuring Groovy projects on Travis CI. If you'r
 new to Travis CI please read our [Tutorial](/user/tutorial/) and
 [build configuration](/user/customizing-the-build/) guides first.
 
-Groovy builds are not available on the OS X environment.
+Groovy builds are not available on the macOS environment.
 
 ## Overview
 

--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -174,8 +174,8 @@ jdk:
 ```
 {: data-file=".travis.yml"}
 
-> Note that testing against multiple Java versions is not supported on OS X. See
-the [OS X Build Environment](/user/reference/osx/#jdk-and-os-x) for more
+> Note that testing against multiple Java versions is not supported on macOS. See
+the [macOS Build Environment](/user/reference/osx/#jdk-and-macos) for more
 details.
 
 The list of available JVMs for different dists are at

--- a/user/languages/julia.md
+++ b/user/languages/julia.md
@@ -39,7 +39,7 @@ of Julia.
  - `X.Y.Z` will test against that exact version.
 
 The oldest versions for which binaries are available is 0.3.1 for Linux,
-or 0.2.0 for [OS X](/user/multi-os/).
+or 0.2.0 for [macOS](/user/multi-os/).
 
 ## Coverage
 

--- a/user/languages/objective-c.md
+++ b/user/languages/objective-c.md
@@ -16,23 +16,23 @@ Objective-C/Swift builds are not available on the Linux environments.
 
 ## Supported Xcode versions
 
-Travis CI uses OS X 10.13 (and Xcode 9.4.1) by default. You can use another
-version of Xcode (and OS X) by specifying the corresponding `osx_image` key from
+Travis CI uses macOS 10.13 (and Xcode 9.4.1) by default. You can use another
+version of Xcode (and macOS) by specifying the corresponding `osx_image` key from
 the following table:
 
 <table>
 
-<tr align="left"><th>osx_image value</th><th>Xcode version</th><th>OS X version</th></tr>
+<tr align="left"><th>osx_image value</th><th>Xcode version</th><th>macOS version</th></tr>
 {% for image in site.data.xcodes.osx_images %}
 <tr>
   <td><code>osx_image: {{image.image}}</code>{% if image.default == true %}  <em>Default</em> {% endif %}</td>
   <td><a href="/user/reference/osx/#xcode-{{image.xcode | downcase | remove:'.' | remove: '-'}}">Xcode {{ image.xcode_full_version }}</a></td>
-  <td>OS X {{ image.osx_version}}
+  <td>macOS {{ image.osx_version}}
   </td></tr>
 {% endfor %}
 </table>
 
-> Detailed iOS SDK versions are available in the [OS X CI environment
+> Detailed iOS SDK versions are available in the [macOS CI environment
 > reference](/user/reference/osx/#xcode-version)
 
 ## Default Test Script
@@ -173,4 +173,4 @@ For Objective-C projects, `env`, `rvm`, `gemfile`, `xcode_sdk`, and
 
 ## Simulators
 
-A complete list of simulators available in each version of Xcode is shown on the [OS X environment page](/user/reference/osx#xcode-version).
+A complete list of simulators available in each version of Xcode is shown on the [macOS environment page](/user/reference/osx#xcode-version).

--- a/user/languages/perl.md
+++ b/user/languages/perl.md
@@ -8,7 +8,7 @@ layout: en
 
 This guide covers build environment and configuration topics specific to Perl projects. Please make sure to read our [Tutorial](/user/tutorial/) and [general build configuration](/user/customizing-the-build/) guides first.
 
-Perl builds are not available on the OS X environment.
+Perl builds are not available on the macOS environment.
 
 ## Choosing Perl versions to test against
 

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -15,7 +15,7 @@ This guide covers build environment and configuration topics specific to
 Perl 6 projects. Please make sure to read our [Tutorial](/user/tutorial/)
 and [general build configuration](/user/customizing-the-build/) guides first.
 
-Perl 6 builds are not available on the OS X environment.
+Perl 6 builds are not available on the macOS environment.
 
 ### Community-Supported Warning
 

--- a/user/languages/php.md
+++ b/user/languages/php.md
@@ -34,7 +34,7 @@ This guide covers build environment and configuration topics specific to PHP
 projects. Please make sure to read our [Tutorial](/user/tutorial/)
 and [build configuration](/user/customizing-the-build/) guides first.
 
-PHP builds are not available on the OS X environment.
+PHP builds are not available on the macOS environment.
 
 ## Choosing PHP versions to test against
 

--- a/user/languages/r.md
+++ b/user/languages/r.md
@@ -212,7 +212,7 @@ repos:
 {: data-file=".travis.yml"}
 
 - `disable_homebrew`: if `true` this removes the preinstalled homebrew
-  installation on OS X. Useful to test if the package builds on a vanilla OS X
+  installation on macOS. Useful to test if the package builds on a vanilla macOS
   machine, such as the CRAN mac builder.
 
 ### Environment Variables
@@ -243,14 +243,14 @@ processed in order, so entries can depend on dependencies in a previous list.
 - `apt_packages`: See above
 
 - `brew_packages`: A list of packages to install via `brew`. This option is
-  ignored on non-OS X builds.
+  ignored on non-macOS builds.
 
 - `r_binary_packages`: A list of R packages to install as binary packages on
   linux builds, via Michael Rutter's
   [cran2deb4ubuntu PPA][launchpad].
   These installs will be faster than source installs, but may not always be
   the most recent version. Specify the name just as you would when installing
-  from CRAN. On OS X builds these packages are installed from source.
+  from CRAN. On macOS builds these packages are installed from source.
 
 - `r_packages`: A list of R packages to install via `install.packages`.
 

--- a/user/languages/ruby.md
+++ b/user/languages/ruby.md
@@ -68,7 +68,7 @@ one is available.
 
 <!-- distro exception -->
 
-If you're using OS X or Trusty environments, you can also use
+If you're using macOS or Trusty environments, you can also use
 [Rubinius](http://rubini.us). To test with Rubinius, add `rbx-X` or `rbx-X.Y.Z`
 to your `.travis.yml`, where X.Y.Z specifies a Rubinius release listed on
 [http://rubies.travis-ci.org/rubinius](http://rubies.travis-ci.org/rubinius) .

--- a/user/languages/scala.md
+++ b/user/languages/scala.md
@@ -24,7 +24,7 @@ Minimal example:
 
 {{ site.data.snippets.trusty_note_no_osx }}
 
-Scala builds are not available on the OS X environment.
+Scala builds are not available on the macOS environment.
 
 The rest of this guide covers configuring Scala projects in Travis CI. If you're
 new to Travis CI please read our [Tutorial](/user/tutorial/) and

--- a/user/multi-os.md
+++ b/user/multi-os.md
@@ -5,7 +5,7 @@ layout: en
 ---
 
 If your code is used on multiple operating systems it probably should be tested on
-multiple operating systems. Travis CI can test on Linux and OS X.
+multiple operating systems. Travis CI can test on Linux and macOS.
 
 To enable testing on multiple operating systems add the `os` key to your `.travis.yml`:
 
@@ -25,9 +25,9 @@ If you are already using a [build matrix](/user/customizing-the-build/#build-mat
 When you test your code on multiple operating systems, be aware of differences
 that can affect your tests:
 
-- Not all tools may be available on OS X.
+- Not all tools may be available on macOS.
 
-  We are still working on building up the toolchain on the [OS X Environment](/user/reference/osx/).
+  We are still working on building up the toolchain on the [macOS Environment](/user/reference/osx/).
   Missing software may be available via Homebrew.
 
 - Language availability.
@@ -38,7 +38,7 @@ that can affect your tests:
 
 - The file system behavior is different.
 
-  The HFS+ file system on our OS X workers is case-insensitive (which is the default for OS X),
+  The HFS+ file system on our macOS workers is case-insensitive (which is the default for macOS),
   and the files in a directory are returned sorted.
   On Linux, the file system is case-sensitive, and returns directory entries in
   the order they appear in the directory internally.
@@ -66,7 +66,7 @@ matrix:
 
 ## Example Multi OS Build Matrix
 
-Here's an example `.travis.yml` file using if/then directives to customize the [build lifecycle](/user/job-lifecycle/) to use [Graphviz](https://graphviz.gitlab.io/) in both Linux and OS X.
+Here's an example `.travis.yml` file using if/then directives to customize the [build lifecycle](/user/job-lifecycle/) to use [Graphviz](https://graphviz.gitlab.io/) in both Linux and macOS.
 
 ```yaml
 language: c
@@ -94,7 +94,7 @@ script:
 ```
 {: data-file=".travis.yml"}
 
-There are many options available and using the `matrix.include` key is essential to include any specific entries. For example, this matrix would route builds to the [Trusty build environment](/user/reference/trusty/) and to an [OS X image using Xcode 7.2](/user/languages/objective-c#supported-xcode-versions):
+There are many options available and using the `matrix.include` key is essential to include any specific entries. For example, this matrix would route builds to the [Trusty build environment](/user/reference/trusty/) and to a [macOS image using Xcode 7.2](/user/languages/objective-c#supported-xcode-versions):
 
 ```yaml
 matrix:
@@ -108,7 +108,7 @@ matrix:
 
 ### Python example (unsupported languages)
 
-For example, this `.travis.yml` uses the `matrix.include` key to include four specific entries in the build matrix. It also takes advantage of `language: generic` to test Python on OS X. Custom requirements are installed in `./.travis/install.sh` below.
+For example, this `.travis.yml` uses the `matrix.include` key to include four specific entries in the build matrix. It also takes advantage of `language: generic` to test Python on macOS. Custom requirements are installed in `./.travis/install.sh` below.
 
 ```yaml
 language: python
@@ -133,22 +133,22 @@ script: make test
 ```
 {: data-file=".travis.yml"}
 
-This custom install script (pseudo code only) uses the `$TRAVIS_OS_NAME` and `$TOXENV` variables to install (Python) prerequisites specific to OS X, Linux and each specific python version.
+This custom install script (pseudo code only) uses the `$TRAVIS_OS_NAME` and `$TOXENV` variables to install (Python) prerequisites specific to macOS, Linux and each specific python version.
 
 ```bash
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 
-    # Install some custom requirements on OS X
+    # Install some custom requirements on macOS
     # e.g. brew install pyenv-virtualenv
 
     case "${TOXENV}" in
         py32)
-            # Install some custom Python 3.2 requirements on OS X
+            # Install some custom Python 3.2 requirements on macOS
             ;;
         py33)
-            # Install some custom Python 3.3 requirements on OS X
+            # Install some custom Python 3.3 requirements on macOS
             ;;
     esac
 else

--- a/user/reference/osx.md
+++ b/user/reference/osx.md
@@ -1,5 +1,5 @@
 ---
-title: The OS X Build Environment
+title: The macOS Build Environment
 layout: en
 redirect_from:
   - /user/osx-ci-environment/
@@ -9,7 +9,7 @@ redirect_from:
 ### What This Guide Covers
 
 This guide explains what packages, tools and settings are available in the
-Travis OS X CI environment (often referred to as the “CI environment”).
+Travis macOS CI environment (often referred to as the “CI environment”).
 
 
 
@@ -28,28 +28,28 @@ and rolled back at the end of it. This offers a number of benefits:
 The environment available to test suites is known as the *Travis CI
 environment*.
 
-## Using OS X
+## Using macOS
 
-To use our OS X build infrastructure, add the following to your `.travis.yml`:
+To use our macOS build infrastructure, add the following to your `.travis.yml`:
 
 ```yaml
 os: osx
 ```
 {: data-file=".travis.yml"}
 
-## OS X Version
+## macOS Version
 
-Travis CI uses OS X 10.13 and Xcode 9.4.1 by default. You can use another version of OS X (and Xcode) by specifying the corresponding `osx_image` key from the following table:
+Travis CI uses macOS 10.13 and Xcode 9.4.1 by default. You can use another version of macOS (and Xcode) by specifying the corresponding `osx_image` key from the following table:
 
 <table>
 
-<tr align="left"><th>osx_image value</th><th>Xcode version</th><th>Xcode build version</th><th>OS X version</th><th>JDK</th></tr>
+<tr align="left"><th>osx_image value</th><th>Xcode version</th><th>Xcode build version</th><th>macOS version</th><th>JDK</th></tr>
 {% for image in site.data.xcodes.osx_images %}
 <tr>
   <td><code>osx_image: {{image.image}}</code>{% if image.default == true %}  <em>Default</em> {% endif %}</td>
   <td><a href="#xcode-{{image.xcode | downcase | remove:'.' | remove: '-'}}">Xcode {{ image.xcode_full_version }}</a></td>
   <td>{{ image.xcode_build_version}}</td>
-  <td>OS X {{ image.osx_version}}</td>
+  <td>macOS {{ image.osx_version}}</td>
   <td>{{image.jdk}}</td>
   </tr>
 {% endfor %}
@@ -59,7 +59,7 @@ Travis CI uses OS X 10.13 and Xcode 9.4.1 by default. You can use another versio
 
 Homebrew is installed and updated every time the virtual machines are updated.
 
-> The [Travis Homebrew addon](/user/installing-dependencies/#installing-packages-on-os-x) is the simplest, fastest and most reliable way to install dependencies.
+> The [Travis Homebrew addon](/user/installing-dependencies/#installing-packages-on-macos) is the simplest, fastest and most reliable way to install dependencies.
 
 The Homebrew addon correctly handles up-to-date, outdated, and missing packages. Manual Homebrew dependency scripts are error-prone, and we recommend against using them.
 
@@ -67,26 +67,26 @@ The Homebrew addon uses the Homebrew database on the build image by default, but
 
 ## File System
 
-VMs running OS X use the default file system, HFS+.
+VMs running macOS use the default file system, HFS+.
 This file system is case-insensitive, and returns entities within a
 directory alphabetically.
 
-## JDK and OS X
+## JDK and macOS
 
 Note the pre-installed JDK version (OracleJDK) for each image in the table below.
 While Mac jobs can test against multiple JDK versions using the [`jdk` key](/user/languages/java/#testing-against-multiple-jdks),
-OS X images up to `xcode9.3` can only switch up to Java 8, and images `xcode9.4` and later can switch to Java 10 (if pre-installed) and later.
+macOS images up to `xcode9.3` can only switch up to Java 8, and images `xcode9.4` and later can switch to Java 10 (if pre-installed) and later.
 In practical terms, if your Mac build requires Java 8 and below, use `xcode9.3` (or below); if your build requires Java 10
 and later, use `xcode9.4` (or later).
 
 <table>
 
-<tr align="left"><th>osx_image value</th><th>Xcode version</th><th>OS X version</th><th>JDK</th></tr>
+<tr align="left"><th>osx_image value</th><th>Xcode version</th><th>macOS version</th><th>JDK</th></tr>
 {% for image in site.data.xcodes.osx_images %}
 <tr>
   <td><code>osx_image: {{image.image}}</code>{% if image.default == true %}  <em>Default</em> {% endif %}</td>
   <td><a href="#xcode-{{image.xcode | downcase | remove:'.' | remove: '-'}}">Xcode {{ image.xcode_full_version }}</a></td>
-  <td>OS X {{ image.osx_version}}</td>
+  <td>macOS {{ image.osx_version}}</td>
   <td>{{image.jdk}}</td>
   </tr>
 {% endfor %}
@@ -156,7 +156,7 @@ Stock Apache Maven 3.5.3
 
 ## Ruby versions/implementations
 
-- system (depends on OS X version) -- You need to use `sudo` to install gems with this ruby
+- system (depends on macOS version) -- You need to use `sudo` to install gems with this ruby
 
 - ruby-1.9.3-p551
 - ruby-2.0.0-p643

--- a/user/reference/overview.md
+++ b/user/reference/overview.md
@@ -19,9 +19,9 @@ Each build runs in one of the following virtual environments.
 
 A sudo enabled, full virtual machine per build, that runs Linux, either [Ubuntu Xenial 16.04](/user/reference/xenial/), [Ubuntu Trusty 14.04](/user/reference/trusty/), or [Ubuntu Precise 12.04](/user/reference/precise/)
 
-### OS X
+### macOS
 
-An [OS X](/user/reference/osx/) environment for Objective-C and other OS X specific projects
+A [macOS](/user/reference/osx/) environment for Objective-C and other macOS specific projects
 
 ### Windows
 
@@ -31,21 +31,21 @@ A [Windows](/user/reference/windows/) environment running Windows Server, versio
 
 The following table summarizes the differences across virtual environments and operating systems:
 
-|                      | Ubuntu Linux ([Xenial](/user/reference/xenial/) , [Trusty](/user/reference/trusty/), [Precise](/user/reference/precise/)) | [OS X](/user/reference/osx/) | [Windows](/user/reference/windows) |
-|:---------------------|:--------------------------------------------------------------------------------------------------------------------------|:-----------------------------|:-----------------------------------|
-| Name                 | Ubuntu                                                                                                                    | OS X                         | Windows                            |
-| Status               | Current                                                                                                                   | Current                      | Early release                      |
-| Infrastructure       | Virtual machine on GCE                                                                                                    | Virtual machine              | Virtual machine on GCE             |
-| `.travis.yml`        | `dist: xenial` or `dist: trusty` or `dist: precise`                                                                       | `os: osx`                    | `os: windows`                      |
-| Allows `sudo`        | Yes                                                                                                                       | Yes                          | No                                 |
-| Approx boot time     | 20-50s                                                                                                                    | 60-90s                       | 60-120s                            |
-| File system          | EXT4                                                                                                                      | HFS+                         | NTFS                               |
-| Operating system     | Ubuntu Linux                                                                                                              | OS X                         | Windows Server 2016                |
-| Memory               | 7.5 GB                                                                                                                    | 4 GB                         | 8 GB                               |
-| Cores                | 2                                                                                                                         | 2                            | 2                                  |
-| IPv4 network         | IPv4 is available                                                                                                         | IPv4 is available            | IPv4 is available                  |
-| IPv6 network         | IPv6 is not available                                                                                                     | IPv6 is not available        | IPv6 is not available              |
-| Available disk space | approx 18GB                                                                                                               | approx 41GB                  | approx 19 GB                       |
+|                      | Ubuntu Linux ([Xenial](/user/reference/xenial/) , [Trusty](/user/reference/trusty/), [Precise](/user/reference/precise/)) | [macOS](/user/reference/osx/) | [Windows](/user/reference/windows) |
+|:---------------------|:--------------------------------------------------------------------------------------------------------------------------|:------------------------------|:-----------------------------------|
+| Name                 | Ubuntu                                                                                                                    | macOS                         | Windows                            |
+| Status               | Current                                                                                                                   | Current                       | Early release                      |
+| Infrastructure       | Virtual machine on GCE                                                                                                    | Virtual machine               | Virtual machine on GCE             |
+| `.travis.yml`        | `dist: xenial` or `dist: trusty` or `dist: precise`                                                                       | `os: osx`                     | `os: windows`                      |
+| Allows `sudo`        | Yes                                                                                                                       | Yes                           | No                                 |
+| Approx boot time     | 20-50s                                                                                                                    | 60-90s                        | 60-120s                            |
+| File system          | EXT4                                                                                                                      | HFS+                          | NTFS                               |
+| Operating system     | Ubuntu Linux                                                                                                              | macOS                         | Windows Server 2016                |
+| Memory               | 7.5 GB                                                                                                                    | 4 GB                          | 8 GB                               |
+| Cores                | 2                                                                                                                         | 2                             | 2                                  |
+| IPv4 network         | IPv4 is available                                                                                                         | IPv4 is available             | IPv4 is available                  |
+| IPv6 network         | IPv6 is not available                                                                                                     | IPv6 is not available         | IPv6 is not available              |
+| Available disk space | approx 18GB                                                                                                               | approx 41GB                   | approx 19 GB                       |
 
 > Available disk space is approximate and depends on the base image and language selection of your project.
   The best way to find out what is available on your specific image is to run `df -h` as part of your build script.

--- a/user/reference/precise.md
+++ b/user/reference/precise.md
@@ -27,7 +27,7 @@ can install anything that's required for them to run.
 ## Networking
 
 The virtual machines in the Legacy environment running the tests have IPv6 enabled. They do not have any external IPv4 address but are fully able to communicate with any external IPv4 service.
-The container-based, OS X, and GCE (both Precise and Trusty) builds do not currently have IPv6 connectivity.
+The container-based, macOS, and GCE (both Precise and Trusty) builds do not currently have IPv6 connectivity.
 
 The IPv6 stack can have some impact on Java services in particular, where one might need to set the flag `java.net.preferIPv4Stack` to force the JVM to resort to the IPv4 stack should services show issues of not booting up or not being reachable via the network: `-Djava.net.preferIPv4Stack=true`.
 
@@ -40,7 +40,7 @@ images.
 
 For other images, see the list below:
 
-- [OS X CI Environment](/user/reference/osx)
+- [macOS CI Environment](/user/reference/osx)
 - [Trusty CI Environment](/user/reference/trusty)
 
 ### Version control
@@ -93,7 +93,7 @@ Language-specific workers have multiple runtimes for their respective language (
 ### Firefox
 
 All virtual environments have recent version of Firefox installed, currently
-31.0 for Linux environments and 25.0 for OS X.
+31.0 for Linux environments and 25.0 for macOS.
 
 If you need a specific version of Firefox, use the Firefox addon to install
 it during the `before_install` stage of the build.

--- a/user/reference/windows.md
+++ b/user/reference/windows.md
@@ -7,7 +7,7 @@ layout: en
 
 This guide explains what packages, tools and settings are available in the Travis Windows CI environment (often referred to as the “CI environment”).
 
-> Take note that our Windows environment is in early stages and a minimal subset of what's available on Linux or OS X/macOS is currently supported.
+> Take note that our Windows environment is in early stages and a minimal subset of what's available on Linux or macOS is currently supported.
 
 ## Support
 

--- a/user/tutorial.md
+++ b/user/tutorial.md
@@ -78,15 +78,15 @@ language: php
 {: data-file=".travis.yml"}
 
 If you have tests that need to run on macOS, or your project uses Swift or
-Objective-C, use our OS X environment:
+Objective-C, use our macOS environment:
 
 ```yaml
 os: osx
 ```
 {: data-file=".travis.yml"}
 
-> You do *not* necessarily need to use OS X if you develop on a Mac.
-> OS X is required only if you need Swift, Objective-C or other
+> You do *not* necessarily need to use macOS if you develop on a Mac.
+> macOS is required only if you need Swift, Objective-C or other
 > macOS-specific software.
 
 Travis CI supports many [programming languages](/user/languages/).


### PR DESCRIPTION
Changes “OS X”, “Mac OS X”, and “Mac OS” to “macOS”.

I didn’t change any programmatic instances (such as `os: osx` in `.travis.yml`), however, I did change a few anchors (for example, `#mac-os-x` → `#macos`). I’ve also updated the article where necessary (for example, “an OS X image” → “a macOS image”) and updated instances of older macOS versions ([since Apple is changing the branding retroactively](https://apple.stackexchange.com/a/256093)).

See also #766 and #1117.