### PR TITLE
Equals comparison on tag is based on its name.

### DIFF
--- a/user/conditions-v1.md
+++ b/user/conditions-v1.md
@@ -115,8 +115,8 @@ Boolean operators:
 ```
 branch = master AND env(FOO) = foo
 branch = master OR env(FOO) = foo
-branch = master AND env(FOO) = foo OR tag = true
-branch = master AND (env(FOO) = foo OR tag = true)
+branch = master AND env(FOO) = foo OR tag = bar
+branch = master AND (env(FOO) = foo OR tag = bar)
 NOT branch = master
 ```
 
@@ -142,8 +142,8 @@ The following boolean operators are supported:
 the following expressions are the same:
 
 ```
-branch = master AND os = linux OR tag = true
-(branch = master AND os = linux) OR tag = true
+branch = master AND os = linux OR tag = bar
+(branch = master AND os = linux) OR tag = bar
 
 NOT branch = master AND os = linux
 NOT (branch = master) AND os = linux


### PR DESCRIPTION
As explained in [here](https://travis-ci.community/t/somewhat-misleading-documentation-on-conditions/2468), the equals comparison on `tag` checks if it had a name `true`. The term true also represents the boolean value `true` and easily confuses a user. Therefore it would be better to make the documentation unambigous by having an example such as `tag = bar`.