### PR TITLE
Update sonarcloud.md to specify JDK 17

### DIFF
--- a/user/sonarcloud.md
+++ b/user/sonarcloud.md
@@ -11,14 +11,14 @@ Please refer to the [SonarCloud documentation](https://sonarcloud.io/documentati
 
 ## Requirements
 
-If a Java JRE/JDK is present within the build environment, it has to be at least Java 11 or higher.
+If a Java JRE/JDK is present within the build environment, it has to be at least Java 17.
 
-The default Travis dist
+Java 11 is set as default within build environments, Add:
 ```yaml
-dist: xenial
+jdk: openjdk17
 ```
 {: data-file=".travis.yml"}
-includes Java 11 by default.
+to use Java 17 JRE/JDK as default.
 
 ## Inspecting code with the SonarQube Scanner
 


### PR DESCRIPTION
Default JDK i.e. 11, is soon going to be deprecated for Sonarcloud scans, see: https://community.sonarsource.com/t/java-11-is-deprecated-as-a-runtime-env-to-scan-your-projects/96597
A warning appears in the build job logs as well, https://app.travis-ci.com/github/test-runs-tci/rspec_ruby_tci/jobs/608556166#L344

Using `jdk: openjdk17` sets up the JRE/JDK 17 thereby making the build job happy, https://app.travis-ci.com/github/test-runs-tci/rspec_ruby_tci/jobs/608557732