### PR TITLE
Update supported languages in Windows

### DIFF
--- a/user/reference/windows.md
+++ b/user/reference/windows.md
@@ -43,12 +43,18 @@ Powershell can be used by calling `powershell` in your .travis.yml file for now.
 VMs running Windows use the default file system, NTFS.
 
 ## Supported languages
-- C with `language: c`
-- C++ with `language: cpp`
-- Node.js with `language: node_js`
-- Rust with `language: rust`
-- Go with `language: go`
-- Bash `language: bash` or `language: shell`
+- [C](/user/languages/c/)
+- [C++](/user/languages/cpp/)
+- [C#](/user/languages/csharp/)
+- [Go](/user/languages/go/)
+- [Julia](/user/languages/julia/)
+- [Node.js](/user/languages/nodejs/)
+<!-- `language: powershell` is accepted but not operational as of this writing. BCV changes it to `ruby` -->
+<!-- `language: script` is accepted but not operational as of this writing. BCV changes it to `ruby` -->
+- [Rust](/user/languages/rust/)
+<!-- `language: minimal` is accepted but not operational as of this writing so listing aliases explicitly
+     because on the link, they are listed as aliases to `minimal` rather than `generic`. BCV changes it to `shell` -->
+- [Generic environment](/user/languages/minimal-and-generic/) with aliases `language: bash`, `language: sh` and `language: shell`.
 
 ## Pre-installed Chocolatey packages
 


### PR DESCRIPTION
https://travis-ci.community/t/support-language-generic-and-language-minimal-in-windows/6377

Checked support status at: https://travis-ci.org/native-api/test_travis/builds/625179816 (w/o config validation), https://travis-ci.org/native-api/test_travis/builds/625189419 (w/ config validation).

Note that I added comments about unsupported but accepted `language:`s to help keep track of them. If you think you can do without, feel free to remove them.

* C# wasn't documented
* There are some undocumented `language:`s in https://github.com/native-api/travis-build/blob/master/lib/travis/build/config.rb#L128 that are accepted but don't currently work. Are they needed there?
    * I reckon `powershell` is. But `script` probably isn't (unless you use it internally or something special; Build Config Validation doesn't recognize it).

Contrary to what I wrote in https://travis-ci.community/t/support-language-generic-and-language-minimal-in-windows/6377, `language: minimal` does NOT produce a VM. My fault. (Note to self: double check my claims before publishing them.)
* So an additional change in VM selection logic is needed for `language: minimal` to be considered supported. (Since this component is not open-source, I cannot help you here.)