### PR TITLE
Add more commands to switch between windows.

### DIFF
--- a/user/running-build-in-debug-mode.md
+++ b/user/running-build-in-debug-mode.md
@@ -188,6 +188,19 @@ ctrl-b 0
 This switches your session's focus to the window with the index 0.
 You can substitute `0` with any valid index to switch to that window.
 
+```
+ctrl-b n
+```
+
+Switch to the next window.
+
+```
+ctrl-b p
+```
+
+Switch to the previous window.
+
+
 Switching between windows can be helpful if you want to run long-running process in
 one window while looking at the debug VM in another.
 


### PR DESCRIPTION
`ctrl-b 1` led to the error message `Window not found: :=1`.
Same for `ctrl-b 0`. (Yes, I created a new window using ``ctrl-b c` beforehand.

So I am happy that I discovered another way to switch windows.
Maybe this helps others, too.