### PR TITLE
Add extra hints for docker-compose integration

### DIFF
--- a/user/docker.md
+++ b/user/docker.md
@@ -189,7 +189,7 @@ before_install:
 ```
 {: data-file=".travis.yml"}
 
-If you're using `docker-compose` to integrate with externals tools, like coveralls, make sure you repass the required environment variables.
+If you're using `docker-compose` to integrate with externals tools, like coveralls, make sure you repass the required environment variables, here's a simple example of a docker-compose.yml file.
 
 ```yaml
   test:

--- a/user/docker.md
+++ b/user/docker.md
@@ -189,6 +189,26 @@ before_install:
 ```
 {: data-file=".travis.yml"}
 
+If you're using `docker-compose` to integrate with externals tools, like coveralls, make sure you repass the required environment variables.
+
+```yaml
+  test:
+    command: busted -c
+    environment:
+      - TRAVIS=true
+      - CI=true
+      - TRAVIS_JOB_ID=${TRAVIS_JOB_ID}
+      - TRAVIS_BRANCH=${TRAVIS_BRANCH}
+      - TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG}
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    volumes:
+      - ".:/lua/"
+    working_dir: "/lua"
+```
+
+
 ## Installing a newer Docker version
 
 You can upgrade to the latest version and use any new Docker features by manually
@@ -219,3 +239,4 @@ addons:
 
 - [heroku/logplex](https://github.com/heroku/logplex/blob/master/.travis.yml) (Heroku log router)
 - [kartorza/docker-pg-backup](https://github.com/kartoza/docker-pg-backup/blob/master/.travis.yml) (A cron job that will back up databases running in a docker PostgreSQL container)
+


### PR DESCRIPTION
Add tip for docker-compose integration with external tools, like coveralls.

I spent a reasonable amount of time [trying to figure out](https://github.com/leandromoreira/nginx-lua-redis-rate-measuring/pull/22) why wasn't my [`.travis.yml`](https://github.com/leandromoreira/nginx-lua-redis-rate-measuring/blob/master/.travis.yml#L16) not sending data for coveralls.

I don't know if this is too specific or not useful but I would be glad to find this documentation close to the `docker-compose` section.