### PR TITLE
Ruby gem trav3 - API v3 client

### DIFF
--- a/user/apps.md
+++ b/user/apps.md
@@ -425,6 +425,7 @@ By Sankarsan Kampa
 ## Ruby
 
 - [travis.rb](https://github.com/travis-ci/travis.rb) **(official)**
+- [trav3](https://github.com/danielpclark/trav3) by Daniel P. Clark
 - [TravisMiner](https://github.com/smcintosh/travisminer) by Shane McIntosh
 - [hoe-travis](https://github.com/drbrain/hoe-travis) by Eric Hodel
 - [Knapsack](https://github.com/ArturT/knapsack) by Artur Trzop


### PR DESCRIPTION
A lightweight abstraction layer for using Travis CI version 3 of their API.  This gem has no dependencies, fully documented API interface methods with examples, and 100% test coverage.