### PR TITLE
Fix Broken Link in Common Build Problems

### DIFF
--- a/user/common-build-problems.md
+++ b/user/common-build-problems.md
@@ -609,4 +609,4 @@ jobs:
 {: data-file=".travis.yml"}
 
 
-This creates only one job,  _Peanut Butter and Bread_ under the stage named _Breakfast_ as you have defined. It is important to note that in YAML, the `-` symbol is used to create a list of items and the earlier example creates a list of 2 items, while you actually wanted 1. You can read more on [How to define Build Stages](user/build-stages/#how-to-define-build-stages) and YAML lists syntax in the official [documentation](https://yaml.org/spec/1.2/spec.html#id2759963).
+This creates only one job,  _Peanut Butter and Bread_ under the stage named _Breakfast_ as you have defined. It is important to note that in YAML, the `-` symbol is used to create a list of items and the earlier example creates a list of 2 items, while you actually wanted 1. You can read more on [How to define Build Stages](/user/build-stages/#how-to-define-build-stages) and YAML lists syntax in the official [documentation](https://yaml.org/spec/1.2/spec.html#id2759963).


### PR DESCRIPTION
Missing slash causes a link that was intended to be absolute to be relative and lead to a page that doesn't exist. I think this is the actual location you want to redirect people to.