### PR TITLE
mention `brew install travis`

### DIFF
--- a/user/environment-variables.md
+++ b/user/environment-variables.md
@@ -106,7 +106,7 @@ env:
 
 Encrypt environment variables with the public key attached to your repository using the `travis` gem:
 
-1. If you do not have the `travis` gem installed, run `gem install travis`.
+1. If you do not have the `travis` gem installed, run `gem install travis` (or `brew install travis` on macOS).
 
 2. In your repository directory:
 


### PR DESCRIPTION
`gem install travis` fails on a default mac installation. `brew install travis` works. https://github.com/travis-ci/travis-ci/issues/2055