### PR TITLE
Use API token instead of user / password

### DIFF
--- a/user/deployment/pypi.md
+++ b/user/deployment/pypi.md
@@ -9,39 +9,42 @@ Travis CI can automatically release your Python package to [PyPI](https://pypi.p
 
 
 
-For a minimal configuration, add the following to your `.travis.yml`:
+For a minimal configuration, generate [PyPI API token](https://pypi.org/help/#apitoken) and add the following to your `.travis.yml`:
 
 ```yaml
 deploy:
   provider: pypi
-  user: "Your username"
-  password: "Your password"
+  user: "__token__"
+  password: "Your PyPI API token, including the pypi- prefix"
 ```
 {: data-file=".travis.yml"}
 
-However, this would expose your PyPI password to the world.
+However, this would expose your PyPI API token to the world.
 We recommend you [encrypt](/user/encryption-keys/) your password and add it to your .travis.yml by running:
 
 ```bash
-travis encrypt your-password-here --add deploy.password
+travis encrypt your-api-token --add deploy.password
 ```
 
 If you are using travis-ci.com and not travis-ci.org, you need to add the `--com` argument to switch the Travis API endpoint:
 
 ```bash
-travis encrypt your-password-here --add deploy.password --com
+travis encrypt your-api-token --add deploy.password --com
 ```
-
-> Note that if your PyPI password contains [special characters](/user/encryption-keys#note-on-escaping-certain-symbols) you need to escape them before encrypting your password. Some people have [reported difficulties](https://github.com/travis-ci/dpl/issues/377) connecting to PyPI with passwords containing anything except alphanumeric characters.
 
 ```yaml
 deploy:
   provider: pypi
-  user: "Your username"
+  user: "__token__"
   password:
-    secure: "Your encrypted password"
+    secure: "Your encrypted token"
 ```
 {: data-file=".travis.yml"}
+
+It is also possible, but not recommended, to use PyPI user and password, instead of token.
+
+> Note that if your PyPI password contains [special characters](/user/encryption-keys#note-on-escaping-certain-symbols) you need to escape them before encrypting your password. Some people have [reported difficulties](https://github.com/travis-ci/dpl/issues/377) connecting to PyPI with passwords containing anything except alphanumeric characters.
+
 
 ## Deploying tags
 


### PR DESCRIPTION
Since July PyPI supports [token based authentication](https://pypi.org/help/#apitoken), and it is now recommended, when possible.

This PR changes references to user and password with `__token__` and API token respectively, and moves user / password  specific notes at the end of the paragraph.