### PR TITLE
Add dry_run option in npm docs

### DIFF
--- a/_includes/deploy/providers/npm.md
+++ b/_includes/deploy/providers/npm.md
@@ -27,6 +27,7 @@ Use the following options to further configure the deployment.
 | `registry` | npm registry url &mdash; type: string |
 | `src` | directory or tarball to publish &mdash; type: string, default: `.` |
 | `tag` | distribution tags to add &mdash; type: string |
+| `dry_run` | performs test run without uploading to registry &mdash; type: boolean |
 | `auth_method` | Authentication method &mdash; type: boolean, known values: `auth` |
 
 ### Shared options


### PR DESCRIPTION
This PR adds the `dry_run` option in the documentation for the [npm provider](https://docs.travis-ci.com/user/deployment-v2/providers/npm/).

It is based on the according PR in the **travis-ci/dpl** repository: https://github.com/travis-ci/dpl/pull/1114, which should add a `--dry-run` CLI parameter, whenever a test run is preferred, without actually uploading the package to the repository.

Therefore a `dry_run: true` in the **.travis.yml** should be the equivalent to `npm publish --dry-run` in the CLI.