### PR TITLE
Add explicit python version to the choco package

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -178,7 +178,7 @@ matrix:
       os: windows           # Windows 10.0.17134 N/A Build 17134
       language: shell       # 'language: python' is an error on Travis CI Windows
       before_install:
-        - choco install python
+        - choco install python --version 3.7.4
         - python -m pip install --upgrade pip
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 install: pip3 install --upgrade pip  # all three OSes agree about 'pip3'


### PR DESCRIPTION
The specified path is invalid for the other versions (current default ver is 3.8)