### PR TITLE
Fix year of github services deprecation

### DIFF
--- a/user/migrate/legacy-services-to-github-apps-migration-guide.md
+++ b/user/migrate/legacy-services-to-github-apps-migration-guide.md
@@ -6,7 +6,7 @@ redirect_from:
   - user/legacy-services-to-github-apps-migration-guide/
 ---
 
-As of May 2, 2018 we are moving toward having repositories integrated via a GitHub App instead of GitHub Services which [will no longer be supported by GitHub as of January 31st, 2018](https://developer.github.com/v3/guides/replacing-github-services/#deprecation-timeline).
+As of May 2, 2018 we are moving toward having repositories integrated via a GitHub App instead of GitHub Services which [will no longer be supported by GitHub as of January 31st, 2019](https://developer.github.com/v3/guides/replacing-github-services/#deprecation-timeline).
 
 > *Note:* While this process is ongoing, we have been migrating from GitHub services to webhooks on the https://travis-ci.org enabled repositories. The closure of GitHub services *will not affect your repositories even if you are currently on .org*.
 


### PR DESCRIPTION
Per https://developer.github.com/v3/guides/replacing-github-services/#deprecation-timeline

> January 31, 2019: GitHub will stop delivering installed services' events on GitHub.com.