### PR TITLE
Update gui-and-headless-browsers.md

### DIFF
--- a/user/gui-and-headless-browsers.md
+++ b/user/gui-and-headless-browsers.md
@@ -158,7 +158,7 @@ mode, which is suitable for driving browser-based tests using Selenium and other
 For example, on Linux
 
 ```yaml
-dist: trusty
+dist: xenial
 addons:
   chrome: stable
 before_install:


### PR DESCRIPTION
Use `xenial` instead of `trusty` in Chrome headless section.