### PR TITLE
Precise & Trusty are versions of Ubuntu

### DIFF
--- a/user/languages/r.md
+++ b/user/languages/r.md
@@ -39,7 +39,7 @@ Travis CI supports a number of configuration options for your R package.
 
 ### R Versions
 
-Travis CI supports R versions `3.0.3` and above on Linux Precise, Trusty and macOS.
+Travis CI supports R versions `3.0.3` and above on Ubuntu Precise, Ubuntu Trusty and macOS.
 Aliases exist for each major release, e.g `3.1` points to `3.1.3`. In addition the
 name `oldrel` is aliased to the previous major release and `release` is aliased to the
 latest minor release. `devel` is built off of the [R git mirror](https://travis-ci.org/wch/r-source)


### PR DESCRIPTION
I suggest to replace 'Linux' with Ubuntu, that is the Linux distro which is referred here with those version names.

Being a Linux user myself (but not at all familiar with CI), I also have a question on this: to me it seems remarkable to use Ubuntu versions that have become outdated and hence, will have older versions of libraries such as GDAL etc. than what typical users nowadays have available.

See https://ubuntu.com/about/release-cycle , especially the long-term-supported (LTS) releases (note: precise = 12.04, trusty = 14.04). Currently Ubuntu is at LTS 18.04 (Bionic) and next year in April will see LTS 20.04.

Also, R-packages for Ubuntu on CRAN ([link](https://cran.r-project.org/bin/linux/ubuntu/)) are not provided anymore for Ubuntu Precise.

Sorry if I misunderstood the whole aim here :wink: 