### PR TITLE
Updated Windows/MSYS2 documentation

### DIFF
--- a/user/reference/windows.md
+++ b/user/reference/windows.md
@@ -134,4 +134,4 @@ MSYS2 contains two noteworthy [subsystems](https://github.com/msys2/msys2/wiki/M
 
 A point of caution: the pre-installed "mingw" Chocolatey package should **not** be used within any MSYS2 subsystem. (In fact, the above snippet uninstalls the "mingw" Chocolatey package to be safe.) Note that the [MSYS2 wiki](https://github.com/msys2/msys2/wiki/MSYS2-introduction#path) says:
 
->Beware that mixing in programs from other MSYS2 installations, Cygwin installations, compiler toolchains or even various other programs is not supported and will probably break things in unexpected ways.
+>Be aware that mixing in programs from other MSYS2 installations, Cygwin installations, compiler toolchains or even various other programs is not supported and will probably break things in unexpected ways.

--- a/user/reference/windows.md
+++ b/user/reference/windows.md
@@ -108,8 +108,7 @@ before_install:
         ## Install more MSYS2 packages from https://packages.msys2.org/base here
         taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
         export PATH=/C/tools/msys64/mingw64/bin:$PATH
-        # Uncomment if necessary (e.g. for Autotools)
-        # export MAKE=mingw32-make
+        export MAKE=mingw32-make  # so that Autotools can find it
         ;;
     esac
 

--- a/user/reference/windows.md
+++ b/user/reference/windows.md
@@ -102,13 +102,14 @@ before_install:
         export msys2='cmd //C RefreshEnv.cmd '
         export msys2+='& set MSYS=winsymlinks:nativestrict '
         export msys2+='& C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start'
-        export mingw64="$msys2 -mingw64 -full-path -here -c \$\* --"
-        export msys2+=" -msys2 -c \$\* --"
+        export mingw64="$msys2 -mingw64 -full-path -here -c "\"\$@"\" --"
+        export msys2+=" -msys2 -c "\"\$@"\" --"
         $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
         ## Install more MSYS2 packages from https://packages.msys2.org/base here
         taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
         export PATH=/C/tools/msys64/mingw64/bin:$PATH
-        export MAKE=mingw32-make  # so that Autotools can find it
+        # Uncomment if necessary (e.g. for Autotools)
+        # export MAKE=mingw32-make
         ;;
     esac
 

--- a/user/reference/windows.md
+++ b/user/reference/windows.md
@@ -134,4 +134,4 @@ MSYS2 contains two noteworthy [subsystems](https://github.com/msys2/msys2/wiki/M
 
 A point of caution: the pre-installed "mingw" Chocolatey package should **not** be used within any MSYS2 subsystem. (In fact, the above snippet uninstalls the "mingw" Chocolatey package to be safe.) Note that the [MSYS2 wiki](https://github.com/msys2/msys2/wiki/MSYS2-introduction#path) says:
 
->Be aware that mixing in programs from other MSYS2 installations, Cygwin installations, compiler toolchains or even various other programs is not supported and will probably break things in unexpected ways.
+> Be aware that mixing in programs from other MSYS2 installations, Cygwin installations, compiler toolchains or even various other programs is not supported and will probably break things in unexpected ways.


### PR DESCRIPTION
* Replaced $* with "$@"
$* does not parse commands with spaces correctly. E.g. `$mingw64 cmake -G"MSYS Makefiles" ..` will fail because of the space after MSYS.

It will parse as just $mingw64 cmake -G"MSYS

* ~~Commented out MAKE=mingw32-make
This is inconsistent with the mingw64 installation described, and will fail on tools like cmake. As it is highly specific, I commented it out.~~