### PR TITLE
Update Riak service details

### DIFF
--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -376,6 +376,8 @@ You can set up more vhosts and roles in the `before_script` section of your `.tr
 
 ## Riak
 
+> Riak is only available in the [Ubuntu Trusty environment](/user/reference/trusty/).
+
 Start Riak in your `.travis.yml`:
 
 ```yaml
@@ -384,9 +386,9 @@ services:
 ```
 {: data-file=".travis.yml"}
 
-Riak uses the default configuration apart from the storage backend, which is LevelDB.
+Riak uses the default configuration with Bitcask as storage backend.
 
-Riak Search is enabled.
+Riak Search is deactivated by default.
 
 ## Memcached
 


### PR DESCRIPTION
We dropped support starting on Xenial and the information on default settings was no longer true since the last Trusty updates https://github.com/travis-ci/travis-cookbooks/commit/042766636ba9aa95fbe996f281048c543d0f0b90

With those changes, the default configuration in the VM (`/etc/riak/riak.conf`) now has:
```
storage_backend = bitcask
search = off
```