### PR TITLE
Environment Variables: matrix -> jobs

### DIFF
--- a/user/environment-variables.md
+++ b/user/environment-variables.md
@@ -63,14 +63,14 @@ this configuration triggers **4 individual builds**:
 
 ### Global Variables
 
-Sometimes you may want to use environment variables that are global to the matrix, i.e. they're inserted into each matrix row. That may include keys, tokens, URIs or other data that is needed for every build. In such cases, instead of manually adding such keys to each `env` line in matrix, you can use `global` and `jobs` keys to differentiate between those two cases. For example:
+Sometimes you may want to use environment variables that are global to the matrix, i.e. they're inserted into each matrix row. That may include keys, tokens, URIs or other data that is needed for every build. In such cases, instead of manually adding such keys to each `env` line in matrix, you can use `global` and `matrix` keys to differentiate between those two cases. For example:
 
 ```yaml
 env:
   global:
     - CAMPFIRE_TOKEN=abc123
     - TIMEOUT=1000
-  jobs:
+  matrix:
     - USE_NETWORK=true
     - USE_NETWORK=false
 ```

--- a/user/environment-variables.md
+++ b/user/environment-variables.md
@@ -63,7 +63,7 @@ this configuration triggers **4 individual builds**:
 
 ### Global Variables
 
-Sometimes you may want to use environment variables that are global to the matrix, i.e. they're inserted into each matrix row. That may include keys, tokens, URIs or other data that is needed for every build. In such cases, instead of manually adding such keys to each `env` line in matrix, you can use `global` and `matrix` keys to differentiate between those two cases. For example:
+Sometimes you may want to use environment variables that are global to the matrix, i.e. they're inserted into each matrix row. That may include keys, tokens, URIs or other data that is needed for every build. In such cases, instead of manually adding such keys to each `env` line in matrix, you can use `global` and `jobs` keys to differentiate between those two cases. For example:
 
 ```yaml
 env:
@@ -139,7 +139,7 @@ To define variables in Repository Settings, make sure you're logged in, navigate
 </figure>
 
   > See [the note above](#note-format) on how to format variables' values correctly.
-  
+
 By default, the value of these new environment variables is hidden from the `export` line in the logs. This corresponds to the behavior of [encrypted variables](#Encrypted-Variables) in your `.travis.yml`. The variables are stored encrypted in our systems, and get decrypted when the build script is generated.
 
 Similarly, we do not provide these values to untrusted builds, triggered by pull requests from another repository.


### PR DESCRIPTION
I believe this is a typo, or leftover from some old syntax. The description says to use "global" and "matrix" keys, but the example `.travis.yml` uses "global" and "jobs" keys.