### PR TITLE
Updated BuildMonitor URL: buildmonitor.io to buildmonitor.cyancor.com

### DIFF
--- a/user/apps.md
+++ b/user/apps.md
@@ -84,14 +84,14 @@ By Ahmed El-Sayed
 
 - [source code](https://github.com/ahmedelsayed-93/ci-dashboard)
 
-### buildmonitor.io
+### CyanCor BuildMonitor
 
-![buildmonitor.io](/images/apps/buildmonitor.png){:.app}
+![buildmonitor.cyancor.com](/images/apps/buildmonitor.png){:.app}
 
 Extensible and plugin-based build monitor.<br>
 By CyanCor
 
-- [website](https://buildmonitor.io/)
+- [website](https://buildmonitor.cyancor.com/)
 - [source code](https://gitlab.com/BuildMonitor/TravisConnector)
 
 ### Meercode CI Build Dashboard


### PR DESCRIPTION
The BuildMonitor tool by CyanCor has moved from `buildmonitor.io` to `buildmonitor.cyancor.com`.
This PR updates the website link in the apps listing accordingly.
Also updates the section heading to the official product name "BuildMonitor".