### PR TITLE
making ataglance minimal examples as minimal as possible

### DIFF
--- a/user/languages/go.md
+++ b/user/languages/go.md
@@ -23,9 +23,6 @@ Minimal example:
 
 ```yaml
 language: go
-go:
-- 1.11.x
-- "1.10"
 ```
 {: data-file=".travis.yml"}
 

--- a/user/languages/haskell.md
+++ b/user/languages/haskell.md
@@ -19,8 +19,6 @@ Minimal example:
 
 ```yaml
 language: haskell
-ghc:
-  - "7.8"
 ```
 {: data-file=".travis.yml"}
 

--- a/user/languages/javascript-with-nodejs.md
+++ b/user/languages/javascript-with-nodejs.md
@@ -19,9 +19,6 @@ Minimal example:
 
 ```yaml
 language: node_js
-node_js:
-  - "iojs"
-  - "7"
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
missed a couple somehow 🤔

Python script is the only non-language key after this:

    ~/Documents/GitHub/docs-travis-ci-com/user/languages $ grep -h "Minimal example:" * -A4 | grep -v -i -E 'language|minimal|```'