### PR TITLE
Julia; document major version selector

### DIFF
--- a/user/languages/julia.md
+++ b/user/languages/julia.md
@@ -37,6 +37,7 @@ julia:
 Acceptable formats are:
  - `nightly` will test against the latest [nightly build](https://julialang.org/downloads/nightlies.html)
 of Julia.
+ - `X` will test against the latest release for that major version.
  - `X.Y` will test against the latest release for that minor version.
  - `X.Y.Z` will test against that exact version.
 

--- a/user/languages/julia.md
+++ b/user/languages/julia.md
@@ -37,7 +37,7 @@ julia:
 Acceptable formats are:
  - `nightly` will test against the latest [nightly build](https://julialang.org/downloads/nightlies.html)
 of Julia.
- - `X` will test against the latest release for that major version.
+ - `X` will test against the latest release for that major version. (Applies only to major versions 1 and later.)
  - `X.Y` will test against the latest release for that minor version.
  - `X.Y.Z` will test against that exact version.
 


### PR DESCRIPTION
This seems to work fine, but is not documented:

https://github.com/travis-ci/travis-build/blob/ead50a6790a3e48c75c3459a017faf743c6246be/lib/travis/build/script/julia.rb#L188-L190

I was already using this since https://github.com/JuliaCI/Appveyor.jl does the same.

cc @ararslan