### PR TITLE
Load tablefilter.js only when necessary

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,6 @@
 
 <script src="{{ "/assets/javascripts/main.js" | prepend: site.baseurl }}" type="text/javascript" charset="utf-8" defer></script>
 <script src="{{ "/assets/javascripts/prism.js" | prepend: site.baseurl }}" type="text/javascript" charset="utf-8" defer></script>
-<script src="{{ "/assets/javascripts/tablefilter/dist/tablefilter/tablefilter.js" | prepend: site.baseurl }}" type="text/javascript" charset="utf-8"></script>
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@travisci" />
 <meta name="twitter:creator" content="@travisci" />

--- a/user/languages/erlang.md
+++ b/user/languages/erlang.md
@@ -115,6 +115,7 @@ These archives are available for on-demand installation.
 - [(English) Continuous Integration for Erlang With Travis-CI](http://blog.equanimity.nl/blog/2013/06/04/continuous-integration-for-erlang-with-travis-ci/)
 - [(Dutch) Geautomatiseerd testen with Erlang en Travis-CI](http://blog.equanimity.nl/blog/2013/04/25/geautomatiseerd-testen-met-erlang/)
 
+<script src="{{ "/assets/javascripts/tablefilter/dist/tablefilter/tablefilter.js" | prepend: site.baseurl }}" type="text/javascript" charset="utf-8"></script>
 <script>
 var tf = new TableFilter(document.querySelector('#erlang-versions-table'), {
     base_path: '/assets/javascripts/tablefilter/dist/tablefilter/',

--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -260,6 +260,7 @@ These archives are available for on-demand installation.
 | {{ file.release }} | {{ file.arch }} | {{ file.name }} |{% endfor %}
 {% endif %}
 
+<script src="{{ "/assets/javascripts/tablefilter/dist/tablefilter/tablefilter.js" | prepend: site.baseurl }}" type="text/javascript" charset="utf-8"></script>
 <script>
 var tf = new TableFilter(document.querySelector('#python-versions-table'), {
     base_path: '/assets/javascripts/tablefilter/dist/tablefilter/',


### PR DESCRIPTION
tablefilter.js is quite heavy at 1.9 MB, and unless it's absolutely
necessary, we should not load it.
Ideally, we should replace this will a smaller library (or a small
JavaScript code) to provide the required functionality.