### PR TITLE
Sign in to travis-ci.com and GitHub warning

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -114,7 +114,7 @@ enterprise_3_encryption_key_backup: |
   1. Make sure you have appropriate access to the kubernetes cluster: you need credentials for `kubectl` and connection to [travis-api-pod] 
   2. Run `kubectl exec -it [travis-api-pod] cat /app/config/travis.yml |grep -A 2 encryption` (using Travis API pod is recommended). 
   3. Create a backup of the value returned by that command by either writing it down on a piece of paper or storing it on a different computer.
-ć: | 
+github_access_rights: | 
   When you do sign in to [travis-ci.com](https://travis-ci.com) using GitHub for the first time, you will receive message on screen from GitHub saying:
   
   > Travis CI by travis-pro wants to access your [account name] account

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -124,10 +124,13 @@ github_oauth_access_rights: |
   > This application will be able to read and write all public and private repository data.
   
   This is not how Travis CI will exactly access yout data, however we can explain it only later in the process. 
+  
   The warning is triggerred due to GitHub OAuth App permissions Travis CI uses and available granularity of permission scopes (see GtiHub [Scopes for OAuth Apps documentation](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps) ).
   
   **Travis CI does not access all your repositories by default**. 
+  
   Once you acknowledge the access rights, you will see Travis CI OAuth application present in your GtiHub [Authorized OAuth Apps list](https://github.com/settings/applications), however **you need to explicitly configure which repositories Travis CI has access to** within your [travis-ci.com](https://travis-ci.com) account. The configuration is done during activation of Travis CI for your repositories. You can use either 'All repositories' option or 'Only select repositories' during the activation process.
+  
   When you're done with Travis CI activation, you will see actual Travis CI GitHub Application installed in GitHub in [Installed GitHub Apps](https://github.com/settings/installations) section.
   
   Travis CI uses OAuth permissions in a following way:

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -137,7 +137,7 @@ github_oauth_access_rights: |
 
   1) Travis CI's system synchronizes certain metadata with GitHub. This metadata is required for proper service functioning. In particular, we sync users, orgs, memberships, repos, permissions and (optionally) branches. This type of sync happens either once a day by schedule or per user's request. You can find more information and source code [in this repository](https://github.com/travis-ci/travis-github-sync#syncs)
 
-  2) In order to run builds, Travis CI's system clones a repository, for which the build is triggered, to the build environment. The build environment is an isolated virtual machine, which gets terminated as soon as build finishes. Clone happens only after build request, and therefore only for the repositories, explicitly enabled at GitHub settings.
+  2) In order to run builds, Travis CI's system clones a repository, for which the build is triggered, to the build environment. The build environment is an isolated virtual machine or LXD container, which gets terminated as soon as build finishes. Clone happens only after build request, and therefore only for the repositories, explicitly enabled at GitHub settings.
 
   3) To set up a build environment and prepare the build, Travis CI's system fetches and processes `.travis.yml` config file from the repository and the branch explicitly specified in the build request, triggered by GitHub.
 

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -139,4 +139,6 @@ github_oauth_access_rights: |
 
   2) In order to run builds, Travis CI's system clones a repository, for which the build is triggered, to the build environment. The build environment is an isolated virtual machine, which gets terminated as soon as build finishes. Clone happens only after build request, and therefore only for the repositories, explicitly enabled at GitHub settings.
 
-  3) Travis CI's system reports build results back to GitHub via its [Checks API](https://developer.github.com/v3/checks/)
+  3) To set up a build environment and prepare the build, Travis CI's system fetches and processes `.travis.yml` config file from the repository and the branch explicitly specified in the build request, triggered by GitHub.
+
+  4) Travis CI's system reports build results back to GitHub via its [Checks API](https://developer.github.com/v3/checks/)

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -125,13 +125,19 @@ github_oauth_access_rights: |
   
   This is not how Travis CI will exactly access yout data, however we can explain it only later in the process. 
   
