### PR TITLE
Update Erlang/OTP release examples

### DIFF
--- a/user/languages/erlang.md
+++ b/user/languages/erlang.md
@@ -40,11 +40,8 @@ Travis CI VMs provide 64-bit [Erlang OTP](http://www.erlang.org/download.html) r
 ```yaml
 language: erlang
 otp_release:
-  - 18.2.1
-  - 18.1
-  - 18.0
-  - 17.5
-  - R16B03
+  - "23.0.2"
+  - "22.3.4"
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
No one is testing on OTP 17.5 or 18.x any more. It would
be more useful to have examples that use
Erlang 23.0.x and 22.3.x.