### PR TITLE
Update pre-installed Ruby versions in Bionic

### DIFF
--- a/user/reference/bionic.md
+++ b/user/reference/bionic.md
@@ -99,7 +99,7 @@ The following versions of Docker, version control software and compilers are pre
 ## Ruby support
 
 * Pre-installed Rubies: `2.4.9`, `2.5.3`, `2.5.7` and `2.6.5`.
-* The default ruby is `2.5.3p105`.
+* The default ruby is `2.6.5p114`.
 * Other ruby versions can be installed during build time.
 
 ## Python support

--- a/user/reference/bionic.md
+++ b/user/reference/bionic.md
@@ -98,7 +98,7 @@ The following versions of Docker, version control software and compilers are pre
 
 ## Ruby support
 
-* Pre-installed Rubies: `2.3.8`, `2.4.5`, `2.5.3` and `2.6.3`.
+* Pre-installed Rubies: `2.4.9`, `2.5.3`, `2.5.7` and `2.6.5`.
 * The default ruby is `2.5.3p105`.
 * Other ruby versions can be installed during build time.
 


### PR DESCRIPTION
Appears out of date. See my recent build:

https://travis-ci.org/citation-style-language/styles/builds/626802555#L160

<img width="255" alt="image" src="https://user-images.githubusercontent.com/77951/71148207-0ef91680-21f9-11ea-93f3-2394368160ac.png">

Not sure how to easily check the default ruby version.