### PR TITLE
Use dir instead of local_dir

### DIFF
--- a/user/deployment-v2/providers/netlify.md
+++ b/user/deployment-v2/providers/netlify.md
@@ -12,13 +12,13 @@ after a successful build.
 
 ## Deploying a specific directory
 
-To deploy a specific directory, use the `local_dir` key:
+To deploy a specific directory, use the `dir` key:
 
 ```yaml
 deploy:
   provider: netlify
   # ⋮
-  local_dir: "_build/"
+  dir: "_build/"
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
I tried today the travis v2 deploy to netfliy option and red this
documentation for it: https://docs.travis-ci.com/user/deployment-v2/providers/netlify/#deploying-a-specific-directory
In the part `known options` it mentions, that when I want to deploy a
specific folder it needs to be defined with the option `dir`
On the bottom of the documentation is an area `Deploying a specific
directory` that wants `local_dir` as a parameter. When I specify
`local_dir` it tells me that the option does not exist. With `dir` it
works.
Let me know what you think of this change and thanks in advance for reviewing.