### PR TITLE
Use bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #language: ruby
-dist: xenial
+dist: bionic
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
   - name: build site
     language: python
     python:
-      - "3.5.2"
+      - "3.8.3"
     env:
       global:
         - PATH=$HOME/.local/user/bin:$PATH


### PR DESCRIPTION
Looks like Xenial's certificates are no longer valid to verify https://language-archives.travis-ci.com.

We could update the package `ca-certificates`, or use a more recent Ubuntu release.