-  The warning is triggerred due to GitHub OAuth App permissions Travis CI uses and available granularity of permission scopes (see GtiHub [Scopes for OAuth Apps documentation](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps) ).
+  The warning is triggerred due to GitHub OAuth App permissions Travis CI uses and available granularity of permission scopes (see GitHub [Scopes for OAuth Apps documentation](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps) ).
   
   **Travis CI does not access all your repositories by default**. 
   
-  Once you acknowledge the access rights, you will see Travis CI OAuth application present in your GtiHub [Authorized OAuth Apps list](https://github.com/settings/applications), however **you need to explicitly configure which repositories Travis CI has access to** within your [travis-ci.com](https://travis-ci.com) account. The configuration is done during activation of Travis CI for your repositories. You can use either 'All repositories' option or 'Only select repositories' during the activation process.
+  Once you acknowledge the access rights, you will see Travis CI OAuth application present in your GitHub [Authorized OAuth Apps list](https://github.com/settings/applications), however **you need to explicitly configure which repositories Travis CI has access to** within your [travis-ci.com](https://travis-ci.com) account. The configuration is done during activation of Travis CI for your repositories. You can use either 'All repositories' option or 'Only select repositories' during the activation process.
   
   When you're done with Travis CI activation, you will see actual Travis CI GitHub Application installed in GitHub in [Installed GitHub Apps](https://github.com/settings/installations) section.
   
-  Travis CI uses OAuth permissions in a following way:
+  Travis CI uses OAuth permissions in a following way:  
+
+  1) Travis CI's system synchronizes certain metadata with GitHub. This metadata is required for proper service functioning. In particular, we sync users, orgs, memberships, repos, permissions and (optionally) branches. This type of sync happens either once a day by schedule or per user's request. You can find more information and source code [in this repository](https://github.com/travis-ci/travis-github-sync#syncs)
+
+  2) In order to run builds, Travis CI's system clones a repository, for which the build is triggered, to the build environment. The build environment is an isolated virtual machine, which gets terminated as soon as build finishes. Clone happens only after build request, and therefore only for the repositories, explicitly enabled at GitHub settings.
+
+  3) Travis CI's system reports build results back to GitHub via its [Checks API](https://developer.github.com/v3/checks/)
   

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -114,17 +114,21 @@ enterprise_3_encryption_key_backup: |
   1. Make sure you have appropriate access to the kubernetes cluster: you need credentials for `kubectl` and connection to [travis-api-pod] 
   2. Run `kubectl exec -it [travis-api-pod] cat /app/config/travis.yml |grep -A 2 encryption` (using Travis API pod is recommended). 
   3. Create a backup of the value returned by that command by either writing it down on a piece of paper or storing it on a different computer.
