### PR TITLE
Use `--workspace` instead of `--all` in rust.md

### DIFF
--- a/user/languages/rust.md
+++ b/user/languages/rust.md
@@ -122,14 +122,14 @@ cargo test --verbose
 You can always configure different commands if you need to. For example,
 if your project is a
 [workspace](http://doc.crates.io/manifest.html#the-workspace-section), you
-should pass `--all` to the build commands to build and test all of the member
+should pass `--workspace` to the build commands to build and test all of the member
 crates:
 
 ```yaml
 language: rust
 script:
-  - cargo build --verbose --all
-  - cargo test --verbose --all
+  - cargo build --verbose --workspace
+  - cargo test --verbose --workspace
 ```
 {: data-file=".travis.yml"}
 


### PR DESCRIPTION
In latest Cargo `--all` flag is deprecated in favor of `--workspace`. This PR updates documentation for Rust to reflect this.