### PR TITLE
PHP nightlies do not include 3rd-party extensions

### DIFF
--- a/user/languages/php.md
+++ b/user/languages/php.md
@@ -98,7 +98,7 @@ before_script:
 
 Travis CI can test your PHP applications with a nightly
 [PHP](https://github.com/php/php-src/) build, which includes PHPUnit and
-Composer:
+Composer, but does not include third-party PHP extensions:
 
 ```yaml
 language: php


### PR DESCRIPTION
This was changed in https://github.com/travis-ci/php-src-builder/pull/28.