### PR TITLE
MOZ_HEADLESS=1 should be set as a global env

### DIFF
--- a/user/gui-and-headless-browsers.md
+++ b/user/gui-and-headless-browsers.md
@@ -195,7 +195,8 @@ Headless mode can be enabled using the `MOZ_HEADLESS`
 
 ```yaml
 env:
-  - MOZ_HEADLESS=1
+  global:
+    - MOZ_HEADLESS=1
 addons:
   firefox: latest
 ```


### PR DESCRIPTION
I don't think it's best practice, even though there is just one variable, to define it as a test matrix entry.