### PR TITLE
Remove quotes from NodeJS version example

### DIFF
--- a/user/languages/javascript-with-nodejs.md
+++ b/user/languages/javascript-with-nodejs.md
@@ -46,7 +46,7 @@ releases in your `.travis.yml`:
 ```yaml
 language: node_js
 node_js:
-  - "7"
+  - 7
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
While setting up my first JS project using TravisCI (https://travis-ci.org/SidOfc/babel-plugin-transform-media-imports) my project was identified as a Ruby project while I had specifically set `language: node_js` and some versions, each enclosed by strings:

```yml
node_js:
  - "12.0.0"
  - "11.0.0"
```
To fix the issue I had to remove the quotes:

```yml
node_js:
  - 12.0.0
  - 11.0.0
```

This minimal change just removes the quotes from the version so that users that are new to either TravisCI or JS have one less bump to overcome :)