### PR TITLE
Add us-east1 ip addresses

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -126,6 +126,7 @@ desc 'Refresh generated files'
 task regen: (%i[clean] + %w[
   _data/ec2_ip_range.yml
   _data/gce_ip_range.yml
+  _data/gce_ip_ue1_range.yml
   _data/ip_range.yml
   _data/linux_containers_ip_range.yml
   _data/macstadium_ip_range.yml
@@ -137,6 +138,7 @@ task :clean do
   rm_f(%w[
          _data/ec2_ip_range.yml
          _data/gce_ip_range.yml
+         _data/gce_ip_ue1_range.yml
          _data/ip_range.yml
          _data/linux_containers_ip_range.yml
          _data/macstadium_ip_range.yml

--- a/Rakefile
+++ b/Rakefile
@@ -96,6 +96,10 @@ file '_data/gce_ip_range.yml' do |t|
   define_ip_range('nat.gce-us-central1.travisci.net', t.name)
 end
 
+file '_data/gce_ip_ue1_range.yml' do |t|
+  define_ip_range('nat.gce-us-east1.travisci.net', t.name)
+end
+
 file '_data/linux_containers_ip_range.yml' do |t|
   define_ip_range('nat.linux-containers.travisci.net', t.name)
 end

--- a/user/ip-addresses.md
+++ b/user/ip-addresses.md
@@ -13,6 +13,7 @@ on the infrastructure your builds are running on.
 |:---------------|:--------------------------------------------|:---------------------------------------------------------------------------------|:----------------------------------------------------------------|
 | OS X           | {{ site.data.macstadium_ip_range['host'] }} | [A recs](https://dnsjson.com/{{ site.data.macstadium_ip_range['host'] }}/A.json) | `{{ site.data.macstadium_ip_range['ip_range'] | join: "` `" }}` |
 | Linux          | {{ site.data.gce_ip_range['host'] }}        | [A recs](https://dnsjson.com/{{ site.data.gce_ip_range['host'] }}/A.json)        | `{{ site.data.gce_ip_range['ip_range'] | join: "`, `" }}`       |
+| Linux          | {{ site.data.gce_ip_ue1_range['host'] }}        | [A recs](https://dnsjson.com/{{ site.data.gce_ip_ue1_range['host'] }}/A.json)        | `{{ site.data.gce_ip_ue1_range['ip_range'] | join: "`, `" }}`       |
 | Windows        | {{ site.data.gce_ip_range['host'] }}        | [A recs](https://dnsjson.com/{{ site.data.gce_ip_range['host'] }}/A.json)        | `{{ site.data.gce_ip_range['ip_range'] | join: "`, `" }}`       |
 | (all combined) | {{ site.data.ip_range['host'] }}            | [A recs](https://dnsjson.com/{{ site.data.ip_range['host'] }}/A.json)            | (sum of all above)                                              |
 {: .ip-address-ranges}


### PR DESCRIPTION
This change adds new IP addresses for us-east1 zone: https://docs.travis-ci.com/user/ip-addresses/