### PR TITLE
Update apps.md - Removed unused screenshot

### DIFF
--- a/user/apps.md
+++ b/user/apps.md
@@ -198,8 +198,6 @@ By ThoughtWorks Inc.
 - [app store](https://itunes.apple.com/us/app/ccmenu/id603117688)
 - [tutorial](/user/cc-menu/)
 
-![Travis CI in Screensaver Ninja with Custom CSS](/images/apps/screensaver-ninja.gif){:.app}
-
 ## Linux
 
 ### BuildNotify


### PR DESCRIPTION
Removed screenshot for Screensaver Ninja (MacOS) that looks like it was left in by mistake. App appears to have been discontinued and previously removed from this page, but screenshot was not under correct heading so it got missed, slightly breaking the page layout.

Should correct this layout misalignment:
![Page screenshot](https://github.com/travis-ci/docs-travis-ci-com/assets/1958728/ceb2d8fc-508d-4723-8762-0eddae45dc8a)
