### PR TITLE
Update the link for Rustup profiles

### DIFF
--- a/user/languages/rust.md
+++ b/user/languages/rust.md
@@ -36,7 +36,7 @@ By default, we download and install the latest stable Rust release at the start
 of the build (thanks to `rustup`). The [`minimal` profile][profiles] is used
 and includes the following language tools `cargo`, `rustc`, and `rustup`.
 
-[profiles]: https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html#profiles
+[profiles]: https://github.com/rust-lang/rustup.rs#profiles
 
 If you want additional language tools like `rustfmt` or `clippy`, please
 install them in `before_install`.


### PR DESCRIPTION
As mentioned in a comment on a previous PR https://github.com/travis-ci/docs-travis-ci-com/pull/2565#discussion_r336368906, the link can now point to the official documentation thanks to https://github.com/rust-lang/rustup.rs/pull/2072. 