### PR TITLE
Reposition tutorials in sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -30,7 +30,7 @@
     <nav>
       <h3>Getting Started</h3>
       <ul>
-        <li><a href="/user/onboarding/">Travis CI OnBoarding</a></li>
+        <li><a href="/user/onboarding/">Travis CI Onboarding</a></li>
         <li><a href="/user/for-beginners/">Core Concepts for Beginners</a></li>
         <li><a href="/user/customizing-the-build/">Customizing the Build</a></li>
         <li><a href="/user/speeding-up-the-build/">Speeding up the Build</a></li>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -44,6 +44,16 @@
         <li><a href="/user/build-config-validation/">Build Config Validation</a></li>
       </ul>
 
+      <h3>Tutorials</h3>
+      <ul>
+        <li class="is-overview"><a href="/user/tutorials/tutorials-overview/">Overview</a></li>
+        <li><a href="/user/tutorials/tutorial-c/">C/C++ Tutorial</a></li>
+        <li><a href="/user/tutorials/tutorial-java/">Java Tutorial</a></li>
+        <li><a href="/user/tutorials/tutorial-nodejs/">Node.js Tutorial</a></li>
+        <li><a href="/user/tutorials/tutorial-python/">Python Tutorial</a></li>
+        <li><a href="/user/tutorials/tutorial-ruby/">Ruby Tutorial</a></li>
+      </ul>
+
       <h3>Jobs, Builds, Matrices and Stages</h3>
       <ul>
         <li><a href="/user/job-lifecycle/">Job Lifecycle</a></li>
@@ -147,16 +157,6 @@
         <li class="is-overview"><a href="/user/billing-overview/">Overview</a></li>
         <li><a href="/user/billing-autorefill/">Auto-refill</a></li>
         <li><a href="/user/billing-faq/">FAQ</a></li>
-      </ul>
-
-      <h3>Tutorials</h3>
-      <ul>
-        <li class="is-overview"><a href="/user/tutorials/tutorials-overview/">Overview</a></li>
-        <li><a href="/user/tutorials/tutorial-c/">C/C++ Tutorial</a></li>
-        <li><a href="/user/tutorials/tutorial-java/">Java Tutorial</a></li>
-        <li><a href="/user/tutorials/tutorial-nodejs/">Node.js Tutorial</a></li>
-        <li><a href="/user/tutorials/tutorial-python/">Python Tutorial</a></li>
-        <li><a href="/user/tutorials/tutorial-ruby/">Ruby Tutorial</a></li>
       </ul>
      
       <h3>Travis CI Enterprise</h3>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ short_title: true
     <img src="images/ui/docs-desktop.svg" alt="Image of desktop">
   </figure>
   <h1>New around here? Let's get you going.</h1>
-  <p><a class="get-started-button" href="/user/tutorial/">Travis CI Tutorial</a></p>
+  <p><a class="get-started-button" href="/user/onboarding/">Travis CI OnBoarding</a></p>
 </section>
 
 <div class="row index-main">

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ short_title: true
     <img src="images/ui/docs-desktop.svg" alt="Image of desktop">
   </figure>
   <h1>New around here? Let's get you going.</h1>
-  <p><a class="get-started-button" href="/user/onboarding/">Travis CI OnBoarding</a></p>
+  <p><a class="get-started-button" href="/user/onboarding/">Travis CI Onboarding</a></p>
 </section>
 
 <div class="row index-main">

