### PR TITLE
Remove ga-tag since it's moved to `en.html` and inheritance will follow.

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,14 @@
 <!DOCTYPE HTML>
 <html lang="en">
   <head>
+<!-- PDTQ-131 -->
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-N3RT7TD');</script>
+<!-- End Google Tag Manager -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Travis CI Documentation - 404 Page not found</title>
@@ -216,6 +224,11 @@
     </script>
   </head>
   <body>
+<!-- PDTQ-131 -->
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N3RT7TD"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
     <div class="error error404">
       <header class="top">
         <div class="row topbar">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,16 +23,4 @@
 
 {% for tag in page.swiftypetags %}
  <meta class="swiftype" name="tags" data-type="string" content="{{tag}}" />
-{% endfor %}
-
-<script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-24868285-6']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-</script>
+{% endfor %} 

--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -12,6 +12,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     {% include head.html %}
   </head>
   <body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N3RT7TD"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
     <div class="wrapper">
 
       {% include header.html %}

--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -1,5 +1,14 @@
 <!DOCTYPE HTML>
 <html lang="en">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-F4D5NTKX3Q"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-F4D5NTKX3Q');
+</script>
   <head>
     {% include head.html %}
   </head>

--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -1,15 +1,14 @@
 <!DOCTYPE HTML>
 <html lang="en">
-<!-- Google tag (gtag.js) -->
+  <head>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-F4D5NTKX3Q"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'G-F4D5NTKX3Q');
-</script>
-  <head>
+  gtag('config', 'G-F4D5NTKX3Q')
+    
     {% include head.html %}
   </head>
   <body>

--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -1,13 +1,15 @@
 <!DOCTYPE HTML>
 <html lang="en">
   <head>
+<!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-F4D5NTKX3Q"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'G-F4D5NTKX3Q')
+  gtag('config', 'G-F4D5NTKX3Q');
+</script>
     
     {% include head.html %}
   </head>

--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -1,15 +1,13 @@
 <!DOCTYPE HTML>
 <html lang="en">
   <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-F4D5NTKX3Q"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-F4D5NTKX3Q');
-</script>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-N3RT7TD');</script>
+<!-- End Google Tag Manager -->
     
     {% include head.html %}
   </head>

--- a/_layouts/en.html
+++ b/_layouts/en.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML>
 <html lang="en">
   <head>
+<!-- PDTQ-131 -->
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -12,6 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     {% include head.html %}
   </head>
   <body>
+<!-- PDTQ-131 -->
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N3RT7TD"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/_layouts/en_enterprise.html
+++ b/_layouts/en_enterprise.html
@@ -1,9 +1,22 @@
 <!DOCTYPE HTML>
 <html lang="en">
   <head>
+    <!-- PDTQ-131 -->
+    <!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-N3RT7TD');</script>
+<!-- End Google Tag Manager -->
     {% include head.html %}
   </head>
   <body class="enterprise">
+    <!-- PDTQ-131 -->
+    <!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N3RT7TD"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
     <div class="wrapper">
 
       {% include header.html %}

--- a/_layouts/nodocs.html
+++ b/_layouts/nodocs.html
@@ -1,9 +1,22 @@
 <!DOCTYPE HTML>
 <html lang="en">
   <head>
+    <!-- PDTQ-131 -->
+    <!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-N3RT7TD');</script>
+<!-- End Google Tag Manager -->
     {% include head.html %}
   </head>
   <body>
+    <!-- PDTQ-131 -->
+    <!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N3RT7TD"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
     <div class="nodocs">
 
       {% include header.html %}


### PR DESCRIPTION
Removed `ga-tag` since I've added the new one that's GA-4 compatible (GTM), in `en.html` and that seems to inherit all other pages given that it's Jekyll based and in the interim Ruby based. 

The PR: https://github.com/travis-ci/docs-travis-ci-com/pull/3366/commits/20b8e73630183b314646daee5942ee3353ff0329

Is the latest one. That should work. 

Steps:

* Removed GTM tag in `head.html`
* Added inside the <head> tag that inherits, the new GTM tag, and this should inherit throughout the docs. 

e.g.

![Screenshot 2024-04-22 at 11 08 33 AM](https://github.com/travis-ci/docs-travis-ci-com/assets/20936398/b43cea2c-e5c8-4fa2-a37b-607351df6aa2)

