### PR TITLE
fix anchor name

### DIFF
--- a/user/environment-variables.md
+++ b/user/environment-variables.md
@@ -36,7 +36,9 @@ env:
 
 > If you define a variable with the same name in `.travis.yml` and in the Repository Settings, the one in `.travis.yml` takes precedence. If you define a variable in `.travis.yml` as both encrypted and unencrypted, the one defined later in the file takes precedence.
 
-> <a id="note-escape"/> Variables' values are passed to the generated build script verbatim. So make sure to escape any [Bash special characters](http://www.tldp.org/LDP/abs/html/special-chars.html) accordingly. In particular, if a value contains spaces, you need to put quotes around that value. E.g. `a long phrase` should be written as `"a long phrase"`.
+<a id="note-format"/>
+
+> Variables' values are passed to the generated build script verbatim. So make sure to escape any [Bash special characters](http://www.tldp.org/LDP/abs/html/special-chars.html) accordingly. In particular, if a value contains spaces, you need to put quotes around that value. E.g. `a long phrase` should be written as `"a long phrase"`.
 
 ### Defining Multiple Variables per Item
 


### PR DESCRIPTION
In https://github.com/travis-ci/docs-travis-ci-com/pull/2720, I've mixed up the name of the added anchor so the intra-page link didn't work.

Also put the anchor above the linked note -- this way, the note looks better when following the link to the anchor.