### PR TITLE
Clarify `cache: yarn` behavior

### DIFF
--- a/user/languages/javascript-with-nodejs.md
+++ b/user/languages/javascript-with-nodejs.md
@@ -186,12 +186,13 @@ before_install:
 
 #### Caching with `yarn`
 
-You can cache `$HOME/.cache/yarn` with:
-
 ```yaml
 cache: yarn
 ```
 {: data-file=".travis.yml"}
+
+will add `yarn`'s default caching directory (which varies depending on the OS),
+as indicated by [`yarn cache dir`](https://yarnpkg.com/en/docs/cli/cache#toc-yarn-cache-dir).
 
 If your caching needs to include other directives, you can use:
 


### PR DESCRIPTION
As to what directory is added to the cache.

To correspond to https://github.com/travis-ci/travis-build/pull/1642.