### PR TITLE
Type in 'escaping certain symbols' example

### DIFF
--- a/user/encryption-keys.md
+++ b/user/encryption-keys.md
@@ -157,7 +157,7 @@ travis encrypt "FOO=6\\&a\\(5\\!1Ab\\\\"
 Equivalently, you can do
 
 ```bash
-travis encrypt 'FOO=6\&a\(5\!1AB\\'
+travis encrypt 'FOO=6\&a\(5\!1Ab\\'
 ```
 
 ### Notifications Example


### PR DESCRIPTION
The string being encrypted had a `B` where there should have been a `b`