### PR TITLE
Update simulators of xcode11.2 image

### DIFF
--- a/_data/xcodes.yml
+++ b/_data/xcodes.yml
@@ -22,8 +22,8 @@ osx_images:
       - iOS 11.4
       - iOS 12.0
       - iOS 12.1
-      - iOS 13.0
-      - iOS 13.1
+      - iOS 12.2
+      - iOS 12.4
       - iOS 13.2
       - tvOS 10.2 
       - tvOS 11.0
@@ -33,7 +33,8 @@ osx_images:
       - tvOS 11.4
       - tvOS 12.0
       - tvOS 12.1
-      - tvOS 13.0
+      - tvOS 12.2
+      - tvOS 12.4
       - tvOS 13.2
       - watchOS 3.2
       - watchOS 4.0
@@ -41,7 +42,8 @@ osx_images:
       - watchOS 4.2
       - watchOS 5.0 
       - watchOS 5.1
-      - watchOS 6.0
+      - watchOS 5.2
+      - watchOS 5.3
       - watchOS 6.1
     jdk: "13.0.1"
   - image: xcode11.1


### PR DESCRIPTION
This list is based on the output of `xcrun simctl list` on the `xcode11.2` image (Xcode 11.2.1, build version 11B500). For example, see [SwifterSwift/SwifterSwift’s job #3025.1](https://travis-ci.org/SwifterSwift/SwifterSwift/jobs/614840490#L178-L593).