### PR TITLE
Update triggering-builds.md with correct `merge_mode` example

### DIFF
--- a/user/triggering-builds.md
+++ b/user/triggering-builds.md
@@ -58,8 +58,8 @@ Trigger Travis CI builds using the API V3 by sending a POST request to `/repo/{s
     "request": {
     "message": "Override the commit message: this is an api request",
     "branch":"master",
+    "merge_mode": "deep_merge",
     "config": {
-      "merge_mode": "deep_merge",
       "env": {
         "jobs": [
           "TEST=unit"


### PR DESCRIPTION
As outlined on [the forums](https://travis-ci.community/t/merge-mode-replace-seems-to-merge-lists-not-replace-them/8839/3), the docs don't correctly outline where the `merge_mode` key should be placed in the API request.

This PR fixes that.