### PR TITLE
Fix 404 link on 'job-lifecycle'

### DIFF
--- a/user/job-lifecycle.md
+++ b/user/job-lifecycle.md
@@ -11,7 +11,7 @@ Keep reading to see how you can customize any phase in this process, via your `.
 
 ## The Build
 
-The `.travis.yml` file describes the build process. A *build* in Travis CI is a sequence of [stages](build-stages). Each *stage* consists of jobs run in parallel. 
+The `.travis.yml` file describes the build process. A *build* in Travis CI is a sequence of [stages](../build-stages). Each *stage* consists of jobs run in parallel. 
 
 ## The Job Lifecycle
 


### PR DESCRIPTION
On page `https://docs.travis-ci.com/user/job-lifecycle/` there is a paragraph with `The .travis.yml file describes the build process. A build in Travis CI is a sequence of stages.`.

The link of 'stages' links to `build-stages` which is the URL of `https://docs.travis-ci.com/user/job-lifecycle/build-stages`, this gives a 404 on visit, and the correct link should be `https://docs.travis-ci.com/user/build-stages/`.

This is a quick fix on that link.