### PR TITLE
Revert "Default Nix version: 2.0.4 -> 2.3.1"

### DIFF
--- a/user/languages/nix.md
+++ b/user/languages/nix.md
@@ -46,11 +46,11 @@ The following command line tools are available in the Nix environment:
 
 ## Default Nix Version
 
-This installs Nix 2.3.1 using [https://nixos.org/releases/nix/nix-2.3.1/install](https://nixos.org/releases/nix/nix-2.3.1/install). You may specify a different version of Nix installer with the `nix:` key in your `.travis.yml`:
+This installs Nix 2.0.4 using [https://nixos.org/releases/nix/nix-2.0.4/install](https://nixos.org/releases/nix/nix-2.0.4/install). You may specify a different version of Nix installer with the `nix:` key in your `.travis.yml`:
 
 ```yaml
 language: nix
-nix: 2.3.1
+nix: 2.0.4
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
Reverts travis-ci/docs-travis-ci-com#2578

Because https://github.com/travis-ci/travis-build/pull/1804 was reverted.