### PR TITLE
Instructions on how to create a cronjob for renewing Lets Encrypt certificates

### DIFF
--- a/user/enterprise/platform-tips.md
+++ b/user/enterprise/platform-tips.md
@@ -253,7 +253,52 @@ $ sudo certbot renew
 $ replicatedctl app start
 ```
 
-In general: These certificate renewals should be automated with a cron job.
+Automate renewal with a cron job
+
+Create a file such as `/home/ubuntu/renew-certs.sh` with the following in it:
+
+```
+#!/bin/bash
+
+set -u
+
+function usage() {
+  echo
+  echo "Usage: $(basename $0)"
+  echo
+  echo "Simple script to renew certs, should be used via a cron. Assumes that certs are already set up."
+  echo
+  echo "See https://docs.travis-ci.com/user/enterprise/platform-tips/#use-a-lets-encrypt-ssl-certificate for initial setup info."
+  echo
+
+  exit 1
+}
+
+if [[ $# -ne 0 ]]; then
+  usage
+fi
+
+replicatedctl app stop
+sudo certbot renew
+replicatedctl app start
+```
+
+You'll then want to create a cronjob by using your favorite text editor, for example:
+
+```
+nano /etc/crontab
+```
+
+Then add the below to the file that you've just opened in your text editor. Make sure to replay the `Year-Month-Day` with the ones that apply to the certificate you are creating.
+
+```
+# Renews certs every 90 days. Certs were regenerated on Year-Month-Day so the next renewal should be Year-Month-Day.
+0 2 1 2,5,8,11 * /home/ubuntu/renew-certs.sh
+```
+
+**Note: Be aware that this process will also introduce downtime.**
+
+Make sure to plan to communicate with your users every time this downtime will happen so they are aware that their builds will temporarily be stopped until the certificate gets renewed and your Travis CI Enterprise installation comes back online.
 
 ## Uninstall Travis CI Enterprise
 

--- a/user/enterprise/platform-tips.md
+++ b/user/enterprise/platform-tips.md
@@ -253,7 +253,7 @@ $ sudo certbot renew
 $ replicatedctl app start
 ```
 
-Automate renewal with a cron job
+### Automate renewal of your Let's Encrypt SSL Certificate with a cron job
 
 Create a file such as `/home/ubuntu/renew-certs.sh` with the following in it:
 
@@ -282,6 +282,7 @@ replicatedctl app stop
 sudo certbot renew
 replicatedctl app start
 ```
+Set the executable permissions you'll need by doing `chmod +x /home/ubuntu/renew-certs.sh`.
 
 You'll then want to create a cronjob by using your favorite text editor, for example:
 

--- a/user/enterprise/platform-tips.md
+++ b/user/enterprise/platform-tips.md
@@ -290,7 +290,7 @@ You'll then want to create a cronjob by using your favorite text editor, for exa
 nano /etc/crontab
 ```
 
-Then append the below to the file that you've just opened in your text editor. Make sure adjust the configuration with values that apply to the certificate you are creating.
+Then append the below to the file that you've just opened in your text editor. Make sure to adjust the configuration with values that apply to the certificate you are creating.
 
 ```
 # Renews certs at 2am on the 1st of February, May, August, and November.

--- a/user/notifications.md
+++ b/user/notifications.md
@@ -167,7 +167,8 @@ to [your verified email addresses](https://github.com/settings/emails) on GitHub
 
 ## Configuring IRC notifications
 
-You can also specify notifications sent to an IRC channel:
+You can also send notifications to an IRC channel.
+Notifications are sent from `travis-ci`, which auto-authenticates on Freenode.
 
 ```yaml
 notifications:


### PR DESCRIPTION
Lets Encrypt certificates need to be renewed every 90 days rather than a user forgetting to do that this provides them with instructions on how to create a cronjob to do that automatically. The only process they need to do externally is communicating with their users whenever there will be downtime for the renewal to take place.