### PR TITLE
Because you should never do mvn install on any CI

### DIFF
--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -48,13 +48,13 @@ language: java
 Before running the build, Travis CI installs dependencies:
 
 ```bash
-mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+mvn --show-version --batch dependency:go-offline
 ```
 
 or if your project uses the `mvnw` wrapper script:
 
 ```bash
-./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+./mvnw --show-version --batch dependency:go-offline
 ```
 
 > Note that the Travis CI build lifecycle and the Maven build lifecycle use similar
@@ -69,14 +69,14 @@ If your project has `pom.xml` file in the repository root but no `build.gradle`,
 Travis CI builds your project with Maven 3:
 
 ```bash
-mvn test -B
+mvn --show-version --batch verify
 ```
 
 If your project also includes the `mvnw` wrapper script in the repository root,
 Travis CI uses that instead:
 
 ```bash
-./mvnw test -B
+./mvnw --show-version --batch verify
 ```
 
 > The default command does not generate JavaDoc (`-Dmaven.javadoc.skip=true`).


### PR DESCRIPTION
Maven `install` phase is *not* about gathering the project dependencies and plugins binaries to store them locally. 
It's about generating the binary of the project and storing it in the `localRepository`, sort of local proxy for Maven artifacts.

The current documented command is in fact recommending to build the project in the TravisCI installation step.
Then build it again in the normal build step.

CI systems should *never ever* perform `mvn install` or any equivalent for any build and project configuration tool.
So an update on the Gradle command might be required as well.