### PR TITLE
included Julia in supported Windows languages

### DIFF
--- a/user/reference/windows.md
+++ b/user/reference/windows.md
@@ -45,12 +45,13 @@ Powershell can be used by calling `powershell` in your .travis.yml file for now.
 VMs running Windows use the default file system, NTFS.
 
 ## Supported languages
+- Bash `language: bash` or `language: shell`
 - C with `language: c`
 - C++ with `language: cpp`
+- Go with `language: go`
+- Julia with `language: julia`
 - Node.js with `language: node_js`
 - Rust with `language: rust`
-- Go with `language: go`
-- Bash `language: bash` or `language: shell`
 
 ## Pre-installed Chocolatey packages
 


### PR DESCRIPTION
Julia has been supported on Windows since August 2019 🎉

Have a look at:
- [the announcement](https://discourse.julialang.org/t/julia-is-now-available-on-travis-windows-builds/27187/2)
- a project that tests Julia on Windows: [https://travis-ci.org/github/ararslan/Jackknife.jl](https://travis-ci.org/github/ararslan/Jackknife.jl)
- the [`.travis.yml` file](https://github.com/ararslan/Jackknife.jl/blob/master/.travis.yml) of that project

I also put the list of languages in **alphabetical order**, hence the multiple changed lines.