### PR TITLE
Add clarification on configuring different versions of PostgreSQL

### DIFF
--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -160,7 +160,7 @@ addons:
 
 Many PostgreSQL versions have been preinstalled in our build environments, and
 others may be added and activated at build time by using a combination of the
-`postgresql` and `apt` addons along with a global env var override for `PGPORT` and `PGUSER`:
+`postgresql` and `apt` addons along with a global env var override for `PGPORT` and for `PGUSER`:
 
 ``` yaml
 addons:

--- a/user/database-setup.md
+++ b/user/database-setup.md
@@ -160,20 +160,28 @@ addons:
 
 Many PostgreSQL versions have been preinstalled in our build environments, and
 others may be added and activated at build time by using a combination of the
-`postgresql` and `apt` addons along with a global env var override for `PGPORT`:
+`postgresql` and `apt` addons along with a global env var override for `PGPORT` and `PGUSER`:
 
 ``` yaml
 addons:
-  postgresql: "10"
+  postgresql: "11"
   apt:
     packages:
-    - postgresql-10
-    - postgresql-client-10
+    - postgresql-11
+    - postgresql-client-11
 env:
   global:
   - PGPORT=5433
+  - PGUSER=travis
 ```
 {: data-file=".travis.yml"}
+
+In the Xenial images Postgres 9.4 through 9.6 just need the version specified and use the user 
+`postgres` by default and the default port of 5432. 
+
+For PostgreSQL 10 you must specify the packages
+to install it and the user is `postgres` and the port is 5432.  For PostgreSQL 11 and 12 you must
+ specify the packages, but the user is `travis` and the port is 5433 instead. So you must specify the PGPORT
 
 ### Using PostGIS
 


### PR DESCRIPTION
Update documentation on how to specify alternate versions of PostgreSQL.

This took a while to figure out all of the nuances.  But it is tested for 9.4, 9.6, 10, 11, and 12. ( see https://travis-ci.com/github/SchemaPlus/schema_plus_functions/builds/215791997/config )