### PR TITLE
Update documentation for Dart's new version scheme

### DIFF
--- a/user/languages/dart.md
+++ b/user/languages/dart.md
@@ -48,12 +48,16 @@ language: dart
 dart:
 # Install the latest stable release
 - stable
+# Install the latest beta release
+- beta
 # Install the latest dev release
 - dev
 # Install a specific stable release - 1.15.0
 - "1.15.0"
-# Install a specific dev release, using a partial download URL - 1.16.0-dev.3.0
-- "dev/release/1.16.0-dev.3.0"
+# Install a specific dev release, using a partial download URL - 2.9.0-2.0.dev
+- "dev/release/2.9.0-2.0.dev"
+# Install a specific beta release, using a partial download URL - 2.9.0-2.0.beta
+- "beta/release/2.9.0-2.0.beta"
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
Dart has a new versioning scheme (https://github.com/travis-ci/travis-build/pull/1897 adds Travis support for that) and a new beta channel.

Part of https://github.com/dart-lang/sdk/issues/40996.