### PR TITLE
Update .travis.yml - cron job fix candidate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     language: shell
     cache: false
     install:
-    - rvm use 2.5.3
+    - rvm use 2.6.3 --install
     script:
     - git clone https://github.com/travis-ci/dpl.git
     - cd dpl


### PR DESCRIPTION
Cron jobs faiuled due to not present rvm 2.5.3
at the same time, other jobs in matrix were already switched to at least 2.6.3 on bionic
just bumping up and adding --install directive