### PR TITLE
Proposing mac example update to Python 3.8

### DIFF
--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -170,10 +170,12 @@ jobs:
   include:
     - name: "Python 3.8.0 on Xenial Linux"
       python: 3.8           # this works for Linux but is ignored on macOS or Windows
-    - name: "Python 3.7.4 on macOS"
+    - name: "Python 3.8.x on macOS"
       os: osx
-      osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
-      language: shell       # 'language: python' is an error on Travis CI macOS
+      osx_image: xcode11.6
+      language: shell
+      install: /usr/local/opt/python@3.8/bin/python3 -m pip install <package>
+      script: /usr/local/opt/python@3.8/bin/python3 -m unittest discover
     - name: "Python 3.8.0 on Windows"
       os: windows           # Windows 10.0.17134 N/A Build 17134
       language: shell       # 'language: python' is an error on Travis CI Windows

--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -173,7 +173,7 @@ jobs:
     - name: "Python 3.8.x on macOS"
       os: osx
       osx_image: xcode11.6
-      language: shell
+      language: shell       # 'language: python' is an error on Travis CI macOS
       install: /usr/local/opt/python@3.8/bin/python3 -m pip install <package>
       script: /usr/local/opt/python@3.8/bin/python3 -m unittest discover
     - name: "Python 3.8.0 on Windows"


### PR DESCRIPTION
I want to share my method of using a certain version of Python in MacOS.

Let me start by saying that I've never used Mac before and that this is my first time making a pull request.
I'm using unittests and pip.

I had trouble using a certain version of Python in Mac, after a lot of experimenting I found this and wanted to share, because I wish I saw this a lot sooner.

I got it working with 'brew upgrade python@3.8" but that took around 8 minutes to finish, so I kept trying:
Tried messing around forever with symlinks but I couldn't get it to work.
Eventually I found this, where you just reference the (already installed?) python version 3.8.x, which only took 22 seconds:
So instead of 'python3' (which results in 3.7 (because of xcode11.x I think)) you can write '/usr/local/opt/python@3.8/bin/python3'.

Could be a better place in the documentation to put this, especially since my example is the only one using unittests, maybe we can just alter it though.
Not sure about what version, but it's 3.8.x. (Guessing latest?)

I'm also unsure about how 'pip install <package>' works. Is it not required in most cases?

Here's my most recent .travis.yml if that's helpful.
https://github.com/Mandera/generalvector/blob/master/.travis.yml