### PR TITLE
Update nix default version to 2.3.6

### DIFF
--- a/user/languages/nix.md
+++ b/user/languages/nix.md
@@ -46,11 +46,11 @@ The following command line tools are available in the Nix environment:
 
 ## Default Nix Version
 
-This installs Nix 2.0.4 using [https://nixos.org/releases/nix/nix-2.0.4/install](https://nixos.org/releases/nix/nix-2.0.4/install). You may specify a different version of Nix installer with the `nix:` key in your `.travis.yml`:
+This installs Nix 2.3.6 using [https://nixos.org/releases/nix/nix-2.3.6/install](https://nixos.org/releases/nix/nix-2.3.6/install). You may specify a different version of Nix installer with the `nix:` key in your `.travis.yml`:
 
 ```yaml
 language: nix
-nix: 2.0.4
+nix: 2.3.6
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
Changing default Nix version from 2.0.4 to 2.3.6 per https://github.com/travis-ci/travis-build/pull/1833