### PR TITLE
minor change to keep consistency in xenial.md

### DIFF
--- a/user/reference/xenial.md
+++ b/user/reference/xenial.md
@@ -162,7 +162,7 @@ is `openjdk8`; `openjdk7` and `openjdk8` on ppc64le.
 ## Databases and services
 
 The following services and databases are preinstalled but but do not run by default.
-To use one in your build, add it to the services key in your `travis.yml` :
+To use one in your build, add it to the services key in your `.travis.yml` :
 
 | service    | version        |
 |:-----------|:---------------|


### PR DESCRIPTION
Hi guys,

I hope you're well.

This is a very tiny change just to keep consistency throughout the document xenial.md. There is one place where the travis file was referred as `travis.yml` instead of `.travis.yml`

BR,
Hussama