### PR TITLE
Emberjsmitlicense

### DIFF
--- a/_includes/enterprise_sidebar.html
+++ b/_includes/enterprise_sidebar.html
@@ -83,6 +83,7 @@
   <section class="sidebar-notice">
     <p>This documentation site is open source.
       The <a href="https://github.com/travis-ci/docs-travis-ci-com">README in our Git repository</a> explains how to contribute.</p>
+    <p>Travis CI relies on Open Source <a href="/user/open_source_licence/">licensing information</a>.</p>
   </section>
 
 </div><!-- /#sidebar -->

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -158,8 +158,9 @@
   </section>
 
   <section class="sidebar-notice">
-    <p>This documentation site is open source.
+    <p>This documentation site is Open Source.
       The <a href="https://github.com/travis-ci/docs-travis-ci-com">README in our Git repository</a> explains how to contribute.</p>
+    <p>Travis CI relies on Open Source <a href="/user/open_source_licence/">licensing information</a>.</p>
   </section>
 
 </div><!-- /#sidebar -->

--- a/user/open_source_licence.md
+++ b/user/open_source_licence.md
@@ -1,0 +1,14 @@
+---
+title: EmberJS MIT License 
+layout: en
+
+---
+
+Copyright (c) 2011 Yehuda Katz, Tom Dale, and Ember.js contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Added the EmberJS MIT License as a sidebar notice. 
The notice was added to both the docs sidebar and the Enterprise sidebar. 
Please review 