### PR TITLE
Fix Incorrect URL to AWS CloudFormation Doc Page

### DIFF
--- a/user/deployment-v2/providers/cloudformation.md
+++ b/user/deployment-v2/providers/cloudformation.md
@@ -5,7 +5,7 @@ deploy: v2
 provider: cloudformation
 ---
 
-Travis CI can automatically deploy files to [AWS CloudFormation](https://convox.com)
+Travis CI can automatically deploy files to [AWS CloudFormation](https://docs.aws.amazon.com/cloudformation/)
 after a successful build.
 
 {% include deploy/providers/cloudformation.md %}


### PR DESCRIPTION
Wrong URL linking to another service was used.

Users are currently redirected to https://convox.com/ instead of AWS CloudFormation doc page when they click on the link.

