### PR TITLE
Fix missing negation in regex example

### DIFF
--- a/user/conditions-v1.md
+++ b/user/conditions-v1.md
@@ -376,7 +376,7 @@ Do not build on forks:
 fork = false
 ```
 
-Build only when the commit message matches against the given regular expression:
+Build only when the commit message doesn't match against the given regular expression:
 
 ```
 commit_message !~ /(no-deploy|wip)/


### PR DESCRIPTION
I'm assuming `foo =~ bar` means `bar` matches `foo`, and `foo !~ bar` means `bar` _does not_ match `foo` 