### PR TITLE
Fix invalid repository secret name

### DIFF
--- a/user/deployment/pages.md
+++ b/user/deployment/pages.md
@@ -20,7 +20,7 @@ For a minimal configuration, add the following to your `.travis.yml`:
 deploy:
   provider: pages
   skip_cleanup: true
-  github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  github_token: $DEPLOY_TOKEN  # Set in the settings page of your repository, as a secure variable
   keep_history: true
   on:
     branch: main


### PR DESCRIPTION
Note: you can't create a repository secret called "GITHUB_TOKEN" because no repository secrets can start with "GITHUB_".
I'm honestly not sure if this is correct that way or if you meant something different, so this PR might be pointless, if it is, I'm sorry for the inconvenience.