### PR TITLE
Following the Haskell guide leads to ruby builds

### DIFF
--- a/user/languages/haskell.md
+++ b/user/languages/haskell.md
@@ -18,6 +18,7 @@ layout: en
 Minimal example:
 
 ```yaml
+language: haskell
 ghc:
   - "7.8"
 ```
@@ -41,6 +42,7 @@ You can specify one or more GHC versions using `major.minor` notation. Patch
 level versions (`7.6.2` for example) may change any time:
 
 ```yaml
+language: haskell
 ghc:
   - "7.10"
   - "7.8"
@@ -76,6 +78,7 @@ If you have multiple packages in subdirectories (each containing a `.cabal` file
 you can specify those directories in an environment variable:
 
 ```yaml
+language: haskell
 ghc:
   - "7.10"
   - "7.8"


### PR DESCRIPTION
When following the guide to setup a Haskell build, travis mistakes the project with a ruby project.
Setting the `language` field explicitly to `haskell` resolves this issue.