### PR TITLE
Added numbers to section headings in ToS

### DIFF
--- a/legal/terms-of-service.md
+++ b/legal/terms-of-service.md
@@ -13,12 +13,12 @@ regarding the software Travis CI (hereinafter “Travis CI Software”)
 
 as of 05/2018
 
-### Subject matter
+### 1. Subject matter
 
 1. The subject matter of these terms and conditions (hereinafter **“Terms and Conditions”**) is the use of Travis CI Software. The Terms and Conditions regulate all relations between Travis CI and Travis CI’s customer (hereinafter **“Customer”**) regarding the use of Travis CI Software and are part of the Agreement as defined below. Standard business conditions and/or general terms and conditions of the Customer do not apply, regardless of whether or not Travis CI has expressly objected to them in a particular case.
 2. Travis CI communicates with the GitHub hosting service (hereinafter **“GitHub”**), which is offered by GitHub Inc. on the Customer’s behalf. Condition to the proper use of Travis CI Software is a valid contract with GitHub Inc. on the use of GitHub, which may lead to costs on the Customer’s sole responsibility. The Customer will provide Travis CI with his GitHub account information (hereinafter **“GitHub Sign-In”**) when signing in through GitHub via travis CI-ci.com (hereinafter the **“Website”**) automatically. He allows Travis CI to access the Customer’s GitHub account. Travis CI will directly communicate in the name of the Customer with GitHub and the Customer authorizes Travis CI to act on his behalf towards GitHub Inc. The Customer is solely liable for any costs or damages that GitHub Inc. associates with the GitHub Sign-In.
 
-### Scope of services
+### 2. Scope of services
 
 1. Travis CI provides Travis CI Software as a service. This means, that Travis CI Software may be used via the internet only.
 2. The Travis CI Software is a hosted continuous integration service that provides the infrastructure for testing software projects subject to downtime and service suspensions as described below. The functional range of the service is dependent on the package the Customer chooses and will be displayed on the Website.
@@ -27,7 +27,7 @@ as of 05/2018
 5. No consultancy, training, trouble shooting or support is within the scope of the services offered by Travis CI under this Agreement if and to the extent they are not part of the agreed warranty as set out in section 9 hereunder.
 6. Travis CI offers unpaid and paid services. If a service by Travis CI is offered free of charge, section 8 shall apply.
 
-### Concluding of the Agreement
+### 3. Concluding of the Agreement
 
 1. Using the Travis CI Software requires the opening of an account via the Website by using the Customer’s GitHub Sign-In (hereinafter the **“Account”**). Travis CI offers the use of the Travis CI Software only to entrepreneurs within the meaning of section 14 (1) of the German Civil Code.
 2. The opening of an Account by the Customer is deemed an offer to conclude an agreement under these Terms and Conditions with Travis CI (hereinafter the **“Agreement”**). Travis CI may at its own discretion accept this offer by explicitly accepting it or rendering services under this Agreement.
@@ -39,7 +39,7 @@ as of 05/2018
   - immediately inform Travis CI in case of loss, theft or other disclosure of the Account data to a third party or in a suspicion of misuse of the Account data and to immediately change the password;
   - allow the use of the Account data only designated administrators to be specified in the registration procedure.
 
-### Obligations of the customer
+### 4. Obligations of the customer
 
 1. The Customer is obliged to make agreed payments in due time.
 2. The Customer must not interfere or intent to interfere in any manner with the functionality or proper working of the Travis CI Software.
@@ -48,39 +48,39 @@ as of 05/2018
 5. When using testing data the Customer will make sure that these data do not contain unanonymized personal data of real people.
 6. The Customer will indemnify and hold harmless Travis CI, its officers and directors, employees and agents from any and all third party claims, damages, costs and (including reasonable attorneys fees) arising out of the Customer’s use of the Travis CI Software in a manner not authorized by this Agreement, and/or applicable law, or the Customer’s or it’s employees’ or personnel’s negligence or willful misconduct.
 
