### PR TITLE
Document the format for environment variables' values

### DIFF
--- a/user/environment-variables.md
+++ b/user/environment-variables.md
@@ -36,6 +36,8 @@ env:
 
 > If you define a variable with the same name in `.travis.yml` and in the Repository Settings, the one in `.travis.yml` takes precedence. If you define a variable in `.travis.yml` as both encrypted and unencrypted, the one defined later in the file takes precedence.
 
+> <a id="note-escape"/> Variables' values are passed to the generated build script verbatim. So make sure to escape any [Bash special characters](http://www.tldp.org/LDP/abs/html/special-chars.html) accordingly. In particular, if a value contains spaces, you need to put quotes around that value. E.g. `a long phrase` should be written as `"a long phrase"`.
+
 ### Defining Multiple Variables per Item
 
 If you need to specify several environment variables for each build, put them all on the same line in the `env` array:
@@ -134,8 +136,8 @@ To define variables in Repository Settings, make sure you're logged in, navigate
   <figcaption>Environment Variables in the Repository Settings</figcaption>
 </figure>
 
-> These values are used directly in your build, so make sure to escape [special characters (for bash)](http://www.tldp.org/LDP/abs/html/special-chars.html) accordingly. In particular, if a value contains spaces, you should put quotes around that value. E.g. `my secret passphrase` should be written `"my secret passphrase"`.
-
+  > See [the note above](#note-format) on how to format variables' values correctly.
+  
 By default, the value of these new environment variables is hidden from the `export` line in the logs. This corresponds to the behavior of [encrypted variables](#Encrypted-Variables) in your `.travis.yml`. The variables are stored encrypted in our systems, and get decrypted when the build script is generated.
 
 Similarly, we do not provide these values to untrusted builds, triggered by pull requests from another repository.


### PR DESCRIPTION
The concensus at https://travis-ci.community/t/travis-incorrectly-double-quotes-environment-variables/7496 is the current way is the most intuitive.