--- a/user/coverity-scan.md
+++ b/user/coverity-scan.md
@@ -32,7 +32,7 @@ The Coverity Scan addon doesn't work on macOS versions with the SIP feature enab
 
 2. If necessary, create a public repo on [GitHub](https://github.com) for your project.
 
-3. If necessary, register for [Travis CI](https://travis-ci.org/) and configure your project by following the [OnBoarding](/user/onboarding/) guide.
+3. If necessary, register for [Travis CI](https://travis-ci.org/) and configure your project by following the [Onboarding](/user/onboarding/) guide.
 
 4. Sign in to Scan, and then add your project. Be sure to add it as a [GitHub Project](https://scan.coverity.com/projects/new?tab=github).
 

--- a/user/enterprise.md
+++ b/user/enterprise.md
@@ -128,7 +128,7 @@ Detailed deployment requirements can be found in **‘Setting up’** and subseq
 
 Set up Travis CI Enterprise by heading over our [set up](/user/enterprise/tcie-3.x-setting-up-travis-ci-enterprise/) page.
 
-Or if you need more information on Travis CI, head back and view our [core concepts](/user/for-beginners/), the [OnBoarding](/user/onboarding/) guide, or the [tutorials](/user/tutorials/tutorials-overview/).
+Or if you need more information on Travis CI, head back and view our [core concepts](/user/for-beginners/), the [Onboarding](/user/onboarding/) guide, or the [tutorials](/user/tutorials/tutorials-overview/).
 
 ## Contact
 

--- a/user/enterprise/setting-up-travis-ci-enterprise.md
+++ b/user/enterprise/setting-up-travis-ci-enterprise.md
@@ -97,7 +97,7 @@ After that, follow [instructions to set up a Worker](/user/enterprise/setting-up
 
 ## 3. Running builds!
 
-Skip over to the [OnBoarding Guide](/user/onboarding/) and connect some repositories to your new Travis CI Setup!
+Skip over to the [Onboarding Guide](/user/onboarding/) and connect some repositories to your new Travis CI Setup!
 
 <!-- TODO
 

--- a/user/enterprise/tcie-3.x-setting-up-travis-ci-enterprise.md
+++ b/user/enterprise/tcie-3.x-setting-up-travis-ci-enterprise.md
@@ -338,4 +338,4 @@ After that, follow the [instructions to set up a Worker](/user/enterprise/settin
 
 ## 3. Running builds!
 
-Skip over to the [OnBoarding Guide](/user/onboarding/) and connect some repositories to your new Travis CI Setup!
+Skip over to the [Onboarding Guide](/user/onboarding/) and connect some repositories to your new Travis CI Setup!

--- a/user/enterprise/user-role-management.md
+++ b/user/enterprise/user-role-management.md
@@ -22,7 +22,7 @@ To enable the setting, select the `Enabled` option and save the settings.
 
 ## Travis CI Roles
 
-New Travis CI Users are created via the “**sign-in with…**” functionality, linking a third-party application (GitHub, Assembla, BitBucket, or GitLab) to Travis CI. See the [OnBoarding guide](/user/onboarding/) for more information.
+New Travis CI Users are created via the “**sign-in with…**” functionality, linking a third-party application (GitHub, Assembla, BitBucket, or GitLab) to Travis CI. See the [Onboarding guide](/user/onboarding/) for more information.
 
 
 In Travis CI, user access to Travis CI repositories and accounts functionalities and the following are the different types of user roles:

--- a/user/for-beginners.md
+++ b/user/for-beginners.md
@@ -77,5 +77,5 @@ the setup that suits your project best:
 
 More details on our build environments are available in our [CI Environment](/user/ci-environment/) documentation.
 
-Now that you've read the basics, head over to our [OnBoarding](/user/onboarding/) guide for details on setting up your first
+Now that you've read the basics, head over to our [Onboarding](/user/onboarding/) guide for details on setting up your first
 build, or see some [Tutorials](/user/tutorials/tutorials-overview/) to get started.

--- a/user/gui-and-headless-browsers.md
+++ b/user/gui-and-headless-browsers.md
@@ -8,7 +8,7 @@ layout: en
 
 ## What This Guide Covers
 
-This guide covers headless GUI & browser testing using tools provided by the Travis [CI environment](/user/reference/precise/). Most of the content is technology-neutral and does not cover all the details of specific testing tools (like Poltergeist or Capybara). We recommend you start with the [OnBoarding](/user/onboarding/) and [Build Configuration](/user/customizing-the-build/) guides before reading this one.
+This guide covers headless GUI & browser testing using tools provided by the Travis [CI environment](/user/reference/precise/). Most of the content is technology-neutral and does not cover all the details of specific testing tools (like Poltergeist or Capybara). We recommend you start with the [Onboarding](/user/onboarding/) and [Build Configuration](/user/customizing-the-build/) guides before reading this one.
 
 ## Using Sauce Labs
 

--- a/user/languages/android.md
+++ b/user/languages/android.md
@@ -6,7 +6,7 @@ layout: en
 
 ### What This Guide Covers
 
-This guide covers build environment and configuration topics specific to Android projects. Please make sure to read our [OnBoarding](/user/onboarding/) and [General Build configuration](/user/customizing-the-build/) guides first.
+This guide covers build environment and configuration topics specific to Android projects. Please make sure to read our [Onboarding](/user/onboarding/) and [General Build configuration](/user/customizing-the-build/) guides first.
 
 Android builds are not available on the macOS environment.
 

--- a/user/languages/c.md
+++ b/user/languages/c.md
@@ -27,7 +27,7 @@ language: c
 {{ site.data.snippets.all_note }}
 
 This guide covers build environment and configuration topics specific to C
-projects. Please make sure to read our [OnBoarding](/user/onboarding/)
+projects. Please make sure to read our [Onboarding](/user/onboarding/)
 and [General Build configuration](/user/customizing-the-build/) guides first.
 
 ## CI environment for C Projects

--- a/user/languages/clojure.md
+++ b/user/languages/clojure.md
@@ -27,7 +27,7 @@ language: clojure
 {{ site.data.snippets.linux_note }}
 
 This guide covers build environment and configuration topics specific to Clojure
-projects. Please make sure to read our [OnBoarding](/user/onboarding/)
+projects. Please make sure to read our [Onboarding](/user/onboarding/)
 and [General Build configuration](/user/customizing-the-build/) guides first.
 
 Clojure builds are not available on the macOS environment.

--- a/user/languages/cpp.md
+++ b/user/languages/cpp.md
@@ -26,7 +26,7 @@ language: cpp
 {{ site.data.snippets.all_note }}
 
 This guide covers build environment and configuration topics specific to C++
-projects. Please make sure to read our [OnBoarding](/user/onboarding/)
+projects. Please make sure to read our [Onboarding](/user/onboarding/)
 and [General Build configuration](/user/customizing-the-build/) guides first.
 
 ## CI environment for C++ Projects

--- a/user/languages/crystal.md
+++ b/user/languages/crystal.md
@@ -26,7 +26,7 @@ language: crystal
 
 This guide covers build environment and configuration topics specific to [Crystal](http://crystal-lang.org)
 projects. Please make sure to read our
-[OnBoarding](/user/onboarding/) and
+[Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 ### Community-Supported Warning

--- a/user/languages/csharp.md
+++ b/user/languages/csharp.md
@@ -25,7 +25,7 @@ language: csharp
 </aside>
 
 This guide covers build environment and configuration topics specific to C#, F#, and Visual Basic
-projects. Please make sure to read our [OnBoarding](/user/onboarding/)
+projects. Please make sure to read our [Onboarding](/user/onboarding/)
 and [General Build configuration](/user/customizing-the-build/) guides first.
 
 ### Community Supported Language

--- a/user/languages/d.md
+++ b/user/languages/d.md
@@ -25,7 +25,7 @@ language: d
 </aside>
 
 This guide covers build environment and configuration topics specific to D projects. Please make
-sure to read our [OnBoarding](/user/onboarding/) and
+sure to read our [Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 ### Community Supported Language

--- a/user/languages/dart.md
+++ b/user/languages/dart.md
@@ -26,7 +26,7 @@ language: dart
 
 This guide covers build environment and configuration topics specific to
 [Dart](https://dart.dev/) projects. Please make sure to read our
-[OnBoarding](/user/onboarding/) and
+[Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 ### Community-Supported Warning

--- a/user/languages/elixir.md
+++ b/user/languages/elixir.md
@@ -28,7 +28,7 @@ language: elixir
 
 The rest of this guide covers build environment and configuration topics
 specific to Elixir projects. Please make sure to read our
-[OnBoarding](/user/onboarding/) and
+[Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 Elixir builds are not available on the macOS environment.

--- a/user/languages/elm.md
+++ b/user/languages/elm.md
@@ -8,7 +8,7 @@ layout: en
 
 This guide covers build environment and configuration topics specific to
 [Elm](https://elm-lang.org/) projects. Please make sure to read our
-[OnBoarding](/user/onboarding/) and
+[Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 <aside markdown="block" class="ataglance">

--- a/user/languages/erlang.md
+++ b/user/languages/erlang.md
@@ -28,7 +28,7 @@ language: erlang
 
 The rest of this guide covers build environment and configuration topics
 specific to Erlang projects. Please make sure to read our
-[OnBoarding](/user/onboarding/) and
+[Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 Erlang builds are not available on the macOS environment.

--- a/user/languages/go.md
+++ b/user/languages/go.md
@@ -33,7 +33,7 @@ Note that, in order to choose Go 1.10, you must use `go: "1.10"` (a string), not
 {{ site.data.snippets.linux_windows_note }}
 
 The rest of this guide covers configuring Go projects in Travis CI. If you're
-new to Travis CI please read our [OnBoarding](/user/onboarding/) and [General Build
+new to Travis CI please read our [Onboarding](/user/onboarding/) and [General Build
 configuration](/user/customizing-the-build/) guides first.
 
 ## Specifying a Go version to use

--- a/user/languages/groovy.md
+++ b/user/languages/groovy.md
@@ -27,7 +27,7 @@ language: groovy
 {{ site.data.snippets.linux_note }}
 
 The rest of this guide covers configuring Groovy projects on Travis CI. If you're
-new to Travis CI, please read our [OnBoarding](/user/onboarding/) and
+new to Travis CI, please read our [Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 Groovy builds are not available on the macOS environment.

--- a/user/languages/haskell.md
+++ b/user/languages/haskell.md
@@ -27,7 +27,7 @@ language: haskell
 {{ site.data.snippets.linux_note }}
 
 The rest of this guide covers configuring Haskell projects on Travis CI. If
-you're new to Travis CI, please read our [OnBoarding](/user/onboarding/)
+you're new to Travis CI, please read our [Onboarding](/user/onboarding/)
 and [General Build configuration](/user/customizing-the-build/) guides first.
 
 ## Specifying Haskell compiler versions

--- a/user/languages/haxe.md
+++ b/user/languages/haxe.md
@@ -8,7 +8,7 @@ layout: en
 
 This guide covers build environment and configuration topics specific to
 [Haxe](http://haxe.org/) projects. Please make sure to read our
-[OnBoarding](/user/onboarding/) and
+[Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 ### Community-Supported Warning

--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -26,7 +26,7 @@ Minimal example:
 {{ site.data.snippets.unix_note }}
 
 The rest of this guide covers configuring Java projects in Travis CI. If you're
-new to Travis CI, please read our [OnBoarding](/user/onboarding/) and
+new to Travis CI, please read our [Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 ## Overview

--- a/user/languages/javascript-with-nodejs.md
+++ b/user/languages/javascript-with-nodejs.md
@@ -29,7 +29,7 @@ language: node_js
 {{ site.data.snippets.all_note }}
 
 This guide covers build environment and configuration topics specific to JavaScript and Node.js
-projects. Please make sure to read our [OnBoarding](/user/onboarding/)
+projects. Please make sure to read our [Onboarding](/user/onboarding/)
 and [General Build configuration](/user/customizing-the-build/) guides first.
 
 ## Specifying Node.js versions

--- a/user/languages/julia.md
+++ b/user/languages/julia.md
@@ -8,7 +8,7 @@ layout: en
 
 This guide covers build environment and configuration topics specific to
 [Julia](http://julialang.org) projects. Please make sure to read our
-[OnBoarding](/user/onboarding/) and
+[Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 ### Community-Supported Warning

--- a/user/languages/matlab.md
+++ b/user/languages/matlab.md
@@ -28,7 +28,7 @@ language: matlab
 
 This guide covers build environment and configuration topics specific to
 [MATLAB&reg;](https://www.mathworks.com/products/matlab.html) and [Simulink&reg;](https://www.mathworks.com/products/simulink.html) projects. Please make sure to read our
-[OnBoarding](/user/onboarding/) and
+[Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 {: .warning}

--- a/user/languages/nix.md
+++ b/user/languages/nix.md
@@ -6,7 +6,7 @@ layout: en
 
 ### What This Guide Covers
 
-This guide covers build environment and configuration topics specific to Nix projects. Please make sure to read our [OnBoarding](/user/onboarding/) and [General Build configuration](/user/customizing-the-build/) guides first.
+This guide covers build environment and configuration topics specific to Nix projects. Please make sure to read our [Onboarding](/user/onboarding/) and [General Build configuration](/user/customizing-the-build/) guides first.
 
 
 

--- a/user/languages/objective-c.md
+++ b/user/languages/objective-c.md
@@ -9,7 +9,7 @@ swiftypetags:
 ## What This Guide Covers
 
 This guide covers build environment and configuration topics specific to
-Objective-C and Swift projects. Please make sure to read our [OnBoarding](/user/onboarding/) and [General Build
+Objective-C and Swift projects. Please make sure to read our [Onboarding](/user/onboarding/) and [General Build
 configuration](/user/customizing-the-build/) guides first.
 
 > Objective-C/Swift builds are not available on the Linux environments.

--- a/user/languages/perl.md
+++ b/user/languages/perl.md
@@ -33,7 +33,7 @@ perl:
 Perl builds are not available on the OS X environment.
 
 The rest of this guide covers configuring Perl projects in Travis CI. If you're
-new to Travis CI, please read our [OnBoarding](/user/onboarding/) and
+new to Travis CI, please read our [Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 ## Specifying Perl versions

--- a/user/languages/perl6.md
+++ b/user/languages/perl6.md
@@ -30,7 +30,7 @@ language: perl6
 </aside>
 
 This guide covers build environment and configuration topics specific to
-Perl 6 projects. Please make sure to read our [OnBoarding](/user/onboarding/)
+Perl 6 projects. Please make sure to read our [Onboarding](/user/onboarding/)
 and [General Build configuration](/user/customizing-the-build/) guides first.
 
 Perl 6 builds are not available on the macOS environment.

--- a/user/languages/php.md
+++ b/user/languages/php.md
@@ -26,7 +26,7 @@ language: php
 {{ site.data.snippets.linux_note }}
 
 This guide covers build environment and configuration topics specific to PHP
-projects. Please make sure to read our [OnBoarding](/user/onboarding/)
+projects. Please make sure to read our [Onboarding](/user/onboarding/)
 and [General Build configuration](/user/customizing-the-build/) guides first.
 
 PHP builds are not available on the macOS environment.

--- a/user/languages/python.md
+++ b/user/languages/python.md
@@ -31,7 +31,7 @@ Minimal example:
 > Python builds are not available on the macOS and Windows environments.
 
 The rest of this guide covers configuring Python projects in Travis CI. If you're
-new to Travis CI, please read our [OnBoarding](/user/onboarding/) and
+new to Travis CI, please read our [Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 ## Specifying Python versions

--- a/user/languages/r.md
+++ b/user/languages/r.md
@@ -8,7 +8,7 @@ layout: en
 
 This guide covers build environment and configuration topics specific to R
 projects.
-Please make sure to read our [OnBoarding](/user/onboarding/) and [General Build configuration](/user/customizing-the-build/) guides first.
+Please make sure to read our [Onboarding](/user/onboarding/) and [General Build configuration](/user/customizing-the-build/) guides first.
 
 ### Community-Supported Warning
 

--- a/user/languages/ruby.md
+++ b/user/languages/ruby.md
@@ -27,7 +27,7 @@ language: ruby
 {{ site.data.snippets.unix_note }}
 
 The rest of this guide covers configuring Ruby projects on Travis CI. If you're
-new to Travis CI, please read our [OnBoarding](/user/onboarding/) and
+new to Travis CI, please read our [Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 ## Specifying Ruby versions and implementations

--- a/user/languages/rust.md
+++ b/user/languages/rust.md
@@ -27,7 +27,7 @@ language: rust
 {{ site.data.snippets.all_note }}
 
 The rest of this guide covers configuring Rust projects in Travis CI. If you're
-new to Travis CI, please read our [OnBoarding](/user/onboarding/) and
+new to Travis CI, please read our [Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 ## Choosing a Rust version

--- a/user/languages/scala.md
+++ b/user/languages/scala.md
@@ -28,7 +28,7 @@ Minimal example:
 Scala builds are not available on the macOS environment.
 
 The rest of this guide covers configuring Scala projects in Travis CI. If you're
-new to Travis CI, please read our [OnBoarding](/user/onboarding/) and
+new to Travis CI, please read our [Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 ## Overview

--- a/user/languages/smalltalk.md
+++ b/user/languages/smalltalk.md
@@ -8,7 +8,7 @@ layout: en
 
 This guide covers build environment and configuration topics specific to Smalltalk
 projects. Please make sure to read our
-[OnBoarding](/user/onboarding/) and
+[Onboarding](/user/onboarding/) and
 [General Build configuration](/user/customizing-the-build/) guides first.
 
 ### Community-Supported Warning

--- a/user/onboarding.md
+++ b/user/onboarding.md
@@ -1,5 +1,5 @@
 ---
-title: Travis CI OnBoarding
+title: Travis CI Onboarding
 layout: en
 redirect_from:
   - /user/getting-started/


### PR DESCRIPTION
- Reposition tutorials in sidebar
- Rename "Travis CI Tutorial" button to "Travis CI OnBoarding"
- changed link for the  "Travis CI OnBoarding" button on the index page