### PR TITLE
Reordered the common words

### DIFF
--- a/user/for-beginners.md
+++ b/user/for-beginners.md
@@ -36,22 +36,21 @@ you can have jobs depend on each other with [Build Stages](/user/build-stages/),
 set up [notifications](/user/notifications/), prepare
 [deployments](/user/deployment/) after builds and many other tasks.
 
-## Builds, Jobs, Stages and Phases
+## Builds, Stages, Jobs and Phases
 
 In the Travis CI documentation, some common words have specific meanings:
 
-* *phase* - the [sequential steps](/user/job-lifecycle/)
-  of a job. For example, the `install` phase, comes before the `script` phase,
-  which comes before the optional `deploy` phase.
+* *build* - a group of *jobs* that run in sequence. For example, a build might have two *jobs*, each
+  of which tests a project with a different version of a programming language.
+  A *build* finishes when all of its jobs are finished.
+* *stage* - a group of *jobs* that run in parallel as part of a sequential build process composed of multiple [stages](/user/build-stages/).
 * *job* - an automated process that clones your repository into a virtual
   environment and then carries out a series of *phases* such as compiling your
   code, running tests, etc. A job fails, if the return code of the `script` *phase*
   is non-zero.
-* *build* - a group of *jobs*. For example, a build might have two *jobs*, each
-  of which tests a project with a different version of a programming language.
-  A *build* finishes when all of its jobs are finished.
-* *stage* - a group of *jobs* that run in parallel as part of a sequential build
-  process composed of multiple [stages](/user/build-stages/).
+* *phase* - the [sequential steps](/user/job-lifecycle/)
+  of a *job*. For example, the `install` phase, comes before the `script` phase,
+  which comes before the optional `deploy` phase.
 
 ## Breaking the Build
 

--- a/user/for-beginners.md
+++ b/user/for-beginners.md
@@ -43,7 +43,7 @@ In the Travis CI documentation, some common words have specific meanings:
 * *build* - a group of *jobs* that run in sequence. For example, a build might have two *jobs*, each
   of which tests a project with a different version of a programming language.
   A *build* finishes when all of its jobs are finished.
-* *stage* - a group of *jobs* that run in parallel as part of a sequential build process composed of multiple [stages](/user/build-stages/).
+* *stage* - a group of *jobs* that run in parallel as part of a sequential *build* process composed of multiple [stages](/user/build-stages/).
 * *job* - an automated process that clones your repository into a virtual
   environment and then carries out a series of *phases* such as compiling your
   code, running tests, etc. A job fails, if the return code of the `script` *phase*


### PR DESCRIPTION
I found the existing order of the "common words" confusing:
1. First phases are mentioned as the steps of jobs
2. Then jobs, which have a series of phases
3. Then builds, which are groups of jobs
4. Finally stages, which are again groups of jobs

I had to jump around the list quite a lot to understand the hierarchy and the different between the words here. I think this new ordering should be easier to understand.