### PR TITLE
Use "jobs" in favor of "matrix" in Global Vars description

### DIFF
--- a/user/environment-variables.md
+++ b/user/environment-variables.md
@@ -63,7 +63,7 @@ this configuration triggers **4 individual builds**:
 
 ### Global Variables
 
-Sometimes you may want to use environment variables that are global to the matrix, i.e. they're inserted into each matrix row. That may include keys, tokens, URIs or other data that is needed for every build. In such cases, instead of manually adding such keys to each `env` line in matrix, you can use `global` and `matrix` keys to differentiate between those two cases. For example:
+Sometimes you may want to use environment variables that are global to the matrix, i.e. they're inserted into each matrix row. That may include keys, tokens, URIs or other data that is needed for every build. In such cases, instead of manually adding such keys to each `env` line in matrix, you can use `global` and `jobs` keys to differentiate between those two cases. For example:
 
 ```yaml
 env:


### PR DESCRIPTION
The yaml example uses the key "jobs" in favor "matrix" (I believe from older versions of the specification). This change updates the language in the description text to match what's found in the example.