### PR TITLE
Haxe support: default Neko version is now 2.3.0

### DIFF
--- a/user/languages/haxe.md
+++ b/user/languages/haxe.md
@@ -40,7 +40,7 @@ the latest stable release defined in the [haxe.org download list](https://haxe.o
 
 ## Default Neko Version
 
-By default, [Neko](http://nekovm.org/) 2.2.0 will also be downloaded and installed.
+By default, [Neko](http://nekovm.org/) 2.3.0 will also be downloaded and installed.
 Use the `neko:` key in your `.travis.yml` file to specify a different Neko version,
 for example:
 


### PR DESCRIPTION
Re https://github.com/travis-ci/travis-build/commit/faa06426f1ecc08c096d029d4afc137c5758b8dd