### PR TITLE
snap provider only works on Ubuntu 16.04+

### DIFF
--- a/user/deployment/snaps.md
+++ b/user/deployment/snaps.md
@@ -11,6 +11,8 @@ Travis CI can automatically upload and release your app to the [Snap Store](http
 To upload your snap, add the following to your `.travis.yml`:
 
 ```yaml
+dist: xenial
+
 deploy:
   provider: snap
   snap: my.snap


### PR DESCRIPTION
Because `snapcraft` is only available there
https://packages.ubuntu.com/search?keywords=snapcraft