### PR TITLE
Fix over indentation on release example

### DIFF
--- a/user/deployment/pypi.md
+++ b/user/deployment/pypi.md
@@ -90,10 +90,10 @@ To release to a different PyPI index:
 
 ```yaml
 deploy:
-      provider: pypi
-      user: ...
-      password: ...
-      server: https://mypackageindex.com/index
+  provider: pypi
+  user: ...
+  password: ...
+  server: https://mypackageindex.com/index
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
The indentation on the "release to a different pypi index"
example was over indented compared to the other examples.