### PR TITLE
Removed localhost:4000 in URL

### DIFF
--- a/_includes/deploy/shared.md
+++ b/_includes/deploy/shared.md
@@ -4,7 +4,7 @@
 
 ## See also
 
-- [Making deployments conditional](/user/deployment-v2/conditional)
-- [Running commands before and after the deploy step](/user/deployment-v2/#running-commands-before-and-after-the-deploy-step)
-- [Deploying to multiple targets](/user/deployment-v2/#deploying-to-multiple-targets)
-- [Running an edge version](/user/deployment-v2/#running-an-edge-version)
+* [Making deployments conditional](/user/deployment-v2/conditional)
+* [Running commands before and after the deploy step](/user/deployment-v2/#running-commands-before-and-after-the-deploy-step)
+* [Deploying to multiple targets](/user/deployment-v2/#deploying-to-multiple-targets)
+* [Running an edge version](/user/deployment-v2/#running-an-edge-version)

--- a/_includes/deploy/shared.md
+++ b/_includes/deploy/shared.md
@@ -4,7 +4,7 @@
 
 ## See also
 
-* [Making deployments conditional](/user/deployment-v2/conditional)
-* [Running commands before and after the deploy step](/user/deployment-v2/#running-commands-before-and-after-the-deploy-step)
-* [Deploying to multiple targets](http://localhost:4000/user/deployment-v2/#deploying-to-multiple-targets)
-* [Running an edge version](/user/deployment-v2/#running-an-edge-version)
+- [Making deployments conditional](/user/deployment-v2/conditional)
+- [Running commands before and after the deploy step](/user/deployment-v2/#running-commands-before-and-after-the-deploy-step)
+- [Deploying to multiple targets](/user/deployment-v2/#deploying-to-multiple-targets)
+- [Running an edge version](/user/deployment-v2/#running-an-edge-version)


### PR DESCRIPTION
This PR fixes a URL where the `http://localhost:4000` prefix was still included and therefore not linkable on the deployed [docs pages](https://docs.travis-ci.com/user/deployment-v2/providers/npm/#see-also)