### PR TITLE
Suggest better wording for 'inside a custom script'

### DIFF
--- a/user/job-lifecycle.md
+++ b/user/job-lifecycle.md
@@ -157,8 +157,7 @@ When overriding these steps, do not use `exit` shell built-in command.
 Doing so will run the risk of terminating the build process without giving Travis a chance to
 perform subsequent tasks.
 
-> Using `exit` inside a custom script which will be invoked from during a build is fine.
-
+> Using `exit` inside a custom script is safe. If an error is indicated the task will be mark as failed.
 
 ## Breaking the Build
 


### PR DESCRIPTION
The origin text

> Using exit inside a custom script which will be invoked from during a build is fine.

is confusing to read because it appears to either be missing words or to be the left over from a previous edit. "invoke from during" is not standard English usage.

This PR updates the text to indicate that using exit is safe and that it will have the expected result of marking the task as failed.