### PR TITLE
naming minimal file examples in all ataglance side panels

### DIFF
--- a/user/languages/cpp.md
+++ b/user/languages/cpp.md
@@ -20,7 +20,7 @@ Minimal example:
 ```yaml
 language: cpp
 ```
-
+{: data-file=".travis.yml"}
 </aside>
 
 {{ site.data.snippets.trusty_note }}

--- a/user/languages/elixir.md
+++ b/user/languages/elixir.md
@@ -8,12 +8,12 @@ layout: en
 
 <aside markdown="block" class="ataglance">
 
-| Elixir            | Default                                   |
-|:------------------|:------------------------------------------|
+| Elixir            | Default                                                        |
+|:------------------|:---------------------------------------------------------------|
 | Typical `install` | `mix local.rebar --force; mix local.hex --force; mix deps.get` |
-| Typical `script`  | `mix test`                                |
-| Matrix keys       | `env`, `elixir`, `otp_release`            |
-| Support           | [Travis CI](mailto:support@travis-ci.com) |
+| Typical `script`  | `mix test`                                                     |
+| Matrix keys       | `env`, `elixir`, `otp_release`                                 |
+| Support           | [Travis CI](mailto:support@travis-ci.com)                      |
 
 Minimal example:
 

--- a/user/languages/go.md
+++ b/user/languages/go.md
@@ -27,6 +27,7 @@ go:
 - 1.11.x
 - "1.10"
 ```
+{: data-file=".travis.yml"}
 
 Note that, in order to choose Go 1.10, you must use `go: "1.10"` (a string), not
 `go: 1.10` (a float).  Using a float results in the use of Go 1.1.

--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -20,6 +20,7 @@ Minimal example:
 ```yaml
   language: java
 ```
+{: data-file=".travis.yml"}
 </aside>
 
 {{ site.data.snippets.trusty_note }}

--- a/user/languages/php.md
+++ b/user/languages/php.md
@@ -25,7 +25,7 @@ php:
   - hhvm # on Trusty only
   - nightly
 ```
-
+{: data-file=".travis.yml"}
 </aside>
 
 {{ site.data.snippets.trusty_note_no_osx }}

--- a/user/languages/scala.md
+++ b/user/languages/scala.md
@@ -20,6 +20,7 @@ Minimal example:
 ```yaml
   language: scala
 ```
+{: data-file=".travis.yml"}
 </aside>
 
 {{ site.data.snippets.trusty_note_no_osx }}


### PR DESCRIPTION
@plaindocs replacing https://github.com/travis-ci/docs-travis-ci-com/pull/2254 because I deleted that fork