### PR TITLE
Fix branch reasoning in environment variables

### DIFF
--- a/user/environment-variables.md
+++ b/user/environment-variables.md
@@ -10,8 +10,8 @@ A common way to customize the build process is to define environment variables, 
 The best way to define an environment variable depends on what type of information it will contain, and when you need to change it:
 
 - if it does *not* contain sensitive information and should be available to forks -- [add it to your .travis.yml](#defining-public-variables-in-travisyml)
-- if it *does* contain sensitive information, and is the same for all branches -- [encrypt it and add it to your .travis.yml](#defining-encrypted-variables-in-travisyml)
-- if it *does* contain sensitive information, and might be different for different branches -- [add it to your Repository Settings](#defining-variables-in-repository-settings)
+- if it *does* contain sensitive information, and might be different for different branches -- [encrypt it and add it to your .travis.yml](#defining-encrypted-variables-in-travisyml)
+- if it *does* contain sensitive information, and is the same for all branches -- [add it to your Repository Settings](#defining-variables-in-repository-settings)
 
 ## Defining Public Variables in .travis.yml
 


### PR DESCRIPTION
I believe it's the yaml file that can be different in different branches, while the repo settings cannot.