### PR TITLE
Expand -r flag to --repo for searchability

### DIFF
--- a/user/encryption-keys.md
+++ b/user/encryption-keys.md
@@ -99,7 +99,7 @@ If you are using [travis-ci.com](https://travis-ci.com) instead of [travis-ci.or
 travis login --pro
 ```
 
-Then, you can use `encrypt` command to encrypt data (This example assumes you are running the command in your project directory. If not, add `-r owner/project`):
+Then, you can use `encrypt` command to encrypt data (This example assumes you are running the command in your project directory. If not, add `--repo owner/project`):
 
 ```bash
 travis encrypt SOMEVAR="secretvalue"
@@ -278,7 +278,7 @@ travis pubkey
 Or, if you're not in your project directory:
 
 ```bash
-travis pubkey -r owner/project
+travis pubkey --repo owner/project
 ```
 
 Note, travis uses `travis.slug` in your project to determine the endpoints if it exists (check by using `git config --local travis.slug`), if you rename your repo or move your repo to another user/organization, you might need to change it.


### PR DESCRIPTION
The --repo flag is not mentioned in these docs anywhere but it's short form, -r is.  It improves searchability and clarity to use the long form as 1) it is clearer what the flag does, 2) searching for "-r" will still work as before and 3) searching for "--repo" now also works.