### PR TITLE
mention ruby pronto issues with shallow cloning

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -85,6 +85,8 @@ git:
 ```
 {: data-file=".travis.yml"}
 
+> Some operations on the repository, such as common automated code review scripts (e.g. Pronto for Ruby), may fail due to the limited git clone depth, not being able to access all the objects in the repository. Removing the depth flag, or running `git fetch --unshallow` might solve the issue.
+
 ## Git Clone Quiet
 
 Travis CI clones repositories without the quiet flag (`-q`) by default. Enabling the quiet flag can be useful if you're trying to avoid log file size limits or even if you just don't need to include it.


### PR DESCRIPTION
I have encountered an issue with ruby's pronto (automated code review), specifically it's rugged git wrapper. It is caused by the default --depth=50 switch on the git clone command, and can be fixed fully by overriding the depth switch, just as mentioned in the docs. However, I have found no actual mention of the caveats of this solution anywhere, and I think that this information would definitely help the next person having a similar problem, given that pronto is pretty much the standard in ruby CI solutions.