### PR TITLE
Add C++ code example to languages.md

### DIFF
--- a/user/languages.md
+++ b/user/languages.md
@@ -1,4 +1,14 @@
----
+---// Source - https://stackoverflow.com/q/79874608
+// Posted by Vincent Nivoliers, modified by community. See post 'Timeline' for change history
+// Retrieved 2026-01-30, License - CC BY-SA 4.0
+
+int main()
+{
+  using nil = decltype(nullptr) ;
+  constexpr nil zero = nullptr ;
+  constexpr nil other_zero = zero ;
+}
+
 title: Languages
 layout: en
 


### PR DESCRIPTION
Added C++ code example demonstrating the use of 'nil' as a type alias for nullptr.