### PR TITLE
Clarify that TRAVIS_TAG is set (but empty) for non-tag builds.

### DIFF
--- a/user/environment-variables.md
+++ b/user/environment-variables.md
@@ -231,7 +231,7 @@ to tag the build, or to run post-build deployments.
   + set to `false` if no encrypted environment variables are available.
 - `TRAVIS_SUDO`: `true` or `false` based on whether `sudo` is enabled.
 - `TRAVIS_TEST_RESULT`: **0** if all commands in the `script` section (up to the point this environment variable is referenced) have exited with zero; **1** otherwise.
-- `TRAVIS_TAG`: If the current build is for a git tag, this variable is set to the tag's name.
+- `TRAVIS_TAG`: If the current build is for a git tag, this variable is set to the tag's name, otherwise it is empty (`""`).
 - `TRAVIS_BUILD_STAGE_NAME`: The [build stage](/user/build-stages/) in capitalized form, e.g. `Test` or `Deploy`. If a build does not use build stages, this variable is empty (`""`).
 
 Language-specific builds expose additional environment variables representing


### PR DESCRIPTION
Clarify that `TRAVIS_TAG` is set to the empty string for non-tag builds. From the current formulation I had (mistakenly) assumed that it was unset instead of set to the empty string.