### PR TITLE
fix nunit console path

### DIFF
--- a/user/languages/csharp.md
+++ b/user/languages/csharp.md
@@ -150,7 +150,7 @@ install:
   - nuget install NUnit.Console -Version 3.9.0 -OutputDirectory testrunner
 script:
   - msbuild /p:Configuration=Release solution-name.sln
-  - mono ./testrunner/NUnit.Runners.3.9.0/tools/nunit-console3.exe ./MyProject.Tests/bin/Release/MyProject.Tests.dll
+  - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./MyProject.Tests/bin/Release/MyProject.Tests.dll
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
This PR fixes the Nunit console path in the [C# NUnit section](https://docs.travis-ci.com/user/languages/csharp/#nunit), see related forum post https://travis-ci.community/t/documentation-is-outdated-on-nunit-section/1705