### PR TITLE
Updating with info about stable python 3.7

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -62,6 +62,15 @@ script:
 ```
 {: data-file=".travis.yml"}
 
+You can also specify the stable release of Python 3.7 on our Xenial build images:
+
+```yaml
+dist: xenial
+language: python
+python: 3.7
+```
+{: data-file=".travis.yml"}
+
 
 ### Travis CI Uses Isolated virtualenvs
 


### PR DESCRIPTION
Updating documentation on Python versions to specify that the stable release of Python 3.7 is supported on Xenial.