### PR TITLE
Refactor Lets Encrypt section of Enterprise SSL Management page

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -75,7 +75,7 @@ contact_enterprise_support: |
    
   - Description of the problem - what are you observing?
   - Which steps did you try already?
-  - A support bundle (You can get it from `https://yourdomain:8800/support`)
+  - A support bundle (You can get it from `https://<your-travis-ci-enterprise-domain>:8800/support`)
   - Log files from all workers (They can be found at `/var/log/upstart/travis-worker.log` - please include as many as you can retrieve).
   - If a build failed or errored, a text file of the build log
   

--- a/user/enterprise/custom-queues.md
+++ b/user/enterprise/custom-queues.md
@@ -18,9 +18,9 @@ Travis::Features.enable_for_all(:template_selection); Travis::Features.enable_fo
 
 The new settings will take effect immediately, but job routing will remain the same until new queues are defined.
 
-## Define Custom Queues in the Management Console  
+## Define Custom Queues in the Management Console
 
-After enabling the feature flags for custom queues, configure the job routing in the management console. This is defined in yaml, in the **Advanced Configuration YAML** section at the bottom of the management console **Settings** page, e.g. `https://<your-domain>:8800/settings`.  
+After enabling the feature flags for custom queues, configure the job routing in the management console. This is defined in yaml, in the **Advanced Configuration YAML** section at the bottom of the management console **Settings** page, e.g. `https://<your-travis-ci-enterprise-domain>:8800/settings`.
 
 There are a number of options/selectors used to define routing to a custom queue. Repos that match _all_ of the selectors for a custom queue will be built on that custom queue. We recommend using the following selectors:
 
@@ -35,6 +35,7 @@ There are a number of options/selectors used to define routing to a custom queue
 > Note: We do not recommend using `dist` and `os` for these selectors. These two have some of their own routing processes built-in and may not entirely behave as intended.
 
 Define selectors in "Advanced Configuration YAML" in the following format:
+
 ```yaml
 production:
   queues:
@@ -44,7 +45,8 @@ production:
     selector: different_value
     selector: something_else
 ```
