### PR TITLE
Fix typo in all_branches example

### DIFF
--- a/user/deployment-v2/conditional.md
+++ b/user/deployment-v2/conditional.md
@@ -56,7 +56,7 @@ deploy:
   provider: <provider>
   # ⋮
   on:
-    all_branch: true
+    all_branches: true
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
Fixes a typo in the all_branches code example where it was written `all_branch`