-gh_access_rights: | 
+ć: | 
   When you do sign in to [travis-ci.com](https://travis-ci.com) using GitHub for the first time, you will receive message on screen from GitHub saying:
-  `Travis CI by travis-pro wants to access your [account name] account`
+  
+  > Travis CI by travis-pro wants to access your [account name] account
   
   and in section about repositories it will state 
-  `This application will be able to read and write all public and private repository data.`
   
-  This is not how Travis CI will exactly access yout data, however we can explain it only later in the process. The warning is triggerred due to GitHub OAuth App permissions Travis CI uses and available granularity of permission scopes (see GtiHub [Scopes for OAuth Apps documentation](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps) ).
+  > This application will be able to read and write all public and private repository data.
   
-  **Travis CI does not access all your repositories by default**. Once you acknowledge the warning, you will see Travis CI OAuth application present in your [GtiHub Account settings](https://github.com/settings/applications), however **you need to explicitly configure to which repositories Travis CI has access to** within your [travis-ci.com](https://travis-ci.com) account by activating Travis CI for your repositories. You can use either 'All repositories' option or 'Only select repositories' during the Travis CI activation.
-  Once you're done with Travis CI activation, you will see actual Travis CI application installed in GitHub in [Installed GitHub Apps](https://github.com/settings/installations) section.
+  This is not how Travis CI will exactly access yout data, however we can explain it only later in the process. 
+  The warning is triggerred due to GitHub OAuth App permissions Travis CI uses and available granularity of permission scopes (see GtiHub [Scopes for OAuth Apps documentation](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps) ).
+  
+  **Travis CI does not access all your repositories by default**. 
+  Once you acknowledge the access rights, you will see Travis CI OAuth application present in your GtiHub [Authorized OAuth Apps list](https://github.com/settings/applications), however **you need to explicitly configure which repositories Travis CI has access to** within your [travis-ci.com](https://travis-ci.com) account. The configuration is done during activation of Travis CI for your repositories. You can use either 'All repositories' option or 'Only select repositories' during the activation process.
+  When you're done with Travis CI activation, you will see actual Travis CI GitHub Application installed in GitHub in [Installed GitHub Apps](https://github.com/settings/installations) section.
   
   Travis CI uses OAuth permissions in a following way:
   

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -114,7 +114,7 @@ enterprise_3_encryption_key_backup: |
   1. Make sure you have appropriate access to the kubernetes cluster: you need credentials for `kubectl` and connection to [travis-api-pod] 
   2. Run `kubectl exec -it [travis-api-pod] cat /app/config/travis.yml |grep -A 2 encryption` (using Travis API pod is recommended). 
   3. Create a backup of the value returned by that command by either writing it down on a piece of paper or storing it on a different computer.
-github_access_rights: | 
+github_oauth_access_rights: | 
   When you do sign in to [travis-ci.com](https://travis-ci.com) using GitHub for the first time, you will receive message on screen from GitHub saying:
   
   > Travis CI by travis-pro wants to access your [account name] account

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -114,3 +114,17 @@ enterprise_3_encryption_key_backup: |
   1. Make sure you have appropriate access to the kubernetes cluster: you need credentials for `kubectl` and connection to [travis-api-pod] 
   2. Run `kubectl exec -it [travis-api-pod] cat /app/config/travis.yml |grep -A 2 encryption` (using Travis API pod is recommended). 
   3. Create a backup of the value returned by that command by either writing it down on a piece of paper or storing it on a different computer.
+gh_access_rights: | 
+  > When you do sign in to [travis-ci.com](https://travis-ci.com) using GitHub for the first time, you will receive message on screen from GitHub saying:
+  > `Travis CI by travis-pro wants to access your [account name] account`
+  >
+  > and in section about repositories it will state 
+  > `This application will be able to read and write all public and private repository data.`
+  >
+  > This is not how Travis CI will exactly access yout data, however we can explain it only later in the process. The warning is triggerred due to GitHub OAuth App permissions Travis CI uses and available granularity of permission scopes (see GtiHub [Scopes for OAuth Apps documentation](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps) ).
+  >
+  > **Travis CI does not access all your repositories by default**. Once you acknowledge the warning, you will see Travis CI OAuth application present in your [GtiHub Account settings](https://github.com/settings/applications), however **you need to explicitly configure to which repositories Travis CI has access to** within your [travis-ci.com](https://travis-ci.com) account by activating Travis CI for your repositories. You can use either 'All repositories' option or 'Only select repositories' during the Travis CI activation.
+  > Once you're done with Travis CI activation, you will see actual Travis CI application installed in GitHub in [Installed GitHub Apps](https://github.com/settings/installations) section.
+  >
+  > Travis CI uses OAuth permissions in a following way:
+  >

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -115,30 +115,30 @@ enterprise_3_encryption_key_backup: |
   2. Run `kubectl exec -it [travis-api-pod] cat /app/config/travis.yml |grep -A 2 encryption` (using Travis API pod is recommended). 
   3. Create a backup of the value returned by that command by either writing it down on a piece of paper or storing it on a different computer.
 github_oauth_access_rights: | 
-  When you do sign in to [travis-ci.com](https://travis-ci.com) using GitHub for the first time, you will receive message on screen from GitHub saying:
+  When you sign in to [travis-ci.com](https://travis-ci.com) using GitHub for the first time, you will receive a message from GitHub saying:
   
-  > Travis CI by travis-pro wants to access your [account name] account
+  > Travis CI by travis-pro wants to access your [account name] account.
   
-  and in section about repositories it will state 
+  and in the repositorie's section it will state: 
   
   > This application will be able to read and write all public and private repository data.
   
-  This is not how Travis CI will exactly access yout data, however we can explain it only later in the process. 
+  This is not how Travis CI access yout data, however we can explain it later in the process. 
   
-  The warning is triggerred due to GitHub OAuth App permissions Travis CI uses and available granularity of permission scopes (see GitHub [Scopes for OAuth Apps documentation](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps) ).
+  The warning is triggerred due to GitHub OAuth App permissions which Travis CI uses, and due to the available granularity of permission scopes (see GitHub [Scopes for OAuth Apps documentation](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps) ).
   
   **Travis CI does not access all your repositories by default**. 
   
-  Once you acknowledge the access rights, you will see Travis CI OAuth application present in your GitHub [Authorized OAuth Apps list](https://github.com/settings/applications), however **you need to explicitly configure which repositories Travis CI has access to** within your [travis-ci.com](https://travis-ci.com) account. The configuration is done during activation of Travis CI for your repositories. You can use either 'All repositories' option or 'Only select repositories' during the activation process.
+  Once you acknowledge the access rights, you will see Travis CI OAuth application present in your GitHub [Authorized OAuth Apps list](https://github.com/settings/applications), however **you need to explicitly configure which repositories Travis CI has access to** within your [travis-ci.com](https://travis-ci.com) account. The configuration is done during the activation of Travis CI for your repositories. You can use either the 'All repositories' option or the 'Only select repositories' option during the activation process.
   
-  When you're done with Travis CI activation, you will see actual Travis CI GitHub Application installed in GitHub in [Installed GitHub Apps](https://github.com/settings/installations) section.
+  When the Travis CI activation has completed, you will see the actual Travis CI GitHub Application installed in [Installed GitHub Apps](https://github.com/settings/installations) section.
   
-  Travis CI uses OAuth permissions in a following way:  
+  Travis CI uses OAuth permissions in the following way:  
 
-  1) Travis CI's system synchronizes certain metadata with GitHub. This metadata is required for proper service functioning. In particular, we sync users, orgs, memberships, repos, permissions and (optionally) branches. This type of sync happens either once a day by schedule or per user's request. You can find more information and source code [in this repository](https://github.com/travis-ci/travis-github-sync#syncs)
+  1) Travis CI's system synchronizes certain metadata with GitHub. This metadata is required for proper service functioning. In particular, we sync users, orgs, memberships, repos, permissions and, (optionally) branches. This type of sync happens either once a day by schedule or per the user's request. You can find more information and source code [in this repository](https://github.com/travis-ci/travis-github-sync#syncs)
 
-  2) In order to run builds, Travis CI's system clones a repository, for which the build is triggered, to the build environment. The build environment is an isolated virtual machine or LXD container, which gets terminated as soon as build finishes. Clone happens only after build request, and therefore only for the repositories, explicitly enabled at GitHub settings.
+  2) In order to run builds, Travis CI's system clones a repository, from which the build is triggered, to the build environment. The build environment is an isolated virtual machine or an LXD container, which gets terminated as soon as the build finishes. Cloning happens only after a build request, and therefore only for the repositories explicitly enabled at GitHub settings.
 
-  3) To set up a build environment and prepare the build, Travis CI's system fetches and processes `.travis.yml` config file from the repository and the branch explicitly specified in the build request, triggered by GitHub.
+  3) To set up a build environment and prepare the build, Travis CI's system fetches and processes the `.travis.yml` config file from the repository and the branch explicitly specified in the build request, triggered by GitHub.
 
-  4) Travis CI's system reports build results back to GitHub via its [Checks API](https://developer.github.com/v3/checks/)
+  4) Travis CI's system reports build results back to GitHub via its [Checks API](https://developer.github.com/v3/checks/).

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -140,4 +140,3 @@ github_oauth_access_rights: |
   2) In order to run builds, Travis CI's system clones a repository, for which the build is triggered, to the build environment. The build environment is an isolated virtual machine, which gets terminated as soon as build finishes. Clone happens only after build request, and therefore only for the repositories, explicitly enabled at GitHub settings.
 
   3) Travis CI's system reports build results back to GitHub via its [Checks API](https://developer.github.com/v3/checks/)
-  

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -115,16 +115,16 @@ enterprise_3_encryption_key_backup: |
   2. Run `kubectl exec -it [travis-api-pod] cat /app/config/travis.yml |grep -A 2 encryption` (using Travis API pod is recommended). 
   3. Create a backup of the value returned by that command by either writing it down on a piece of paper or storing it on a different computer.
 gh_access_rights: | 
-  > When you do sign in to [travis-ci.com](https://travis-ci.com) using GitHub for the first time, you will receive message on screen from GitHub saying:
-  > `Travis CI by travis-pro wants to access your [account name] account`
-  >
-  > and in section about repositories it will state 
-  > `This application will be able to read and write all public and private repository data.`
-  >
-  > This is not how Travis CI will exactly access yout data, however we can explain it only later in the process. The warning is triggerred due to GitHub OAuth App permissions Travis CI uses and available granularity of permission scopes (see GtiHub [Scopes for OAuth Apps documentation](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps) ).
-  >
-  > **Travis CI does not access all your repositories by default**. Once you acknowledge the warning, you will see Travis CI OAuth application present in your [GtiHub Account settings](https://github.com/settings/applications), however **you need to explicitly configure to which repositories Travis CI has access to** within your [travis-ci.com](https://travis-ci.com) account by activating Travis CI for your repositories. You can use either 'All repositories' option or 'Only select repositories' during the Travis CI activation.
-  > Once you're done with Travis CI activation, you will see actual Travis CI application installed in GitHub in [Installed GitHub Apps](https://github.com/settings/installations) section.
-  >
-  > Travis CI uses OAuth permissions in a following way:
-  >
+  When you do sign in to [travis-ci.com](https://travis-ci.com) using GitHub for the first time, you will receive message on screen from GitHub saying:
+  `Travis CI by travis-pro wants to access your [account name] account`
+  
+  and in section about repositories it will state 
+  `This application will be able to read and write all public and private repository data.`
+  
+  This is not how Travis CI will exactly access yout data, however we can explain it only later in the process. The warning is triggerred due to GitHub OAuth App permissions Travis CI uses and available granularity of permission scopes (see GtiHub [Scopes for OAuth Apps documentation](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps) ).
+  
+  **Travis CI does not access all your repositories by default**. Once you acknowledge the warning, you will see Travis CI OAuth application present in your [GtiHub Account settings](https://github.com/settings/applications), however **you need to explicitly configure to which repositories Travis CI has access to** within your [travis-ci.com](https://travis-ci.com) account by activating Travis CI for your repositories. You can use either 'All repositories' option or 'Only select repositories' during the Travis CI activation.
+  Once you're done with Travis CI activation, you will see actual Travis CI application installed in GitHub in [Installed GitHub Apps](https://github.com/settings/installations) section.
+  
+  Travis CI uses OAuth permissions in a following way:
+  

--- a/user/migrate/open-source-repository-migration.md
+++ b/user/migrate/open-source-repository-migration.md
@@ -76,6 +76,8 @@ If you are already using GitHub Apps for your account in travis-ci.com, you need
 
 1. Log in to [https://travis-ci.com] and access your profile (or your organization's) at [https://travis-ci.com/profile](https://travis-ci.com/profile)
 
+{{ site.data.snippets.gh_access_rights }}
+
 2. If you aren't using the new GitHub Apps integration already, activate it for your account
   ![Activate GitHub Apps](/user/images/oss-migration/gapps-activate.png)
 

--- a/user/migrate/open-source-repository-migration.md
+++ b/user/migrate/open-source-repository-migration.md
@@ -74,7 +74,7 @@ No. Unless there was something very customised in your `.travis.yml`, no changes
 
 If you are already using GitHub Apps for your account in travis-ci.com, you need to access your installation settings and grant access to the repositories you'd like to migrate. Otherwise:
 
-1. Log in to [https://travis-ci.com] and access your profile (or your organization's) at [https://travis-ci.com/profile](https://travis-ci.com/profile). If there's any doubt with regards to GitHub warning for Travis CI OAuth Application, please read more details [below](/user/migrate/open-source-repository-migration#travis-ci-github-oauth-app-access-rights).
+1. Log in to [https://travis-ci.com] and access your profile (or your organization's) at [https://travis-ci.com/profile](https://travis-ci.com/profile). If there's any doubt with regards to GitHub message for Travis CI Authorized OAuth App access rights, please read more details [below](/user/migrate/open-source-repository-migration#travis-ci-github-oauth-app-access-rights).
 
 2. If you aren't using the new GitHub Apps integration already, activate it for your account
   ![Activate GitHub Apps](/user/images/oss-migration/gapps-activate.png)
@@ -85,7 +85,7 @@ If you are already using GitHub Apps for your account in travis-ci.com, you need
 
 #### Travis CI GitHub OAuth App access rights
 
-{{ site.data.snippets.gh_access_rights }}
+{{ site.data.snippets.github_oauth_access_rights }}
 
 ### The migration steps
 

--- a/user/migrate/open-source-repository-migration.md
+++ b/user/migrate/open-source-repository-migration.md
@@ -74,7 +74,7 @@ No. Unless there was something very customised in your `.travis.yml`, no changes
 
 If you are already using GitHub Apps for your account in travis-ci.com, you need to access your installation settings and grant access to the repositories you'd like to migrate. Otherwise:
 
-1. Log in to [https://travis-ci.com] and access your profile (or your organization's) at [https://travis-ci.com/profile](https://travis-ci.com/profile). For any doubts regarding the GitHub message for the Travis CI Authorized OAuth App access rights, please read more details [below](/user/migrate/open-source-repository-migration#travis-ci-github-oauth-app-access-rights).
+1. Log in to [https://travis-ci.com] and access your profile (or your organization's) at [https://travis-ci.com/profile](https://travis-ci.com/profile). For any doubts on the Travis CI GitHub Authorized OAuth App access rights message, please read more details [below](/user/migrate/open-source-repository-migration#travis-ci-github-oauth-app-access-rights).
 
 2. If you aren't using the new GitHub Apps integration already, activate it for your account
   ![Activate GitHub Apps](/user/images/oss-migration/gapps-activate.png)

--- a/user/migrate/open-source-repository-migration.md
+++ b/user/migrate/open-source-repository-migration.md
@@ -74,7 +74,7 @@ No. Unless there was something very customised in your `.travis.yml`, no changes
 
 If you are already using GitHub Apps for your account in travis-ci.com, you need to access your installation settings and grant access to the repositories you'd like to migrate. Otherwise:
 
-1. Log in to [https://travis-ci.com] and access your profile (or your organization's) at [https://travis-ci.com/profile](https://travis-ci.com/profile). If there's any doubt with regards to GitHub message for Travis CI Authorized OAuth App access rights, please read more details [below](/user/migrate/open-source-repository-migration#travis-ci-github-oauth-app-access-rights).
+1. Log in to [https://travis-ci.com] and access your profile (or your organization's) at [https://travis-ci.com/profile](https://travis-ci.com/profile). For any doubts regarding the GitHub message for the Travis CI Authorized OAuth App access rights, please read more details [below](/user/migrate/open-source-repository-migration#travis-ci-github-oauth-app-access-rights).
 
 2. If you aren't using the new GitHub Apps integration already, activate it for your account
   ![Activate GitHub Apps](/user/images/oss-migration/gapps-activate.png)

--- a/user/migrate/open-source-repository-migration.md
+++ b/user/migrate/open-source-repository-migration.md
@@ -74,7 +74,7 @@ No. Unless there was something very customised in your `.travis.yml`, no changes
 
 If you are already using GitHub Apps for your account in travis-ci.com, you need to access your installation settings and grant access to the repositories you'd like to migrate. Otherwise:
 
-1. Log in to [https://travis-ci.com] and access your profile (or your organization's) at [https://travis-ci.com/profile](https://travis-ci.com/profile). If there's any doubt with regards to GitHub warning for Travis CI OAuth Application, please read more details [below](/user/migrate/travis-ci-github-oauth-app-access-rights).
+1. Log in to [https://travis-ci.com] and access your profile (or your organization's) at [https://travis-ci.com/profile](https://travis-ci.com/profile). If there's any doubt with regards to GitHub warning for Travis CI OAuth Application, please read more details [below](/user/migrate/open-source-repository-migration#travis-ci-github-oauth-app-access-rights).
 
 2. If you aren't using the new GitHub Apps integration already, activate it for your account
   ![Activate GitHub Apps](/user/images/oss-migration/gapps-activate.png)

--- a/user/migrate/open-source-repository-migration.md
+++ b/user/migrate/open-source-repository-migration.md
@@ -74,9 +74,7 @@ No. Unless there was something very customised in your `.travis.yml`, no changes
 
 If you are already using GitHub Apps for your account in travis-ci.com, you need to access your installation settings and grant access to the repositories you'd like to migrate. Otherwise:
 
-1. Log in to [https://travis-ci.com] and access your profile (or your organization's) at [https://travis-ci.com/profile](https://travis-ci.com/profile)
-
-{{ site.data.snippets.gh_access_rights }}
+1. Log in to [https://travis-ci.com] and access your profile (or your organization's) at [https://travis-ci.com/profile](https://travis-ci.com/profile). If there's any doubt with regards to GitHub warning for Travis CI OAuth Application, please read more details [below](/user/migrate/travis-ci-github-oauth-app-access-rights).
 
 2. If you aren't using the new GitHub Apps integration already, activate it for your account
   ![Activate GitHub Apps](/user/images/oss-migration/gapps-activate.png)
@@ -84,6 +82,10 @@ If you are already using GitHub Apps for your account in travis-ci.com, you need
 3. When activating the Travis CI GitHub App, grant access to the repositories (both public and private) that you want to build in travis-ci.com. Save the changes.
 
 4. Once back in your Travis CI profile, the selected repositories will be listed there. Those projects that were already building in travis-ci.org will appear in the Migrate tab for your account.
+
+#### Travis CI GitHub OAuth App access rights
+
+{{ site.data.snippets.gh_access_rights }}
 
 ### The migration steps
 

--- a/user/tutorial.md
+++ b/user/tutorial.md
@@ -23,6 +23,8 @@ To start using Travis CI, make sure you have:
 
 2. Accept the Authorization of Travis CI. You'll be redirected to GitHub.
 
+{{ site.data.snippets.gh_access_rights }}
+
 3. Click on your profile picture in the top right of your Travis Dashboard, click Settings and then the green *Activate* button, and select the repositories you want to use with Travis CI.
 
 > Or you click the *Activate all repositories using GitHub Apps* button on the getting started page to just activate all your repos

--- a/user/tutorial.md
+++ b/user/tutorial.md
@@ -21,7 +21,7 @@ To start using Travis CI, make sure you have:
 
 1. Go to [Travis-ci.com](https://travis-ci.com) and [*Sign up with GitHub*](https://travis-ci.com/signin).
 
-2. Accept the Authorization of Travis CI. You'll be redirected to GitHub. Shall you have doubts on Travis CI GitHub Authorized OAuth App access rights message, please read more details [below](/user/tutorial#travis-ci-github-oauth-app-access-rights)
+2. Accept the Authorization of Travis CI. You'll be redirected to GitHub. For any doubts on the Travis CI GitHub Authorized OAuth App access rights message, please read more details [below](/user/tutorial#travis-ci-github-oauth-app-access-rights)
 
 3. Click on your profile picture in the top right of your Travis Dashboard, click Settings and then the green *Activate* button, and select the repositories you want to use with Travis CI.
 

--- a/user/tutorial.md
+++ b/user/tutorial.md
@@ -21,7 +21,7 @@ To start using Travis CI, make sure you have:
 
 1. Go to [Travis-ci.com](https://travis-ci.com) and [*Sign up with GitHub*](https://travis-ci.com/signin).
 
-2. Accept the Authorization of Travis CI. You'll be redirected to GitHub. Shall you have questions on Travis CI Github OAuth access rights, please read more details [below](/user/tutorial#travis-ci-github-oauth-app-access-rights)
+2. Accept the Authorization of Travis CI. You'll be redirected to GitHub. Shall you have doubts on Travis CI Github Authorized OAuth App access rights message, please read more details [below](/user/tutorial#travis-ci-github-oauth-app-access-rights)
 
 3. Click on your profile picture in the top right of your Travis Dashboard, click Settings and then the green *Activate* button, and select the repositories you want to use with Travis CI.
 
@@ -51,7 +51,7 @@ To start using Travis CI, make sure you have:
 
 #### Travis CI GitHub OAuth App access rights
 
-{{ site.data.snippets.gh_access_rights }}
+{{ site.data.snippets.github_oauth_access_rights }}
 
 ## To get started with Travis CI using Bitbucket
 

--- a/user/tutorial.md
+++ b/user/tutorial.md
@@ -21,7 +21,7 @@ To start using Travis CI, make sure you have:
 
 1. Go to [Travis-ci.com](https://travis-ci.com) and [*Sign up with GitHub*](https://travis-ci.com/signin).
 
-2. Accept the Authorization of Travis CI. You'll be redirected to GitHub. Shall you have doubts on Travis CI Github Authorized OAuth App access rights message, please read more details [below](/user/tutorial#travis-ci-github-oauth-app-access-rights)
+2. Accept the Authorization of Travis CI. You'll be redirected to GitHub. Shall you have doubts on Travis CI GitHub Authorized OAuth App access rights message, please read more details [below](/user/tutorial#travis-ci-github-oauth-app-access-rights)
 
 3. Click on your profile picture in the top right of your Travis Dashboard, click Settings and then the green *Activate* button, and select the repositories you want to use with Travis CI.
 

--- a/user/tutorial.md
+++ b/user/tutorial.md
@@ -21,9 +21,7 @@ To start using Travis CI, make sure you have:
 
 1. Go to [Travis-ci.com](https://travis-ci.com) and [*Sign up with GitHub*](https://travis-ci.com/signin).
 
-2. Accept the Authorization of Travis CI. You'll be redirected to GitHub.
-
-{{ site.data.snippets.gh_access_rights }}
+2. Accept the Authorization of Travis CI. You'll be redirected to GitHub. Shall you have questions on Travis CI Github OAuth access rights, please read more details [below](/user/tutorial#travis-ci-github-oauth-app-access-rights)
 
 3. Click on your profile picture in the top right of your Travis Dashboard, click Settings and then the green *Activate* button, and select the repositories you want to use with Travis CI.
 
@@ -50,6 +48,10 @@ To start using Travis CI, make sure you have:
    > Travis only runs builds on the commits you push *after* you've added a `.travis.yml` file.
 
 6. Check the build status page to see if your build [passes or fails](/user/job-lifecycle/#breaking-the-build) according to the return status of the build command by visiting [Travis CI](https://travis-ci.com/auth) and selecting your repository.
+
+#### Travis CI GitHub OAuth App access rights
+
+{{ site.data.snippets.gh_access_rights }}
 
 ## To get started with Travis CI using Bitbucket
 


### PR DESCRIPTION
Add pre-explanation on the warning people do get from GitHub due to OAuth scopes Travis CI uses.

# Problem

Teams are scared off by first-time sign-in warning received from GitHub, particularly about write access to all private and public repositories. This prevents them from moving to travis-ci.com, as they do not agree to activate Travis CI OAuth GitHub App, which actually is needed in the process, but does no harm when accessing users repository.