### PR TITLE
Fix 404 link in julia doc

### DIFF
--- a/user/languages/julia.md
+++ b/user/languages/julia.md
@@ -35,7 +35,7 @@ julia:
 {: data-file=".travis.yml"}
 
 Acceptable formats are:
- - `nightly` will test against the latest [nightly build](https://julialang.org/downloads/nightlies.html)
+ - `nightly` will test against the latest [nightly build](https://julialang.org/downloads/nightlies/)
 of Julia.
  - `X` will test against the latest release for that major version. (Applies only to major versions 1 and later.)
  - `X.Y` will test against the latest release for that minor version.


### PR DESCRIPTION
Fixed 404 link in [Julia document](https://docs.travis-ci.com/user/languages/julia/).

https://julialang.org/downloads/nightlies.html -> https://julialang.org/downloads/nightlies/