-### Downtime and services suspensions
+### 5. Downtime and services suspensions
 
 1. Adjustments, changes and updates of the Travis CI Software that help to avoid or maintain dysfunctions of the Travis CI Software may lead to temporary service suspensions. Travis CI will try to limit downtime of the service or restrictions of accessibility to 10 hours a month. Travis CI will try to do regular maintenance works during the weekend or at times between 10 p.m. and 6 a.m. (CET). Outside of the said hours, Travis CI will inform the Customer about upcoming maintenance works.
 2. The Customer is aware that the service relies on a working internet infrastructure. Additional downtime of the service can occur if the website is not available and at any other time with restrictive access to the internet of the Customer.
 3. The Customer is aware that the Travis CI Software does not work if GitHub is not properly available (be it to Travis CI or the Customer).
 4. For the avoidance of doubt, in case of dysfunctions of the Travis CI Software caused by Travis CI through willful intent or gross negligence, Travis CI’s liability for such dysfunctions is not excluded by this section 5
 
-### Rights to use
+### 6. Rights to use
 
-1. TSubject to the full payment of due fees for the services under the Agreement, Customer is granted a limited, non-exclusive, non-transferable, non-sublicenseable right to use the Travis CI Software as software as a service via the internet according to these Terms and Conditions.
+1. Subject to the full payment of due fees for the services under the Agreement, Customer is granted a limited, non-exclusive, non-transferable, non-sublicenseable right to use the Travis CI Software as software as a service via the internet according to these Terms and Conditions.
 2. The Customer is not granted any additional right to the Travis CI Software or any other intellectual property of Travis CI. This especially means that the Customer shall not be entitled to make copies of the Travis CI Software. The Customer shall not translate the program code into other forms of code (decompilation) or employ other methods aimed at revealing the Travis CI Software’s code in the various stages of its development (reverse engineering).
 3. The Customer is not entitled to remove or make alterations to copyright notices, serial numbers or other features which serve to identify the Travis CI Software.
 4. To the extent the Travis CI Software includes any open source software, Customer’s right to use with respect to each item of the open source software will be governed exclusively by the applicable open source software license associated with the respective open source software, regardless of any other provisions of these Terms and Conditions. Without limiting the foregoing sentence, Customer recognizes that the only warranties and representations respecting the open source software are those provided in the applicable open source software license and Travis shall bear no responsibility or liability whatsoever related to its supply of or Customer's use of such software. Identification of and licenses for open source software may be found in the Travis CI Software, or in libraries provided with the Travis CI Software, or in links provided in the software or such libraries, or on the Travis-ci.org website, or in other documentation provided or linked to by Travis.
 
-### Payments
+### 7. Payments
 
 1. The compensation of the paid services rendered by Travis CI is calculated per month. The current prices are shown in the current price list of Travis CI that is available on the Website. The compensation is due monthly in advance.
 2. Invoices will be issued via email. Payments shall become due immediately upon issuance of the invoice. Payment must be made using the payment methods provided by Travis CI from time to time and chosen by the Customer in his Account settings.
 3. All prices in the price list are net-price. Value Added Tax will be added in the invoice if applicable.
 4. Travis CI may alter the current price list and/or the structuring of prices with at least one month notice to the end of each quarter. Travis CI will inform the Customer via email about the price change. If the Customer does not expressly disagree in writing within a month from the notification of change this is deemed to be his acceptance of the change. The Customer will be informed about this circumstance in the notification of change.
 
-### Free Services
+### 8. Free Services
 
 For any services offered by Travis CI free of charge (**“Free Services”**), the following shall apply in derogation of sections 5, 9 and 10 hereunder: the Free Service is provided on an “as is” and “as available” basis with no right to any warranty given by Travis CI or indemnification hereunder. For the avoidance of doubt, sections 5.1 Sentences 2 to 4 and 5.4 (Downtime and Service Suspensions), section 9 (Warranty) and section 10 (Limitation of Liability) shall not apply to Free Services.
 
-### Warranty
+### 9. Warranty
 
 1. Defects in the supplied Travis CI Software shall be remediated within a reasonable time following a detailed notification of such defect being given to Travis CI by the Customer.
 2. For the purpose of remedying defects, Travis CI may choose to replace the defective Travis CI Software with a version of the Travis CI Software which is free of defects. In case of defects of updated, upgraded or new versions (the aforementioned hereinafter each a **“New Version”**), the right of defect with regard to a New Version shall be limited to the new features of New Version of the Travis CI Software compared to the previous version release.
 3. Unless Travis CI fails to repair or replace the Travis CI Software, the right of the Customer to terminate the contract due to an inability to use the Travis CI Software shall be excluded.
 4. The limitation period for all warranty claims shall be 12 months commencing with the first coming to show of the defect.
 
