### PR TITLE
Fix(?) doc for `fast_finish`

### DIFF
--- a/user/customizing-the-build.md
+++ b/user/customizing-the-build.md
@@ -653,7 +653,7 @@ If some jobs in the build matrix are allowed to fail, the build won't be marked 
 To mark the build as finished as soon as possible, add `fast_finish: true` to the `matrix` section of your `.travis.yml` like this:
 
 ```yaml
-jobs:
+matrix:
   fast_finish: true
 ```
 {: data-file=".travis.yml"}


### PR DESCRIPTION
The doc says "To mark the build as finished as soon as possible, add `fast_finish: true` to the `matrix` section of your `.travis.yml` like this:" but then showed `jobs: ...`

This blog post suggests it should be `matrix`: https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/