### PR TITLE
Updates docs links and replaces tunnel-identifier

### DIFF
--- a/user/sauce-connect.md
+++ b/user/sauce-connect.md
@@ -16,11 +16,11 @@ request builds unless you use the [JWT Addon](/user/jwt).
 ## Setting up Sauce Connect
 
 [Sauce Connect][sauce-connect] securely proxies browser traffic between Sauce
-Labs' cloud-based VMs and your local servers. Connect uses ports 443 and 80 for
-communication with Sauce's cloud. If you're using Sauce Labs for your Selenium
-tests, this makes connecting to your webserver a lot easier.
+Labs' cloud-based VMs and your local servers. Sauce Connect uses ports 443 and 80 for
+communication with the Sauce Labs cloud. If you're using Sauce Labs for your Selenium
+tests, this makes connecting to your web server a lot easier.
 
-[sauce-connect]: https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy
+[sauce-connect]: https://docs.saucelabs.com/secure-connections/sauce-connect/
 
 First, [sign up][sauce-sign-up] with Sauce Labs if you haven't already (it's
 [free][open-sauce] for Open Source projects), and get your access key from your
@@ -70,19 +70,19 @@ addons:
 [jwt]: /user/jwt/
 
 To allow multiple tunnels to be open simultaneously, Travis CI opens a
-Sauce Connect [Identified Tunnel][identified-tunnels]. Make sure you are sending
+Sauce Connect [Tunnel Pool][identified-tunnels]. Make sure you are sending
 the `TRAVIS_JOB_NUMBER` environment variable when you are opening the connection
-to Sauce Labs' selenium grid, as the desired capability `tunnel-identifier`,
+to Sauce Labs' selenium grid, as the desired `tunnel-name` capability,
 or it will not be able to connect to the server running on the VM.
 
-[identified-tunnels]: https://wiki.saucelabs.com/display/DOCS/Using+Multiple+Sauce+Connect+Tunnels#UsingMultipleSauceConnectTunnels-UsingTunnelIdentifierswithMultipleTunnels
+[identified-tunnels]: https://docs.saucelabs.com/secure-connections/sauce-connect/setup-configuration/high-availability/#tunnel-pools
 
 How this looks will depend on the client library you're using, in
 Ruby's [selenium-webdriver][ruby-bindings] bindings:
 
 ```
 caps = Selenium::WebDriver::Remote::Capabilities.firefox({
-  'tunnel-identifier' => ENV['TRAVIS_JOB_NUMBER']
+  'tunnel-name' => ENV['TRAVIS_JOB_NUMBER']
 })
 driver = Selenium::WebDriver.for(:remote, {
   url: 'http://username:access_key@ondemand.saucelabs.com/wd/hub',


### PR DESCRIPTION
The Sauce Labs Wiki has been replaced with the Sauce Labs Documentation site.

In the Sauce Labs Documentation, tunnel-identifier has been deprecated and replaced with tunnel-name.

https://docs.saucelabs.com/secure-connections/sauce-connect/setup-configuration/basic-setup/#using-tunnel-names