-### Limitation of Liability
+### 10. Limitation of Liability
 
 1. Travis CI’s liability for damages caused by or related to the exercise of rights and obligations under this Agreement shall be excluded. The limitation of liability shall not cover
   - damage from injury to life, body or health caused by Travis CI;
@@ -91,12 +91,12 @@ For any services offered by Travis CI free of charge (**“Free Services”**), 
 3. Liability under the Product Liability Act (Produkthaftungsgesetz) shall remain unaffected.
 4. Travis CI will not be liable hereunder by reasons of any failure to timely perform its services due to an event beyond its reasonable control, including acts of God.
 
-### Data protection, References and Confidentiality
+### 11. Data protection, References and Confidentiality
 
 1. Travis CI stores, processes and uses Customer data in accordance with the applicable (data protection) law(s). For further information please refer to Travis CI privacy policy under [https://docs.travis-ci.com/legal/privacy-policy/](https://docs.travis-ci.com/legal/privacy-policy/). In the event Travis CI processes personal data controlled by Customer the data processing agreement under [https://docs.travis-ci.com/legal/data-processing-agreement](https://docs.travis-ci.com/legal/data-processing-agreement) applies.
 2. Travis CI may identify Customer as a customer of Travis CI and display Customer's name and logo solely for such purpose on its customer lists, its website, and its marketing and promotional materials provided that Customer may request that Travis CI cease such use at any time upon written notice to Travis CI.
 
-### Term and Termination
+### 12. Term and Termination
 
 1. The Agreement runs for an indefinite time and will remain in effect until terminated by one of Parties in accordance with this section 12.
 2. The Parties may terminate this Agreement for any or no reason at their convenience with a 30 day notice to the end of each month. Termination may be issued in writing or by using the provided account closing mechanism, if provided by Travis CI.
@@ -112,14 +112,14 @@ For any services offered by Travis CI free of charge (**“Free Services”**), 
 - an application for the initiation of insolvency proceedings concerning the Customer, as well as the refusal to open insolvency proceedings for lack of assets, or the issue of a declaration in lieu of an oath, or any similar proceedings.
 4. In case of the termination of the Agreement, any rights of use granted to Customer for the Travis CI Software shall expire immediately and Customer shall cease to use the Travis CI Software.
 
-### Disputes, Applicable Law, Notices
+### 13. Disputes, Applicable Law, Notices
 
 1. This Agreement (and any dispute, controversy, proceedings or claim of whatever nature arising out of or in any way relating to this Agreement or its formation) shall be governed by the laws of the Federal Republic of Germany. The UN Convention on Contracts for the International Sale of Goods (CISG) shall not apply.
 2. The parties agree that the courts of the seat of Travis CI shall have exclusive jurisdiction to settle any dispute arising out of this Agreement.
 3. Notices made by Travis CI to the Customer may be posted on the Website and/or send to the email-address specified by the Customer when registering or to any updated email-address the Customer provides. Notices to Travis CI must be directed to contact@travis-ci.com and/or Travis CI GmbH, Rigaer Str. 8, 10247 Berlin, Germany.
 4. The official text of this Agreement and any annexes attached here to and any notices given here shall be in English. However communication between Travis CI and the Customer may be in English or German.
 
-### Final provisions
+### 14. Final provisions
 
 1. This Agreement, together with any documents referred to in it, or expressed to be entered into in connection with it, constitutes the whole agreement between the Parties concerning the subject matter of this Agreement.
 2. The Customer may set off only legally, binding and recognized claims. The rights and obligations arising from this Agreement are generally not transferable. However, Travis CI may transfer this Agreement with all rights and obligations to a company of its choice.


### PR DESCRIPTION
They are referred to by number in the text e.g. "the following shall apply in derogation of sections 5, 9 and 10...", but did not have numbers previously.

Also fixed typo "TSubject" -> "Subject".