### PR TITLE
Add v for docker-compose version in GitHub link

### DIFF
--- a/user/docker.md
+++ b/user/docker.md
@@ -181,7 +181,7 @@ by adding the following `before_install` step to your `.travis.yml`:
 
 ```yaml
 env:
-  - DOCKER_COMPOSE_VERSION=v1.4.2
+  - DOCKER_COMPOSE_VERSION=v2.11.1
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose

--- a/user/docker.md
+++ b/user/docker.md
@@ -181,7 +181,7 @@ by adding the following `before_install` step to your `.travis.yml`:
 
 ```yaml
 env:
-  - DOCKER_COMPOSE_VERSION=1.4.2
+  - DOCKER_COMPOSE_VERSION=v1.4.2
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose


### PR DESCRIPTION
https://github.com/docker/compose/issues/6268#issuecomment-969963108

Links to versions should now contain a v in the link, otherwise it downloads a 404 page.