-see the [example](#advanced-configuration-yaml-example) for details on syntax. Click "Save" on the Management Console Settings when you are ready. Travis CI Enterprise will restart, with your new queue settings.
+
+See the [example](#advanced-configuration-yaml-example) for details on syntax. Click "Save" on the Management Console Settings when you are ready. Travis CI Enterprise will restart, with your new queue settings.
 
 ### Advanced Configuration YAML Example
 

--- a/user/enterprise/high-availability.md
+++ b/user/enterprise/high-availability.md
@@ -23,7 +23,7 @@ HA is configured entirely on the Enterprise platform instance, but installing an
 
 1. Contact [enterprise@travis-ci.com](mailto:enterprise@travis-ci.com?subject=HA%20Installation) to have your Enterprise license configured for HA mode.
 1. Setup your [platform instance per the standard installation steps](/user/enterprise/setting-up-travis-ci-enterprise/#1-setting-up-enterprise-platform-virtual-machine)
-1. Sign into your Admin Dashboard (at `your-domain.tld:8800`)
+1. Sign into your Admin Dashboard (at `https://<your-travis-ci-enterprise-domain>:8800`)
    1. Go to "Settings" and click "Enable HA"
    1. Paste in the urls where you have [Postgres](https://www.postgresql.org/), [Redis](https://redis.io/), and [RabbitMQ](https://www.rabbitmq.com/) hosted. The connection strings should be in the format of:
    ```
@@ -40,7 +40,7 @@ Once your first platform instance is fulling configured, you should be able to s
 
 We recommend at least two Platform containers for HA mode, and you can install more Enterprise containers in the same way you [installed](/user/enterprise/setting-up-travis-ci-enterprise/#1-setting-up-enterprise-platform-virtual-machine) the first.
 
-Once your second platform is installed, it will also need its HA settings configured. Go to the Admin Dashboard for your new platform container at `secondIP:8800` or `second-platform-public-dns.tld:8800` to complete this the same way as [the first platform installation](#installing-the-platform-in-high-availability-mode)
+Once your second platform is installed, it will also need its HA settings configured. Go to the Admin Dashboard for your new platform container at `https://<your-second-travis-ci-enterprise-domain>:8800` to complete this the same way as [the first platform installation](#installing-the-platform-in-high-availability-mode)
 
 ## Installing the Worker in High Availability Mode
 

--- a/user/enterprise/platform-tips.md
+++ b/user/enterprise/platform-tips.md
@@ -210,7 +210,7 @@ If you need to boot more worker machines, please see our docs about [installing 
 To check if your Travis CI Enterprise installation is up and running, query the `/api/uptime` endpoint of your instance.
 
 ```
-$ curl -H "Authorization: token XXXXX" https://travis.example.com/api/uptime
+$ curl -H "Authorization: token XXXXX" https://<your-travis-ci-enterprise-domain>/api/uptime
 ```
 
 If everything is up and running, it answers with a `HTTP 200 OK`, or in case of failure with a `HTTP 500 Internal Server Error`.

--- a/user/enterprise/precise.md
+++ b/user/enterprise/precise.md
@@ -7,7 +7,7 @@ layout: en_enterprise
 
 **Platform Requirements**: Precise Build Containers are supported for Travis CI Enterprise version 2.0 and higher. We recommend [Trusty Build Environments](/user/enterprise/trusty/) for Travis CI Enterprise 2.2+, as Trusty Build Environments are the default environment.
 
-To Legacy workers as default on Travis CI Enterprise 2.2+, override the fault behavior in the Admin Dashboard at `https://your-domain.tld:8800/settings#override_default_dist_enable`
+To Legacy workers as default on Travis CI Enterprise 2.2+, override the fault behavior in the Admin Dashboard at `https://<your-travis-ci-enterprise-domain>:8800/settings#override_default_dist_enable`
 
 **Worker Requirements**:
 The Legacy worker must be running Ubuntu 14.04 LTS as an underlying operating system. We recommend using AWS's `c3.2xlarge` as the instance type. Port 22 must be open for SSH during installation and operation.

--- a/user/enterprise/setting-up-travis-ci-enterprise.md
+++ b/user/enterprise/setting-up-travis-ci-enterprise.md
@@ -74,7 +74,7 @@ Ubuntu 16.04 LTS or later as the underlying operating system.
     sudo bash /tmp/installer.sh
     ```
 
-3. *In your browser*, navigate to `https://<hostname>:8800` (your Enterprise
+3. *In your browser*, navigate to `https://<your-travis-ci-enterprise-domain>:8800` (your Enterprise
 installation's hostname, port 8800) to complete the setup:
 
    1. Add a secure certificate or configure a trusted one.

--- a/user/enterprise/ssl-certificate-management.md
+++ b/user/enterprise/ssl-certificate-management.md
@@ -88,12 +88,12 @@ Upon restart you can then verify whether SSL verification is now working. If you
 
 ## Using a Let's Encrypt SSL Certificate
 
-You can use a certificate from [Let's Encrypt](https://letsencrypt.org/) instead of a self-signed certificate or a certificate purchased from a trusted certificate authority. Certificates from Let's Encrypt are free and behave the same as those purchased from a trusted certificate authority. More information about Let's Encrypt can be found [here](https://letsencrypt.org/about/).
+You can use a certificate from [Let's Encrypt](https://letsencrypt.org/) instead of a self-signed certificate or a certificate purchased from a trusted certificate authority. Certificates from Let's Encrypt are free and behave the same as those purchased from a trusted certificate authority.
 
 What you will need:
 
-1. An email address (Let's Encrypt will send notifications regarding urgent renewal and security issues).
-2. A domain name under which your installation is available (we're using `travis.example.com` in this guide).
+- An email address (Let's Encrypt will send notifications regarding urgent renewal and security issues).
+- A domain name under which your installation is available.
 
 > The following steps require downtime for your Travis CI Enterprise instance. For this reason we recommend that you perform these steps during a maintenance window.
 
@@ -102,7 +102,7 @@ What you will need:
 We will be using [certbot](https://certbot.eff.org/#ubuntutrusty-other) to obtain a SSL certificate from Let's Encrypt. To install certbot:
 
 1. Open a ssh connection to the platform machine.
-2. Add the certbot PPA:
+2. Add the certbot personal package archive:
   ```bash
   sudo add-apt-repository ppa:certbot/certbot
   ```
@@ -201,7 +201,7 @@ Your certificate is now generated and saved on your Travis CI Enterprise platfor
 To use your generated certificate in your Travis CI Enterprise instance:
 
 1. Log into your dashboard at `https://<your-travis-ci-enterprise-domain>:8800`.
-2. Click the gear icon on the rightmost side of the top menu and select 'Console Settings' from the dropdown.
+2. On the rightmost side of the top menu click the gear icon and select 'Console Settings' from the dropdown.
 3. Click 'TLS Key & Cert' in the left menu (or scroll down).
 4. Select the 'Server path' option.
 5. Enter the paths to your certificate that were provided in the certbot output above. Example:

--- a/user/enterprise/ssl-certificate-management.md
+++ b/user/enterprise/ssl-certificate-management.md
@@ -173,15 +173,15 @@ To generate your certificate:
 8. Provide your domain name:
   ```bash
   Please enter in your domain name(s) (comma and/or space separated)  (Enter 'c'
-  to cancel): travis.example.com
+  to cancel): <your-travis-ci-enterprise-domain>
   ```
 9. Upon successful completion you should see a message similar to the following:
   ```bash
   IMPORTANT NOTES:
      Congratulations! Your certificate and chain have been saved at:
-     /etc/letsencrypt/live/travis.example.com/fullchain.pem
+     /etc/letsencrypt/live/<your-travis-ci-enterprise-domain>/fullchain.pem
      Your key file has been saved at:
-     /etc/letsencrypt/live/travis.example.com/privkey.pem
+     /etc/letsencrypt/live/<your-travis-ci-enterprise-domain>/privkey.pem
      Your cert will expire on 2018-02-07. To obtain a new or tweaked
      version of this certificate in the future, simply run certbot
      again. To non-interactively renew *all* of your certificates, run
@@ -206,8 +206,8 @@ To use your generated certificate in your Travis CI Enterprise instance:
 4. Select the 'Server path' option.
 5. Enter the paths to your certificate that were provided in the certbot output above. Example:
   ```
-  - SSL Private Key Filename: `/etc/letsencrypt/live/travis.example.com/privkey.pem`
-  - SSL Certificate Filename: `/etc/letsencrypt/live/travis.example.com/fullchain.pem`
+  - SSL Private Key Filename: `/etc/letsencrypt/live/<your-travis-ci-enterprise-domain>/privkey.pem`
+  - SSL Certificate Filename: `/etc/letsencrypt/live/<your-travis-ci-enterprise-domain>/fullchain.pem`
   ```
 6. Click 'Save' at the bottom of the page.
 7. Open a ssh connection to the platform machine.

--- a/user/enterprise/ssl-certificate-management.md
+++ b/user/enterprise/ssl-certificate-management.md
@@ -88,131 +88,167 @@ Upon restart you can then verify whether SSL verification is now working. If you
 
 ## Using a Let's Encrypt SSL Certificate
 
-Travis CI Enterprise works well together with a Let's Encrypt SSL Certificate. To obtain one for your domain, please follow the steps below.
+You can use a certificate from [Let's Encrypt](https://letsencrypt.org/) instead of a self-signed certificate or a certificate purchased from a trusted certificate authority. Certificates from Let's Encrypt are free and behave the same as those purchased from a trusted certificate authority. More information about Let's Encrypt can be found [here](https://letsencrypt.org/about/).
 
-What you need:
+What you will need:
 
-1. An email address Let's Encrypt can send emails to. This will be used to notify about urgent renewal and security notices.
+1. An email address (Let's Encrypt will send notifications regarding urgent renewal and security issues).
 2. A domain name under which your installation is available (we're using `travis.example.com` in this guide).
 
-**Please note: This change will cause downtime for your system,for this reason, we recommend to perform this process in a maintenance window.**
+> The following steps require downtime for your Travis CI Enterprise instance. For this reason we recommend that you perform these steps during a maintenance window.
 
-To obtain an SSL certificate we'll be using [certbot](https://certbot.eff.org/#ubuntutrusty-other). Certbot is available as an Ubuntu package.
+### Installing certbot
 
-Please log in to your platform machine via SSH and run the following steps to install certbot:
+We will be using [certbot](https://certbot.eff.org/#ubuntutrusty-other) to obtain a SSL certificate from Let's Encrypt. To install certbot:
 
-```
-$ sudo apt-get update
-$ sudo apt-get install software-properties-common
-$ sudo add-apt-repository ppa:certbot/certbot
-$ sudo apt-get update
-$ sudo apt-get install certbot
-```
+1. Open a ssh connection to the platform machine.
+2. Add the certbot PPA:
+  ```bash
+  sudo add-apt-repository ppa:certbot/certbot
+  ```
+3. Update available packages:
+  ```bash
+  sudo apt-get update
+  ```
+3. Install required certbot dependency:
+  ```bash
+  sudo apt-get install software-properties-common
+  ```
+5. Install the certbot package:
+  ```bash
+  sudo apt-get install certbot
+  ```
 
-`certbot` offers multiple ways to obtain a certificate. We'll pick the `temporary webserver` option since it doesn't require any additional configuration. The only prerequisite though is that the Travis CI Enterprise container has to be stopped so that webserver can bind to port 443 properly.
+### Generating a new Let's Encrypt certificate
 
-***To start***, please stop Travis CI Enterprise:
+The certbot tool offers multiple ways to obtain a certificate. We'll pick the 'temporary webserver' option since it doesn't require any additional setup or configuration. The only prerequisite is that the Travis CI Enterprise container must be stopped so that the certbot webserver can bind properly to port 443.
 
-```
-$ replicatedctl app stop
-```
+> Your Travis CI Enterprise instance will be unavailable during this process.
 
-***Now***, run the following to start the interactive process to obtain the SSL certificate:
+To generate your certificate:
 
-```
-$ sudo certbot certonly
-```
+1. Open a ssh connection to the platform machine.
+2. Stop your Travis CI Enterprise:
+  ```bash
+  replicatedctl app stop
+  ```
+3. Start the interactive certificate process:
+  ```bash
+  sudo certbot certonly
+  ```
+4. At the prompt select option `1` to `Spin up a temporary webserver`:
+  ```bash
+  How would you like to authenticate with the ACME CA?
+  -------------------------------------------------------------------------------
+  1: Spin up a temporary webserver (standalone)
+  2: Place files in webroot directory (webroot)
+  -------------------------------------------------------------------------------
+  Select the appropriate number [1-2] then [enter] (press 'c' to cancel): 1
+  ```
+5. Fill in your email address:
+  ```bash
+  Enter email address (used for urgent renewal and security notices) (Enter 'c' to
+  cancel): ops@example.com
+  ```
+6. Accept the Terms of Services:
+  ```bash
+  -------------------------------------------------------------------------------
+  Please read the Terms of Service at
+  https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf. You must agree
+  in order to register with the ACME server at
+  https://acme-v01.api.letsencrypt.org/directory
+  -------------------------------------------------------------------------------
+  (A)gree/(C)ancel: A
+  ```
+7. Decide if you'd like to share your email address with the EFF (this decision has no effect on your certificate or your Travis CI Enterprise instance):
+  ```bash
+  -------------------------------------------------------------------------------
+  Would you be willing to share your email address with the Electronic Frontier
+  Foundation, a founding partner of the Let's Encrypt project and the non-profit
+  organization that develops Certbot? We'd like to send you email about EFF and
+  our work to encrypt the web, protect its users and defend digital rights.
+  -------------------------------------------------------------------------------
+  (Y)es/(N)o: N
+  ```
+8. Provide your domain name:
+  ```bash
+  Please enter in your domain name(s) (comma and/or space separated)  (Enter 'c'
+  to cancel): travis.example.com
+  ```
+9. Upon successful completion you should see a message similar to the following:
+  ```bash
+  IMPORTANT NOTES:
+     Congratulations! Your certificate and chain have been saved at:
+     /etc/letsencrypt/live/travis.example.com/fullchain.pem
+     Your key file has been saved at:
+     /etc/letsencrypt/live/travis.example.com/privkey.pem
+     Your cert will expire on 2018-02-07. To obtain a new or tweaked
+     version of this certificate in the future, simply run certbot
+     again. To non-interactively renew *all* of your certificates, run
+     "certbot renew"
+  ```
+10. Restart your Travis CI Enterprise instance:
+  ```bash
+  replicatedctl app start
+  ```
 
-It'll first ask you ***to pick the authentication method:***
+Your certificate is now generated and saved on your Travis CI Enterprise platform machine, however you must take additional steps to configure your Travis CI Enterprise instance to use the new certificate. Please see the [Using a Let's Encrypt certificate](#using-a-lets-encrypt-certificate) section for instructions.
 
-```
-How would you like to authenticate with the ACME CA?
--------------------------------------------------------------------------------
-1: Spin up a temporary webserver (standalone)
-2: Place files in webroot directory (webroot)
--------------------------------------------------------------------------------
-Select the appropriate number [1-2] then [enter] (press 'c' to cancel): 1
-```
+### Using a Let's Encrypt certificate
 
-Here, ***pick `1` and press return.***
+> Your Travis CI Enterprise instance will be unavailable during this process.
 
+To use your generated certificate in your Travis CI Enterprise instance:
 
-Then, ***fill in the aforementioned email address:***
+1. Log into your dashboard at `https://<your-travis-ci-enterprise-domain>:8800`.
+2. Click the gear icon on the rightmost side of the top menu and select 'Console Settings' from the dropdown.
+3. Click 'TLS Key & Cert' in the left menu (or scroll down).
+4. Select the 'Server path' option.
+5. Enter the paths to your certificate that were provided in the certbot output above. Example:
+  ```
+  - SSL Private Key Filename: `/etc/letsencrypt/live/travis.example.com/privkey.pem`
+  - SSL Certificate Filename: `/etc/letsencrypt/live/travis.example.com/fullchain.pem`
+  ```
+6. Click 'Save' at the bottom of the page.
+7. Open a ssh connection to the platform machine.
+8. Stop your Travis CI Enterprise instance:
+  ```bash
+  replicatedctl app stop
+  ```
+9. Restart your Travis CI Enterprise instance:
+  ```bash
+  replicatedctl app start
+  ```
 
-```
-Enter email address (used for urgent renewal and security notices) (Enter 'c' to
-cancel): ops@example.com
-```
+### Renewing your certificate
 
-Then, ***accept the Terms of Services*** and decide if you'd like to share your email address with the EFF:
+Let's Encrypt certificates are short-lived and ***expire after 90 days.*** Because of this you will need to renew them on a regular basis. This can be done manually with certbot.
 
-```
--------------------------------------------------------------------------------
-Please read the Terms of Service at
-https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf. You must agree
-in order to register with the ACME server at
-https://acme-v01.api.letsencrypt.org/directory
--------------------------------------------------------------------------------
-(A)gree/(C)ancel: A
+> Your Travis CI Enterprise instance will be unavailable during this process.
 
--------------------------------------------------------------------------------
-Would you be willing to share your email address with the Electronic Frontier
-Foundation, a founding partner of the Let's Encrypt project and the non-profit
-organization that develops Certbot? We'd like to send you email about EFF and
-our work to encrypt the web, protect its users and defend digital rights.
--------------------------------------------------------------------------------
-(Y)es/(N)o: N
-```
+To manually renew your certificate for another 90 days:
 
-In the last step you're ***providing your domain name:***
-
-```
-Please enter in your domain name(s) (comma and/or space separated)  (Enter 'c'
-to cancel): travis.example.com
-```
-
-After that ***finished successfully,*** you'll see a message similar to the one below:
-
-```
-IMPORTANT NOTES:
- - Congratulations! Your certificate and chain have been saved at:
-   /etc/letsencrypt/live/travis.example.com/fullchain.pem
-   Your key file has been saved at:
-   /etc/letsencrypt/live/travis.example.com/privkey.pem
-   Your cert will expire on 2018-02-07. To obtain a new or tweaked
-   version of this certificate in the future, simply run certbot
-   again. To non-interactively renew *all* of your certificates, run
-   "certbot renew"
-```
-
-Your certificate has been generated and is now saved on the machine. Please head over to `https://travis.example.com:8800/console/settings`.
-
-There, in the ***TLS Key & Cert*** section, select ***Server path*** and fill in the following:
-
-- SSL Private Key Filename: `/etc/letsencrypt/live/travis.example.com/privkey.pem`
-- SSL Certificate Filename: `/etc/letsencrypt/live/travis.example.com/fullchain.pem`
-
-After that, **scroll down and click "Save"**. After your changes have been saved, you can restart Travis CI Enterprise via:
-
-```
-$ replicatedctl app start
-```
-
-Let's Encrypt certificates are short-lived, this means ***they expire after 90 days.*** This means that you'll have to renew them on a regular basis. Thankfully this can be done with `certbot` as well. Run the following commands in order to renew your certificate.
-
-**Note: Be aware that this process will also introduce downtime.**
-
-```
-$ replicatedctl app stop
-$ sudo certbot renew
-$ replicatedctl app start
-```
+1. Open a ssh connection to the platform machine.
+2. Stop your Travis CI Enterprise instance:
+  ```bash
+  replicatedctl app stop
+  ```
+3. Perform the certificate renewal:
+  ```bash
+  sudo certbot renew
+  ```
+4. Restart your Travis CI Enterprise instance:
+  ```bash
+  replicatedctl app start
+  ```
 
 ### Automate renewal of your Let's Encrypt SSL Certificate with a cron job
 
+You can avoid manual renewals by using a cron job to automate the certbot renewal:
+
 1. Create `/home/ubuntu/renew-certs.sh` containing the following script:
 
-    ```sh
+    ```bash
     #!/bin/bash
 
     set -u
@@ -247,16 +283,13 @@ $ replicatedctl app start
 
 3. Create a cronjob by editing `/etc/crontab` and appending the following:
 
-
-    ```
+    ```sh
     # Renews certs at 2am on the 1st of February, May, August, and November.
     # Please change the configuration that applies to the certificate you are creating.
     0 2 1 2,5,8,11 * /home/ubuntu/renew-certs.sh
     ```
     {: data-file="/etc/crontab"}
 
-    Make sure to adjust the configuration with values that apply to the certificate you are creating.
-
 > This process will introduce a small amount of downtime while the certificates are renewed.
 
-Make sure to communicate with your users before each renewal so they are aware that their builds will temporarily be stopped until the certificate gets renewed.
+We recommend that you communicate with your users before each renewal so they are aware that their builds will temporarily be stopped until the certificate is renewed.

--- a/user/enterprise/troubleshooting-guide.md
+++ b/user/enterprise/troubleshooting-guide.md
@@ -48,12 +48,12 @@ Here is an example:
 # them to take effect.
 
 export TRAVIS_ENTERPRISE_BUILD_ENDPOINT="__build__"
-export TRAVIS_ENTERPRISE_HOST="travisci.example.com"
+export TRAVIS_ENTERPRISE_HOST="<your-travis-ci-enterprise-domain>"
 export TRAVIS_ENTERPRISE_SECURITY_TOKEN="abc12345"
 # export TRAVIS_WORKER_DOCKER_PRIVILEGED="true"
 ```
 
-The relevant variables are `TRAVIS_ENTERPRISE_HOST` and `TRAVIS_ENTERPRISE_SECURITY_TOKEN`. The former needs to contain your primary domain you use to access the Travis CI Enterprise Web UI. The `travis-worker` process uses this domain to reach the platform machine. The value of the latter needs to match the `RabbitMQ Password` on `https://your-travis-ci-enterprise-domain:8800/settings`.
+The relevant variables are `TRAVIS_ENTERPRISE_HOST` and `TRAVIS_ENTERPRISE_SECURITY_TOKEN`. The former needs to contain your primary domain you use to access the Travis CI Enterprise Web UI. The `travis-worker` process uses this domain to reach the platform machine. The value of the latter needs to match the `RabbitMQ Password` found at `https://<your-travis-ci-enterprise-domain>:8800/settings`.
 
 If you have made changes to this file, please run the following so they take effect:
 

--- a/user/enterprise/upgrading.md
+++ b/user/enterprise/upgrading.md
@@ -29,13 +29,9 @@ To make a backup, please follow these steps:
 
 ## Updating your Travis CI Enterprise Platform
 
-You can check for new releases by going to the management interface
-dashboard `https://:8800` and clicking on the 'Check Now' button. If an
-update is available you will be able to read the release notes and
-install the update.
+You can check for new releases by going to the management interface dashboard `https://<your-travis-ci-enterprise-domain>:8800` and clicking on the 'Check Now' button. If an update is available you will be able to read the release notes and install the update.
 
-**Please note that this will cause downtime for the platform, because
-Replicated services get restarted during the update.**
+> There will be a small amount of downtime while an update is installed. For this reason we recommend that you perform each update during a maintenance window.
 
 ## Updating Replicated on the Platform
 

--- a/user/enterprise/worker-cli-commands.md
+++ b/user/enterprise/worker-cli-commands.md
@@ -52,7 +52,7 @@ wait until some or all jobs are being worked off successfully, you can
 issue a `SIGINT` instead. This together with a `sleep` ensures that
 either at least some or all active jobs can finish (depending on how
 long your queue is). After `sleep` finished the worker has to be
-shutdown via `sudo stop travis-worker`.\
+shutdown via `sudo stop travis-worker`.
 
 ## Example Worker Stop and Start
 

--- a/user/enterprise/worker-configuration.md
+++ b/user/enterprise/worker-configuration.md
@@ -15,7 +15,7 @@ If you need to change the hostname the Worker should connect to, or the
 RabbitMQ password, you can do so by updating:
 
 ```sh
-export AMQP_URI="amqp://travis:<rabbitmq password>@<Travis CI Enterprise platform hostname>/travis"
+export AMQP_URI="amqp://travis:<rabbitmq password>@<your-travis-ci-enterprise-domain>/travis"
 ```
 
 ### With Ubuntu 14.04 as host operating system
@@ -28,7 +28,7 @@ If you need to change the hostname the Worker should connect to, or the
 RabbitMQ password, you can do so by updating:
 
 ```sh
-export TRAVIS_ENTERPRISE_HOST="enterprise.hostname.corp"
+export TRAVIS_ENTERPRISE_HOST="<your-travis-ci-enterprise-domain>"
 export TRAVIS_ENTERPRISE_SECURITY_TOKEN="super-secret-password"
 ```
 


### PR DESCRIPTION
This is a followup based on [this comment](https://github.com/travis-ci/docs-travis-ci-com/pull/2280#discussion_r263014787) from @plaindocs.

Summary of the changes:

* Break apart instructions into separate sections
* Use a numbered list for the steps of the instructions in each section
* General language updates for readability and clarity