### PR TITLE
Fix docker-compose version in `dist: focal` env

### DIFF
--- a/user/reference/focal.md
+++ b/user/reference/focal.md
@@ -138,7 +138,7 @@ To use the IBM Advance Toolchain v14 compilers under `amd64` architecture in Foc
 ### Docker
 
 * Docker `19.03.8` is installed.
-* docker-compose `1.23.1` is also available.
+* docker-compose `1.25.1` is also available.
 
 ## Ruby support
 


### PR DESCRIPTION
Was debugging a Compose issue (I was trying to use Compose file version 3.8, which was added in docker-compose 1.25.5) when I noticed these stale docs.

Output from debugging in this environment:
```yaml
arch: arm64-graviton2
virt: lxd
os: linux
dist: focal
```

```
$ docker-compose version
docker-compose version 1.25.1, build a82fef0
docker-py version: 4.2.0
CPython version: 3.8.2
OpenSSL version: OpenSSL 1.1.1f  31 Mar 2020
```

```
$ docker version
Client:
 Version:           19.03.8
 API version:       1.40
 Go version:        go1.13.8
 Git commit:        afacb8b7f0
 Built:             Wed Mar 11 23:43:15 2020
 OS/Arch:           linux/arm64
 Experimental:      false

Server:
 Engine:
  Version:          19.03.8
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.13.8
  Git commit:       afacb8b7f0
  Built:            Wed Mar 11 22:48:33 2020
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          1.3.3-0ubuntu2
  GitCommit:
 runc:
  Version:          spec: 1.0.1-dev
  GitCommit:
 docker-init:
  Version:          0.18.0
  GitCommit:
```