### PR TITLE
Update osx.md

### DIFF
--- a/user/reference/osx.md
+++ b/user/reference/osx.md
@@ -95,15 +95,19 @@ and later, use `xcode9.4` (or later).
 ## Compilers and Build toolchain
 
 - automake
+- clang
+- cmake
+- gcc
 - maven
 - mercurial
 - pkg-config
 - wget
 - xctool
-- cmake
 
 ## Languages
 
+- C
+- C++
 - Go
 - Java
 - Nodejs


### PR DESCRIPTION
Added Clang and GCC to Compilers section, and C and C++ to Languages. Also moved CMake entry in Compilers to keep alphabetic order.