### PR TITLE
making ataglance minimal examples as minimal as possible

### DIFF
--- a/user/languages/elixir.md
+++ b/user/languages/elixir.md
@@ -19,8 +19,6 @@ Minimal example:
 
 ```yaml
 language: elixir
-elixir: '1.5.2'
-otp_release: '19.0'
 ```
 {: data-file=".travis.yml"}
 

--- a/user/languages/elm.md
+++ b/user/languages/elm.md
@@ -24,8 +24,6 @@ Minimal example:
 
 ```yaml
   language: elm
-  elm:
-    - "0.19.0"
 ```
 {: data-file=".travis.yml"}
 

--- a/user/languages/erlang.md
+++ b/user/languages/erlang.md
@@ -19,9 +19,6 @@ Minimal example:
 
 ```yaml
 language: erlang
-otp_release:
-  - 19.0
-  - 18.2.1
 ```
 {: data-file=".travis.yml"}
 

--- a/user/languages/php.md
+++ b/user/languages/php.md
@@ -19,11 +19,6 @@ Minimal example:
 
 ```yaml
 language: php
-php:
-  - '5.6'
-  - '7.1'
-  - hhvm # on Trusty only
-  - nightly
 ```
 {: data-file=".travis.yml"}
 </aside>

--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -19,8 +19,6 @@ Minimal example:
 
 ```yaml
   language: python
-  python:
-    - "3.6"
   script:
     - pytest
 ```

--- a/user/languages/ruby.md
+++ b/user/languages/ruby.md
@@ -19,11 +19,6 @@ Minimal example:
 
 ```yaml
 language: ruby
-rvm:
-  - 2.2
-  - jruby
-  - truffleruby
-  - 2.0.0-p247
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
Python is the only language without a default script in its at-a-glance side panel. Should Python's script default to `pytest`?