### PR TITLE
Remove Python 3.4 from this example because it is EOL

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -103,7 +103,6 @@ in your `.travis.yml`:
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   # PyPy versions


### PR DESCRIPTION
Removes Python 3.4 from one example because that release has reached its end of life.
* https://devguide.python.org/devcycle/#end-of-life-branches

This PR does _not_ remove Python 3.4 from line 48 where it appears with other EOLed versions of Python (2.6 and 3.3) that Travis CI continues to make available.