### PR TITLE
Fix false info on default command

### DIFF
--- a/user/languages/clojure.md
+++ b/user/languages/clojure.md
@@ -10,7 +10,7 @@ layout: en
 
 | Clojure                                     | Default                                   |
 |:--------------------------------------------|:------------------------------------------|
-| [Default `install`](#dependency-management) | `project.clj`                             |
+| [Default `install`](#dependency-management) | `lein deps`                             |
 | [Default `script`](#default-build-script)   | `lein test`                               |
 | [Matrix keys](#build-matrix)                | `env`, `lein`, `jdk`                      |
 | Support                                     | [Travis CI](mailto:support@travis-ci.com) |


### PR DESCRIPTION
As per https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/clojure.rb#L30

`project.clj` cannot be run directly so the current info is not an equivalent to that