### PR TITLE
fix style issue with multiline alpha/beta messages

### DIFF
--- a/assets/stylesheets/_utils.sass
+++ b/assets/stylesheets/_utils.sass
@@ -89,12 +89,14 @@ img.app
   font-style: normal
   background: $cream-light
   color: $quartz-red
+  padding: 0 1em
   border: 1px solid $quartz-red
   p
     color: $brick-red
     &:before
       content: ""
-      display: inline-block
+      display: block
+      float: left
       width: 1.7em
       height: 1.7em
       border-radius: 50%
@@ -111,12 +113,14 @@ img.app
   font-style: normal
   background: $haze-yellow
   color: $dozer-yellow
+  padding: 0 1em
   border: 1px solid $canary-yellow
   p
     color: $dozer-yellow
     &:before
       content: ""
-      display: inline-block
+      display: block
+      float: left
       width: 1.7em
       height: 1.7em
       border-radius: 50%


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/2208/64706760-519cab80-d4b2-11e9-8345-54f1dc05101c.png)

after:

![image](https://user-images.githubusercontent.com/2208/64706317-96741280-d4b1-11e9-91aa-f69494a66bf9.png)
